### PR TITLE
Implement equals method for RichBoundsLocation

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
@@ -30,6 +30,7 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.components.location.IGetBox3D;
 import fr.neatmonster.nocheatplus.components.location.IGetBlockPosition;
 import fr.neatmonster.nocheatplus.components.location.IGetBukkitLocation;
+import fr.neatmonster.nocheatplus.components.location.IGetLocationWithLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPosition;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.collision.CollisionUtil;
@@ -1670,9 +1671,45 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
-    @Override    
+    @Override
     public int hashCode() {
         return LocUtil.hashCode(this);
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof IGetLocationWithLook) {
+            final IGetLocationWithLook other = (IGetLocationWithLook) obj;
+            final String wnThis = world == null ? null : world.getName();
+            final String wnOther = other.getWorldName();
+            return (wnThis == null ? wnOther == null : wnThis.equals(wnOther))
+                    && x == other.getX()
+                    && y == other.getY()
+                    && z == other.getZ()
+                    && yaw == other.getYaw()
+                    && pitch == other.getPitch();
+        }
+        if (obj instanceof Location) {
+            final Location other = (Location) obj;
+            final String wnThis = world == null ? null : world.getName();
+            final String wnOther = other.getWorld() == null ? null : other.getWorld().getName();
+            return (wnThis == null ? wnOther == null : wnThis.equals(wnOther))
+                    && x == other.getX()
+                    && y == other.getY()
+                    && z == other.getZ()
+                    && yaw == other.getYaw()
+                    && pitch == other.getPitch();
+        }
+        return false;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
### **User description**
## Summary
- add missing import for `IGetLocationWithLook`
- implement `equals(Object)` in RichBoundsLocation with world, position and look checks

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_b_685b1b2f30b48329978aac2922cb10cb


___

### **PR Type**
Enhancement


___

### **Description**
- Add missing import for `IGetLocationWithLook` interface

- Implement `equals(Object)` method in `RichBoundsLocation` class

- Support equality comparison with both `IGetLocationWithLook` and `Location` objects

- Compare world name, position coordinates (x, y, z) and look angles (yaw, pitch)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RichBoundsLocation.java</strong><dd><code>Add equals method with location comparison</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java

<li>Add import for <code>IGetLocationWithLook</code> interface<br> <li> Implement <code>equals(Object)</code> method with comprehensive comparison logic<br> <li> Support equality checks for both <code>IGetLocationWithLook</code> and <code>Location</code> <br>types<br> <li> Compare world names, coordinates, and look angles for equality


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/12/files#diff-bf70a4b19f868eafa81105e2c08944a59db8679f2611e0ed5db1de7eeacfe215">+38/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>