### PR TITLE
Fix BuildParameters if/else style

### DIFF
--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/BuildParameters.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/BuildParameters.java
@@ -53,8 +53,11 @@ public class BuildParameters {
      */
     public static String getMappingValue(String path, String preset){
         String input = fileContents.get(path);
-        if (input == null) return preset;
-        else return input;
+        if (input == null) {
+            return preset;
+        } else {
+            return input;
+        }
     }
 
     /**
@@ -65,21 +68,31 @@ public class BuildParameters {
      */
     public static String getString(String path, String preset){
         String input = fileContents.get(path);
-        if (input == null) return preset;
-        else if (input.startsWith("${") && input.endsWith("}")) return preset;
-        else return input;
+        if (input == null) {
+            return preset;
+        } else if (input.startsWith("${") && input.endsWith("}")) {
+            return preset;
+        } else {
+            return input;
+        }
     }
 
     public static Boolean getBoolean(String path, Boolean preset){
         String input = fileContents.get(path);
-        if (input == null) return preset;
-        else return ResourceUtil.getBoolean(input, preset);
+        if (input == null) {
+            return preset;
+        } else {
+            return ResourceUtil.getBoolean(input, preset);
+        }
     }
 
     public static Integer getInteger(String path, Integer preset){
         String input = fileContents.get(path);
-        if (input == null) return preset;
-        else return ResourceUtil.getInteger(input, preset);
+        if (input == null) {
+            return preset;
+        } else {
+            return ResourceUtil.getInteger(input, preset);
+        }
     }
 
     //////////////////////


### PR DESCRIPTION
### **User description**
## Summary
- refactor `BuildParameters` to put `else` clauses on the same line as closing braces

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check -Dcheckstyle.includes="**/BuildParameters.java"` *(fails: multiple existing violations)*
- `mvn -q pmd:check` *(fails: PMD found 3 violations)*
- `mvn -q spotbugs:check` *(fails: plugin not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b3f7e53348329b886573da8885d54


___

### **PR Type**
Other


___

### **Description**
- Refactor conditional statements to use proper brace formatting

- Convert single-line if/else to multi-line block structure

- Improve code readability and consistency


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildParameters.java</strong><dd><code>Refactor conditional statements formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/BuildParameters.java

<li>Convert single-line if/else statements to multi-line format with <br>braces<br> <li> Apply consistent formatting to <code>getMappingValue</code>, <code>getString</code>, <code>getBoolean</code>, <br>and <code>getInteger</code> methods<br> <li> Improve code readability by adding proper block structure


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/41/files#diff-abc991b6cb5f0333807bfbbb389fbf3c3143a5e05459f783d16fdd8fc7912209">+36/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>