### PR TITLE
Simplify boolean returns

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
@@ -85,11 +85,8 @@ public class BlockCacheBukkit extends BlockCache {
                 }
                 final double locY = entity.getLocation(useLoc).getY();
                 useLoc.setWorld(null);
-                if (Math.abs(locY - minY) < 0.7){
-                    // TODO: A "better" estimate is possible, though some more tolerance would be good. 
-                    return true;
-                }
-                else return false;
+                // TODO: A "better" estimate is possible, though some more tolerance would be good.
+                return Math.abs(locY - minY) < 0.7;
             }
         }
         catch (Throwable t){

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
@@ -93,11 +93,8 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
                 final double vehicleY = vehicle.getLocation(useLoc).getY() + vehicle.getHeight();
                 final double entityY = entity.getLocation(useLoc).getY();
                 useLoc.setWorld(null);
-                if (vehicleY < entityY + 0.1 && Math.abs(vehicleY - entityY) < 0.7){
-                    // TODO: A "better" estimate is possible, though some more tolerance would be good. 
-                    return true; 
-                }
-                else return false;
+                // TODO: A "better" estimate is possible, though some more tolerance would be good.
+                return vehicleY < entityY + 0.1 && Math.abs(vehicleY - entityY) < 0.7;
             }		
         }
         catch (Throwable t){

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitBase.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitBase.java
@@ -84,17 +84,11 @@ public class MCAccessBukkitBase implements MCAccess {
          */
         if (BlockFlags.hasAnyFlag(flags, BlockFlags.F_IGN_PASSABLE)) {
             // TODO: Blocks with min_height may actually be ok, if xz100 and some height are set.
-            if (BlockFlags.hasNoFlags(flags, 
-                    BlockFlags.F_GROUND_HEIGHT 
+            // Potentially itchy if any ground related flags are set.
+            return !BlockFlags.hasNoFlags(flags,
+                    BlockFlags.F_GROUND_HEIGHT
                     | BlockFlags.F_GROUND
-                    | BlockFlags.F_SOLID)) {
-                // Explicitly passable.
-                return false;
-            }
-            else {
-                // Potentially itchy.
-                return true;
-            }
+                    | BlockFlags.F_SOLID);
         }
 
         long testFlags1 = (BlockFlags.F_SOLID | BlockFlags.F_XZ100);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/OnGroundReference.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/OnGroundReference.java
@@ -275,13 +275,8 @@ public class OnGroundReference {
                     node = null;
                 }
             }
-            if (entry == null){
-                // No more entries to check.
-                return false;
-            }
-            else {
-                return true;
-            }
+            // No more entries to check.
+            return entry != null;
         }
         else {
             // Both not null (that case has been excluded above).

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/RegistrationOrder.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/RegistrationOrder.java
@@ -301,19 +301,14 @@ public class RegistrationOrder {
                                 return true;
                             }
                             else {
-                                if (
+                                return !(
                                         // order1 might be set to come after order2.
-                                        tag2 != null && tag2.matches(afterTag1) 
+                                        tag2 != null && tag2.matches(afterTag1)
                                         // Must proceed to check other entries with afterTag set.
                                         || afterTag2 == null
                                         || tag1 == null
                                         // The other entry is not set to come after this one.
-                                        || !tag1.matches(afterTag2)) {
-                                    return false;
-                                }
-                                else {
-                                    return true;
-                                }
+                                        || !tag1.matches(afterTag2));
                             }
                         }
                         else {
@@ -375,18 +370,15 @@ public class RegistrationOrder {
                                 // Order1 comes first.
                                 return true;
                             }
-                            else if (afterTag1 != null) {
-                                // Order1 is sorted to the end of the region rather.
-                                return false;
-                            }
                             else {
+                                // Order1 is sorted to the end of the region rather if afterTag1 is not null.
                                 /*
                                  * Prefer to have have set basePriority 0 first,
                                  * assuming null basePriority to be interpreted
                                  * as 'later registered', keeping the order of
                                  * registration rather.
                                  */
-                                return true;
+                                return afterTag1 == null;
                             }
                         }
                     }
@@ -428,27 +420,15 @@ public class RegistrationOrder {
                                         // Greedy (could override afterTag2).
                                         return false;
                                     }
