### PR TITLE
Fix Folia repeating task API

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
@@ -73,14 +73,16 @@ public class Folia {
     }
 
     /**
-     * Run a repeating task, either with bukkit scheduler or folia scheduler
+     * Run a repeating task using the Bukkit or Folia scheduler.
+     *
      * @param plugin Plugin to assign for
-     * @param run Consumer that accepts an object or null, for Folia or Paper/Spigot respectively
+     * @param run Consumer that accepts an object or {@code null}, for Folia or Paper/Spigot respectively
      * @param delay Delay in ticks
      * @param period Period in ticks
-     * @return An int represent for task id when running on Paper/Spigot or a ScheduledTask when running on Folia or null if can't schedule
+     * @return An {@link Integer} task id when running on Paper/Spigot, a {@code ScheduledTask}
+     *         when running on Folia or {@code null} if scheduling failed
      */
-    public static Object runSyncRepatingTask(Plugin plugin, Consumer<Object> run, long delay, long period) {
+    public static Object runSyncRepeatingTask(Plugin plugin, Consumer<Object> run, long delay, long period) {
         if (!isFoliaServer) {
             return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> run.accept(null), delay, period);
         }
@@ -100,6 +102,14 @@ public class Folia {
             e.printStackTrace();
         }
         return null;
+    }
+
+    /**
+     * @deprecated Use {@link #runSyncRepeatingTask(Plugin, Consumer, long, long)} instead.
+     */
+    @Deprecated
+    public static Object runSyncRepatingTask(Plugin plugin, Consumer<Object> run, long delay, long period) {
+        return runSyncRepeatingTask(plugin, run, delay, period);
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/TickTask.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/TickTask.java
@@ -451,7 +451,7 @@ public class TickTask implements Runnable {
     // Public methods for internal use.
     public static Object start(final Plugin plugin) {
         cancel();
-        taskId = Folia.runSyncRepatingTask(plugin, (arg) -> new TickTask().run(), 1, 1);
+        taskId = Folia.runSyncRepeatingTask(plugin, (arg) -> new TickTask().run(), 1, 1);
         if (Folia.isTaskScheduled(taskId)) {
             timeStart = System.currentTimeMillis();
         }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -1020,7 +1020,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         TickTask.start(this);
 
         // dataMan expiration checking.
-        this.dataManTaskId = Folia.runSyncRepatingTask(this, (arg) -> pDataMan.checkExpiration(), 1207, 1207);
+        this.dataManTaskId = Folia.runSyncRepeatingTask(this, (arg) -> pDataMan.checkExpiration(), 1207, 1207);
 
         // Ensure dataMan is first on disableListeners so it cleans up after others.
         Misc.putFirst(pDataMan, disableListeners);
@@ -1062,7 +1062,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         Folia.runSyncTask(this, (arg) -> new PostEnableTask(onlinePlayers).run());
 
         // Mid-term cleanup (seconds range).
-        Folia.runSyncRepatingTask(this, (arg) -> midTermCleanup(), 83, 83);
+        Folia.runSyncRepeatingTask(this, (arg) -> midTermCleanup(), 83, 83);
 
         // Set StaticLog to more efficient output.
         StaticLog.setStreamID(Streams.STATUS);
@@ -1381,7 +1381,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         }
         // Schedule task in seconds.
         final long delay = 20L * config.getInt(ConfPaths.DATA_CONSISTENCYCHECKS_INTERVAL, 1, 3600, 10);
-        consistencyCheckerTaskId = Folia.runSyncRepatingTask(this, (arg) -> runConsistencyChecks(), delay, delay);
+        consistencyCheckerTaskId = Folia.runSyncRepeatingTask(this, (arg) -> runConsistencyChecks(), delay, delay);
     }
 
     /**


### PR DESCRIPTION
## Summary
- rename `runSyncRepatingTask` to `runSyncRepeatingTask`
- keep old method as deprecated wrapper
- update calls in plugin and utilities

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685b3de635ec8329995aacfbc6ca4071

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the spelling of the `runSyncRepeatingTask` method in the Folia API and update all its references.

### Why are these changes being made?

The misspelling of `runSyncRepeatingTask` as `runSyncRepatingTask` could lead to errors or confusion when using the Folia API. Correcting the method name and updating all instances ensures consistency in the codebase and prevents potential bugs. The deprecated method is maintained for backward compatibility.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->