### PR TITLE
Add comments for ignored reflection exceptions

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
@@ -224,9 +224,15 @@ public class ReflectionUtil {
         try {
             return method.invoke(object);
         }
-        catch (IllegalAccessException e) {}
-        catch (IllegalArgumentException e) {}
-        catch (InvocationTargetException e) {}
+        catch (IllegalAccessException e) {
+            // Failed to access method reflectively.
+        }
+        catch (IllegalArgumentException e) {
+            // Arguments mismatch for reflective call.
+        }
+        catch (InvocationTargetException e) {
+            // Target method threw an exception.
+        }
         return null;
     }
 
@@ -242,9 +248,15 @@ public class ReflectionUtil {
         try {
             return method.invoke(object, arguments);
         }
-        catch (IllegalAccessException e) {}
-        catch (IllegalArgumentException e) {}
-        catch (InvocationTargetException e) {}
+        catch (IllegalAccessException e) {
+            // Failed to access method reflectively.
+        }
+        catch (IllegalArgumentException e) {
+            // Arguments mismatch for reflective call.
+        }
+        catch (InvocationTargetException e) {
+            // Target method threw an exception.
+        }
         return null;
     }
 
@@ -271,7 +283,9 @@ public class ReflectionUtil {
                 }
             }
         } catch (SecurityException e) {
+            // Access restrictions prevented retrieving the method.
         } catch (NoSuchMethodException e) {
+            // Method not found; ignore and return null.
         }
         return null;
     }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -144,8 +144,10 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
             this.reflectLivingEntity = new ReflectLivingEntity(this.reflectBase, null, this.reflectDamageSource);
             // Can be null
             this.reflectDamageSources = new ReflectDamageSources(this.reflectBase, this.reflectDamageSource);
-        } 
-        catch (ClassNotFoundException ex) {}
+        }
+        catch (ClassNotFoundException ex) {
+            // Optional classes may not be present on older versions.
+        }
     }
 
     @Override

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -259,14 +259,18 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
                 counters.addPrimaryThread(idIllegalItem, 1);
             }
         }
-        catch (final ArrayIndexOutOfBoundsException e) {} // Hotfix (CB)
+        catch (final ArrayIndexOutOfBoundsException e) {
+            // Hotfix (CB) for out-of-range slot on some CraftBukkit versions.
+        }
         try {
             if (!cancel && Items.checkIllegalEnchantments(player, cursor, pData)) {
                 cancel = true;
                 counters.addPrimaryThread(idIllegalItem, 1);
             }
         }
-        catch (final ArrayIndexOutOfBoundsException e) {} // Hotfix (CB)
+        catch (final ArrayIndexOutOfBoundsException e) {
+            // Hotfix (CB) for out-of-range slot on some CraftBukkit versions.
+        }
 
         // Fast inventory manipulation check.
         if (fastClick.isEnabled(player, pData)) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MaterialUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MaterialUtil.java
@@ -145,7 +145,9 @@ public class MaterialUtil {
                         builder.append('\n');
                     }
                 } catch (IllegalArgumentException e) {
+                    // Ignore issues accessing the field value.
                 } catch (IllegalAccessException e) {
+                    // Field not accessible, skip logging it.
                 }
             }
         }


### PR DESCRIPTION
### **User description**
## Summary
- document why reflection errors are ignored in MaterialUtil
- clarify empty catch block in MCAccessBukkitModern
- explain CraftBukkit slot exceptions in InventoryListener
- add comments to ignored reflection exceptions in ReflectionUtil

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685b36200cb88329a1c51451588a2236


___

### **PR Type**
Documentation


___

### **Description**
- Add explanatory comments to empty catch blocks

- Document reflection exception handling in ReflectionUtil

- Clarify CraftBukkit slot exceptions in InventoryListener

- Explain optional class loading failures in MCAccessBukkitModern


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReflectionUtil.java</strong><dd><code>Document reflection exception handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java

<li>Add comments explaining IllegalAccessException handling<br> <li> Document IllegalArgumentException for argument mismatches<br> <li> Clarify InvocationTargetException for method execution failures<br> <li> Add comments for SecurityException and NoSuchMethodException


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/31/files#diff-b5d3608b115e3b9e746c2affc1a1900b1e749f8606837e6e4b715c0a413bc90e">+25/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MCAccessBukkitModern.java</strong><dd><code>Document optional class loading failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java

<li>Add comment explaining ClassNotFoundException catch block<br> <li> Document that optional classes may not be present on older versions


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/31/files#diff-92d8bbfc92bb2b04705db5381d04aea98bb6cae28dc3179fa1d4cd99fff36c7c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InventoryListener.java</strong><dd><code>Document CraftBukkit slot exception handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java

<li>Add comments explaining ArrayIndexOutOfBoundsException handling<br> <li> Document CraftBukkit slot range issues as hotfix reason


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/31/files#diff-ab8e8f28aa826c176c2aff22954adf92625f4ac624b945b0e78544d532318496">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MaterialUtil.java</strong><dd><code>Document field access exception handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MaterialUtil.java

<li>Add comment for IllegalArgumentException in field access<br> <li> Document IllegalAccessException for inaccessible fields


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/31/files#diff-4a78f4de396e30a2a85e32d13020fd4827edcb3e76f038c208a4418fce134606">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>