### PR TITLE
Add disable cleanup tests

### DIFF
--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
@@ -65,12 +65,31 @@ public class TestPluginLifecycle {
         DummyComponent b = new DummyComponent("B", calls);
         plugin.addComponent(a);
         plugin.addComponent(b);
+        // populate event registry and task fields to verify cleanup
+        Field regField = NoCheatPlus.class.getDeclaredField("eventRegistry");
+        regField.setAccessible(true);
+        Object registry = regField.get(plugin);
+        Field attachmentsField = registry.getClass().getSuperclass().getSuperclass()
+                .getDeclaredField("attachments");
+        attachmentsField.setAccessible(true);
+        ((java.util.Map<Object, java.util.Set<?>>) attachmentsField.get(registry))
+                .put(new Object(), new java.util.HashSet<>());
+        Field dataTaskField = NoCheatPlus.class.getDeclaredField("dataManTaskId");
+        dataTaskField.setAccessible(true);
+        dataTaskField.set(plugin, Integer.valueOf(1));
+        Field ccTaskField = NoCheatPlus.class.getDeclaredField("consistencyCheckerTaskId");
+        ccTaskField.setAccessible(true);
+        ccTaskField.set(plugin, Integer.valueOf(2));
+
         plugin.onDisable();
         assertEquals("B", calls.get(0));
         assertEquals("A", calls.get(1));
         assertTrue(getListeners().isEmpty());
         assertTrue(getDisableListeners().isEmpty());
         assertTrue(getAllComponents().isEmpty());
+        assertNull(dataTaskField.get(plugin));
+        assertNull(ccTaskField.get(plugin));
+        assertTrue(((java.util.Map<?, ?>) attachmentsField.get(registry)).isEmpty());
     }
 
     private static class DummyComponent implements Listener, IDisableListener {


### PR DESCRIPTION
### **User description**
## Summary
- expand lifecycle tests to check task and registry cleanup

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685b2fc7afe88329b07b61dd76b2e7d8


___

### **PR Type**
Tests


___

### **Description**
- Expand lifecycle tests to verify task and registry cleanup

- Add reflection-based testing for internal field cleanup

- Verify onDisable properly cleans up event registry attachments

- Ensure task IDs are nullified during plugin shutdown


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestPluginLifecycle.java</strong><dd><code>Enhanced lifecycle test with cleanup verification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java

<li>Add reflection-based access to internal plugin fields<br> <li> Populate event registry and task fields before testing cleanup<br> <li> Verify task IDs are nullified and registry attachments cleared<br> <li> Enhance existing test to validate comprehensive cleanup behavior


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/21/files#diff-e53f6b74644d40561c60d4c9e6471281d829159da1ee761d14c9e5e9e92f5386">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>