-                                    else if (tag1 != null && tag1.matches(afterTag2)) {
-                                        // order2 is set to come after order1.
-                                        return true;
-                                    }
-                                    else {
-                                        // order1 may be set to come after another entry that follows.
-                                        return false;
-                                    }
+                                    // order2 is set to come after order1, otherwise order1 may be set to come after another entry that follows.
+                                    return tag1 != null && tag1.matches(afterTag2);
                                 }
                             }
                         }
                         else {
                             // beforeTag1 is null, beforeTag2 not.
-                            if (afterTag2 != null && tag1 != null && tag1.matches(afterTag2)) {
-                                // order2 is set to come after order1,
-                                return true;
-                            }
-                            else {
-                                // beforeTag set rules otherwise.
-                                return false;
-                            }
+                            // order2 is set to come after order1, otherwise beforeTag set rules apply.
+                            return afterTag2 != null && tag1 != null && tag1.matches(afterTag2);
                         }
                     }
                     else {
@@ -485,14 +465,8 @@ public class RegistrationOrder {
                                     return false;
                                 }
                                 else if (afterTag2 != null){
-                                    if (tag1 != null && tag1.matches(afterTag2)) {
-                                        // order2 is set to come after order1.
-                                        return true;
-                                    }
-                                    else {
-                                        // Rather keep checking.
-                                        return false;
-                                    }
+                                    // order2 is set to come after order1, otherwise rather keep checking.
+                                    return tag1 != null && tag1.matches(afterTag2);
                                 }
                                 else {
                                     // afterTag1 is null, otherwise not matching, thus order1 comes behind.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/PathUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/PathUtils.java
@@ -462,14 +462,8 @@ public class PathUtils {
     }
 
     public static boolean mayBeInConfig(final String path) {
-        if (deprecatedPrefixes.hasPrefix(path)) {
-            return false;
-        }
-        else if (movedPaths.containsKey(path)) {
-            return false;
-        } else {
-            return true;
-        }
+        return !deprecatedPrefixes.hasPrefix(path)
+                && !movedPaths.containsKey(path);
     }
 
 }


### PR DESCRIPTION
### **User description**
## Summary
- remove redundant boolean branches for readability
- replace if/else blocks with boolean expressions in registry ordering logic
- simplify return logic in various compatibility helpers

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685b360908048329b2f6523498024448


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify boolean return statements across multiple files

- Replace if/else blocks with direct boolean expressions

- Improve code readability in compatibility helpers

- Streamline registry ordering logic conditions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BlockCacheBukkit.java</strong><dd><code>Simplify entity standing check return logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java

<li>Replace if/else block with direct boolean expression return<br> <li> Simplify <code>standsOnEntity</code> method logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-c5d2dfe1319f743a824438cb70f659bbc0fbcf2fe2dd6c50f8a2c8e095df2632">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BlockCacheBukkitModern.java</strong><dd><code>Simplify vehicle standing check return logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java

<li>Replace if/else block with direct boolean expression return<br> <li> Streamline vehicle standing check logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-46d86efa1b25fd6cb7b5a41eadb6fb89547e855ab5346f41d530a08bcac13148">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MCAccessBukkitBase.java</strong><dd><code>Simplify itchy block detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitBase.java

<li>Replace if/else block with negated boolean expression<br> <li> Simplify <code>guessItchyBlock</code> method return logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-fd0650a8af8599e2dc5808478c635210c28925f1bfb9f41cf134bec68dc91d3d">+4/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OnGroundReference.java</strong><dd><code>Simplify entry existence check logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/OnGroundReference.java

<li>Replace if/else block with direct null check return<br> <li> Simplify entry existence check logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-57fd50fbd83b4671768c9744c71e60566f7696d3e4e5482fee36b26b2201ccb1">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RegistrationOrder.java</strong><dd><code>Simplify registration ordering conditional logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/RegistrationOrder.java

<li>Replace multiple if/else blocks with direct boolean expressions<br> <li> Simplify complex conditional logic in <code>shouldSortBefore</code> method<br> <li> Improve readability of registration ordering conditions


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-7685bfe9c70c67c0ac3f6cc4085511a0bf2d71ec35874a98c2fd0ba2debbc237">+11/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PathUtils.java</strong><dd><code>Simplify config path validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/PathUtils.java

<li>Replace if/else chain with combined boolean expression<br> <li> Simplify <code>mayBeInConfig</code> method return logic


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/32/files#diff-5dd19fc306f813367b37d54c1e4fe7bcd69c2a1691a220adcb455e290a8d463c">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>