### PR TITLE
Implement equals for location models

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/location/setback/SetBackEntry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/location/setback/SetBackEntry.java
@@ -189,6 +189,22 @@ public class SetBackEntry implements IGetLocationWithLook, ISetLocationWithLook 
         return LocUtil.hashCode(this);
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof IGetLocationWithLook) {
+            final IGetLocationWithLook other = (IGetLocationWithLook) obj;
+            return (worldName == null ? other.getWorldName() == null
+                    : worldName.equals(other.getWorldName()))
+                    && other.getX() == getX() && other.getY() == getY()
+                    && other.getZ() == getZ() && other.getYaw() == getYaw()
+                    && other.getPitch() == getPitch();
+        }
+        return false;
+    }
+
     // TODO: Equals !?
 
     @Override

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/LocationData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/LocationData.java
@@ -224,6 +224,22 @@ public class LocationData implements IGetLocationWithLook {
     }
 
     @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof IGetLocationWithLook) {
+            final IGetLocationWithLook other = (IGetLocationWithLook) obj;
+            return (worldName == null ? other.getWorldName() == null
+                    : worldName.equals(other.getWorldName()))
+                    && other.getX() == getX() && other.getY() == getY()
+                    && other.getZ() == getZ() && other.getYaw() == getYaw()
+                    && other.getPitch() == getPitch();
+        }
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "LocationData(" + worldName + "/" + LocUtil.simpleFormat(this) + ")";
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/DataLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/DataLocation.java
@@ -128,4 +128,18 @@ public class DataLocation implements IGetPositionWithLook {
         return LocUtil.hashCode(this);
     }
 
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof IGetPositionWithLook) {
+            final IGetPositionWithLook other = (IGetPositionWithLook) obj;
+            return other.getX() == getX() && other.getY() == getY()
+                    && other.getZ() == getZ() && other.getYaw() == getYaw()
+                    && other.getPitch() == getPitch();
+        }
+        return false;
+    }
+
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
@@ -30,6 +30,7 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.components.location.IGetBox3D;
 import fr.neatmonster.nocheatplus.components.location.IGetBlockPosition;
 import fr.neatmonster.nocheatplus.components.location.IGetBukkitLocation;
+import fr.neatmonster.nocheatplus.components.location.IGetLocationWithLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPosition;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.collision.CollisionUtil;
@@ -1670,9 +1671,24 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
-    @Override    
+    @Override
     public int hashCode() {
         return LocUtil.hashCode(this);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof IGetLocationWithLook) {
+            final IGetLocationWithLook other = (IGetLocationWithLook) obj;
+            return getWorldName().equals(other.getWorldName())
+                    && other.getX() == getX() && other.getY() == getY()
+                    && other.getZ() == getZ() && other.getYaw() == getYaw()
+                    && other.getPitch() == getPitch();
+        }
+        return false;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
## Summary
- add equals implementations for DataLocation, LocationData, SetBackEntry and RichBoundsLocation

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685b1b30a4b48329bd4b880cdfef21c1