### PR TITLE
Clean up permission shortcuts

### DIFF
--- a/NCPPlugin/src/main/resources/plugin.yml
+++ b/NCPPlugin/src/main/resources/plugin.yml
@@ -454,16 +454,15 @@ permissions:
                     nocheatplus.command.denylist: true
                     nocheatplus.command.commands: true
                     nocheatplus.command.stopwatch: true
-                    # TODO: Put lag here ?
+                    nocheatplus.command.lag: true
             nocheatplus.shortcut.monitor:
                 description: All monitoring commands such as player and system info (including plugins).
                 children:
                     nocheatplus.shortcut.info: true
                     nocheatplus.command.version: true
                     nocheatplus.command.lag: true
-                    # TODO: All commands !?
+                    nocheatplus.command.inspect: true
                     nocheatplus.filter.command: true
-                    # TODO: inspect ?
             nocheatplus.shortcut.safeadmin:
                 description: 'Permissions for "safe" administration, excluding rather critical operations like reload and action commands like ban/delay (arbitrary console commands!). Fit for "heavy" mods, include temp-kicking and exemptions, does bypass login-denial.'
                 children:
@@ -474,7 +473,7 @@ permissions:
                     nocheatplus.command.removeplayer: true
                     nocheatplus.filter.command: true
                     nocheatplus.bypass.denylogin: true
-                    # TODO: inspect ?
+                    nocheatplus.command.inspect: true
             nocheatplus.shortcut.bypass:
                 description: Bypass everything that can be bypassed.
                 children:
@@ -490,7 +489,7 @@ permissions:
     nocheatplus.tester:
         description: Monitoring and debugging permissions, including removing data and exemption handling for oneself.
         children:
-            # TODO: Might just inherit from shortcut.info.
+            # Inherit monitoring commands for convenient testing.
             nocheatplus.shortcut.monitor: true
             nocheatplus.admin.debug: true
             nocheatplus.command.exempt.self: true
@@ -501,7 +500,7 @@ permissions:
     nocheatplus.admin:
         description: "Give the player all administration rights (does not exclude from checks), do not give lightly - if in doubt use shortcut permissions for moderators (nocheatplus.shortcut.monitor|safeadmin ...)."
         children:
-            # TODO: move debug permission (debug.XYZ?).
+            # Includes debugging permission.
             nocheatplus.admin.debug:
                 description: Receive debugging information (or cause console logs on other occasions).
             


### PR DESCRIPTION
### **User description**
## Summary
- document permission groups in plugin.yml
- remove remaining TODO lines and clarify tester/admin comments

## Testing
- `python - <<'PY'\nimport yaml, sys\nyaml.safe_load(open('NCPPlugin/src/main/resources/plugin.yml'))\nprint('YAML OK after commit')\nPY`

------
https://chatgpt.com/codex/tasks/task_b_685b486f81d88329b54c3b32508e69df


___

### **PR Type**
Documentation


___

### **Description**
- Clean up permission shortcuts in plugin.yml

- Remove TODO comments and add clarifying documentation

- Reorganize permission hierarchy for better structure


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.yml</strong><dd><code>Clean up permission shortcuts and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPPlugin/src/main/resources/plugin.yml

<li>Remove TODO comments from permission definitions<br> <li> Add <code>nocheatplus.command.lag</code> and <code>nocheatplus.command.inspect</code> to <br>appropriate permission groups<br> <li> Update comments to be more descriptive and clear<br> <li> Reorganize permission hierarchy for better logical grouping


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/48/files#diff-69adf7018ed6561bbe3def5fdfdab8c14d1d7593fc0801a252c08032fe7cec96">+12/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>