### PR TITLE
Fix resource reader cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,6 @@ nb-configuration.xml
 
 dummy/
 
+!NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
+
 essa.patch

--- a/NCPBuildBase/pom.xml
+++ b/NCPBuildBase/pom.xml
@@ -35,6 +35,20 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.7.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -18,7 +18,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
@@ -47,33 +46,16 @@ public class ResourceUtil {
                 + "/" + path;
         try {
             final URL url = new URL(absPath);
-            BufferedReader reader = null;
-            try {
-                final Object obj = url.getContent();
-                if (obj instanceof InputStream) {
-                    reader = new BufferedReader(new InputStreamReader((InputStream) obj));
-                    final StringBuilder builder = new StringBuilder();
-                    String last = reader.readLine();
-                    while (last != null) {
-                        builder.append(last).append('\n');
-                        last = reader.readLine();
-                    }
-                    reader.close();
-                    return builder.toString();
-                } else {
-                    return null;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader((InputStream) url.getContent()))) {
+                final StringBuilder builder = new StringBuilder();
+                String last = reader.readLine();
+                while (last != null) {
+                    builder.append(last).append('\n');
+                    last = reader.readLine();
                 }
-            } catch (IOException e) {
-                if (reader != null) {
-                    try {
-                        reader.close();
-                    } catch (IOException e1) {
-                        // ignore
-                    }
-                }
-                return null;
+                return builder.toString();
             }
-        } catch (MalformedURLException e) {
+        } catch (IOException e) {
             return null;
         }
     }

--- a/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
+++ b/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
@@ -1,0 +1,55 @@
+package fr.neatmonster.nocheatplus.utilities.build;
+
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.Test;
+
+public class ResourceUtilTest {
+
+    private Class<?> createJarWithResource() throws Exception {
+        Path jar = Files.createTempFile("resource", ".jar");
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            // Add ResourceUtil class from build output
+            String classPath = "fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.class";
+            jos.putNextEntry(new JarEntry(classPath));
+            Path base = Paths.get(ResourceUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            Path classFile = base.resolve(classPath);
+            Files.copy(classFile, jos);
+            jos.closeEntry();
+            // Add test resource
+            jos.putNextEntry(new JarEntry("BuildParameters.properties"));
+            jos.write("KEY=VALUE\n".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+        URLClassLoader cl = new URLClassLoader(new URL[] { jar.toUri().toURL() }, null);
+        return cl.loadClass("fr.neatmonster.nocheatplus.utilities.build.ResourceUtil");
+    }
+
+    @Test
+    public void fetchExistingResource() throws Exception {
+        Class<?> clazz = createJarWithResource();
+        URL classUrl = clazz.getResource(clazz.getSimpleName() + ".class");
+        System.out.println("classUrl=" + classUrl);
+        String res = ResourceUtil.fetchResource(clazz, "BuildParameters.properties");
+        System.out.println("resFromMethod=" + res);
+        assertNotNull("Expected resource content", res);
+        assertTrue(res.contains("KEY=VALUE"));
+    }
+
+    @Test
+    public void fetchMissingResource() throws Exception {
+        Class<?> clazz = createJarWithResource();
+        String res = ResourceUtil.fetchResource(clazz, "missing.txt");
+        assertNull(res);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,24 @@
                         <target>21</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-pmd-plugin</artifactId>
+                    <version>3.21.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>4.7.3.0</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
## Summary
- use try-with-resources in `ResourceUtil.fetchResource`
- add unit tests for `ResourceUtil.fetchResource`
- wire SpotBugs plugin and skip root execution

## Testing
- `mvn -q verify`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check` *(fails: 23 Checkstyle violations)*

------
https://chatgpt.com/codex/tasks/task_b_685b4875e74083298bdecb0083c1cc43