### PR TITLE
Fix PMD empty catch violations

### DIFF
--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -47,33 +47,22 @@ public class ResourceUtil {
                 + "/" + path;
         try {
             final URL url = new URL(absPath);
-            BufferedReader reader = null;
-            try {
-                final Object obj = url.getContent();
-                if (obj instanceof InputStream) {
-                    reader = new BufferedReader(new InputStreamReader((InputStream) obj));
+            final Object obj = url.getContent();
+            if (obj instanceof InputStream) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader((InputStream) obj))) {
                     final StringBuilder builder = new StringBuilder();
                     String last = reader.readLine();
                     while (last != null) {
                         builder.append(last).append('\n');
                         last = reader.readLine();
                     }
-                    reader.close();
                     return builder.toString();
-                } else {
-                    return null;
                 }
-            } catch (IOException e) {
-                if (reader != null) {
-                    try {
-                        reader.close();
-                    } catch (IOException e1) {
-                        // ignore
-                    }
-                }
+            } else {
                 return null;
             }
-        } catch (MalformedURLException e) {
+        } catch (IOException e) {
+            // ignore
             return null;
         }
     }
@@ -141,8 +130,7 @@ public class ResourceUtil {
         try {
             return Integer.parseInt(input);
         } catch (NumberFormatException e) {
-            // ignore and return preset
+            return preset;
         }
-        return preset;
     }
 }


### PR DESCRIPTION
### **User description**
## Summary
- refactor ResourceUtil to avoid empty catch blocks
- handle integer parsing directly in catch block

## Testing
- `mvn -e -pl NCPBuildBase test`
- `mvn -q -pl NCPBuildBase checkstyle:check` *(fails: 23 violations)*
- `mvn -q -pl NCPBuildBase com.github.spotbugs:spotbugs-maven-plugin:spotbugs`
- `mvn -q -pl NCPBuildBase pmd:pmd`

------
https://chatgpt.com/codex/tasks/task_b_685b477a2ae883299b52422da2f71951


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PMD empty catch block violations in ResourceUtil

- Replace try-with-resources for proper resource management

- Handle NumberFormatException directly in catch block

- Remove redundant null checks and nested try-catch blocks


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResourceUtil.java</strong><dd><code>Fix empty catch blocks and resource management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java

<li>Replace nested try-catch with try-with-resources for BufferedReader<br> <li> Remove empty catch block by handling NumberFormatException directly<br> <li> Simplify resource management and exception handling<br> <li> Consolidate IOException and MalformedURLException handling


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/46/files#diff-7116bfbca3b34aee6a816489168038a9c8c8f4eb38e2006425871de8ba51fcb3">+7/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>