### PR TITLE
Refactor vDist reset helper

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -1798,11 +1798,11 @@ public class SurvivalFly extends Check {
 
         if (InAirPhase && cc.survivalFlyAccountingV) {
             if (MovingUtil.isCollideWithHB(from, to, data) && thisMove.yDistance < 0.0 && thisMove.yDistance > -0.21) {
-                data.vDistAcc.clear();
+                handleResetVDist(data);
                 data.vDistAcc.add((float) -0.2033);
             }
             else if (ChangedYDir && lastMove.yDistance > 0.0) {
-                data.vDistAcc.clear();
+                handleResetVDist(data);
                 data.vDistAcc.add((float) yDistance);
             }
             else if (thisMove.verVelUsed == null && !(lastMove.from.inLiquid && Math.abs(yDistance) < 0.31
@@ -1815,7 +1815,7 @@ public class SurvivalFly extends Check {
                 }
             }
             else {
-                data.vDistAcc.clear();
+                handleResetVDist(data);
             }
         }
 
@@ -2196,6 +2196,20 @@ public class SurvivalFly extends Check {
             return new double[]{yDistance, 0.0};
         }
         return null;
+    }
+
+    /**
+     * Reset bookkeeping related to vertical distance checks. This method
+     * currently just clears the vertical distance accumulator but is kept
+     * for future refactoring and unit tests.
+     *
+     * @param data
+     *            moving data for the player
+     */
+    private void handleResetVDist(final MovingData data) {
+        if (data != null) {
+            data.clearAccounting();
+        }
     }
 
     private double[] calculateViolation(final Player player, final double yDistance, final double yDistAbs,


### PR DESCRIPTION
### **User description**
## Summary
- centralize vertical distance reset logic with `handleResetVDist`
- use the helper where accounting is cleared

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_b_685b115a235083299ef716dbdb16e273


___

### **PR Type**
Enhancement


___

### **Description**
- Centralize vertical distance reset logic with `handleResetVDist` helper method

- Replace direct `data.vDistAcc.clear()` calls with new helper function

- Add documentation and null safety to vertical distance reset operations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurvivalFly.java</strong><dd><code>Centralize vertical distance reset with helper method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java

<li>Added new <code>handleResetVDist</code> helper method with documentation and null <br>safety<br> <li> Replaced three direct <code>data.vDistAcc.clear()</code> calls with <br><code>handleResetVDist(data)</code><br> <li> Centralized vertical distance accounting reset logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/4/files#diff-695323687c716bfa7b23bf2d8e9935c19bb2b814890d9e4e2bfde492b74863d3">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of vertical distance accounting for smoother maintenance and potential future enhancements. No visible changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->