### PR TITLE
Fix PMD FQN issues

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/corw/LinkedHashMapCOW.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/corw/LinkedHashMapCOW.java
@@ -104,7 +104,7 @@ public class LinkedHashMapCOW<K, V> implements Map<K, V> {
      * Unmodifiable version of the EntrySet. Entry.setValue might be possible, but dangerous :p
      */
     @Override
-    public Set<java.util.Map.Entry<K, V>> entrySet() {
+    public Set<Map.Entry<K, V>> entrySet() {
         return Collections.unmodifiableSet(map.entrySet());
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/RegisteredPermission.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/RegisteredPermission.java
@@ -18,6 +18,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.PluginManager;
+import java.util.Locale;
 
 /**
  * A permission registered with the PermissionRegistry. Essentially contains an
@@ -29,7 +30,7 @@ import org.bukkit.plugin.PluginManager;
 public class RegisteredPermission {
 
     public static final String toLowerCaseStringRepresentation(final String stringRepresentation) {
-        return stringRepresentation.toLowerCase(java.util.Locale.ENGLISH);
+        return stringRepresentation.toLowerCase(Locale.ENGLISH);
     }
 
     private final Integer id;

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCreativeFlyHDist.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCreativeFlyHDist.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.InvocationHandler;
+import java.util.HashMap;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -115,7 +116,7 @@ public class TestCreativeFlyHDist {
         Object pdm = un.allocateInstance(fr.neatmonster.nocheatplus.players.PlayerDataManager.class);
         Field eh = fr.neatmonster.nocheatplus.players.PlayerDataManager.class.getDeclaredField("executionHistories");
         eh.setAccessible(true);
-        eh.set(pdm, new java.util.HashMap<>());
+        eh.set(pdm, new HashMap<>());
         Field dm = fr.neatmonster.nocheatplus.players.DataManager.class.getDeclaredField("instance");
         dm.setAccessible(true);
         dm.set(null, pdm);

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestTeleportHandling.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestTeleportHandling.java
@@ -30,6 +30,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.UUID;
 
 import static org.junit.Assert.*;
 
@@ -77,7 +79,7 @@ public class TestTeleportHandling {
         Object pdm = u.allocateInstance(PlayerDataManager.class);
         Field eh = PlayerDataManager.class.getDeclaredField("executionHistories");
         eh.setAccessible(true);
-        eh.set(pdm, new java.util.HashMap<>());
+        eh.set(pdm, new HashMap<>());
         Field dm = DataManager.class.getDeclaredField("instance");
         dm.setAccessible(true);
         dm.set(null, pdm);
@@ -136,7 +138,7 @@ public class TestTeleportHandling {
         @Override public PlayerData getPlayerData(Player player, boolean create) { return pData; }
         @Override public PlayerData getPlayerData(Player player) { return pData; }
         @Override public PlayerData getPlayerData(String playerName) { return pData; }
-        @Override public PlayerData getPlayerData(java.util.UUID id) { return pData; }
+        @Override public PlayerData getPlayerData(UUID id) { return pData; }
     }
 
     private static DummyPlayerDataManager createDataMan(PlayerData data, sun.misc.Unsafe u) throws Exception {

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
@@ -16,7 +16,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -71,8 +73,8 @@ public class TestPluginLifecycle {
         Field attachmentsField = registry.getClass().getSuperclass().getSuperclass()
                 .getDeclaredField("attachments");
         attachmentsField.setAccessible(true);
-        ((java.util.Map<Object, java.util.Set<?>>) attachmentsField.get(registry))
-                .put(new Object(), new java.util.HashSet<>());
+        ((Map<Object, Set<?>>) attachmentsField.get(registry))
+                .put(new Object(), new HashSet<>());
         Field dataTaskField = NoCheatPlus.class.getDeclaredField("dataManTaskId");
         dataTaskField.setAccessible(true);
         dataTaskField.set(plugin, Integer.valueOf(1));
@@ -88,7 +90,7 @@ public class TestPluginLifecycle {
         assertTrue(getAllComponents().isEmpty());
         assertNull(dataTaskField.get(plugin));
         assertNull(ccTaskField.get(plugin));
-        assertTrue(((java.util.Map<?, ?>) attachmentsField.get(registry)).isEmpty());
+        assertTrue(((Map<?, ?>) attachmentsField.get(registry)).isEmpty());
     }
 
     private static class DummyComponent implements Listener, IDisableListener {


### PR DESCRIPTION
### **User description**
## Summary
- shorten `java.util` FQNs
- fix `entrySet` return type to use `Map.Entry`
- update tests to use simple class names
- import `Locale` in `RegisteredPermission`

## Testing
- `mvn -q -DskipITs=true test`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check` *(fails: Checkstyle violations)*
- `mvn -DskipTests=true pmd:check`
- `mvn -DskipTests=true spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685b4f3835dc832990d6df41a7c0034c


___

### **PR Type**
Enhancement


___

### **Description**
- Replace fully qualified names with simple class names

- Add missing imports for simplified references

- Fix return type annotation for entrySet method

- Update test files to use simplified class names


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LinkedHashMapCOW.java</strong><dd><code>Simplify Map.Entry return type annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/corw/LinkedHashMapCOW.java

<li>Replace <code>java.util.Map.Entry</code> with <code>Map.Entry</code> in entrySet return type


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/55/files#diff-a5315e06c013ce7561b011a1e98ba2ba39511b682d62c834979d571d956bd0dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RegisteredPermission.java</strong><dd><code>Add Locale import and simplify reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/RegisteredPermission.java

<li>Add <code>java.util.Locale</code> import<br> <li> Replace <code>java.util.Locale.ENGLISH</code> with <code>Locale.ENGLISH</code>


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/55/files#diff-8f2cfd5e2647e22233b7b6a14496bc40d40a383737a20b9dea9242c773f27679">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestCreativeFlyHDist.java</strong><dd><code>Add HashMap import and simplify instantiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCreativeFlyHDist.java

<li>Add <code>java.util.HashMap</code> import<br> <li> Replace <code>java.util.HashMap<>()</code> with <code>HashMap<>()</code>


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/55/files#diff-5857aed8969100d7872db8d6a30c6191c359afe09ced2b62a2a23c806ddae2b0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestTeleportHandling.java</strong><dd><code>Add imports and simplify HashMap and UUID references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestTeleportHandling.java

<li>Add <code>java.util.HashMap</code> and <code>java.util.UUID</code> imports<br> <li> Replace <code>java.util.HashMap<>()</code> with <code>HashMap<>()</code><br> <li> Replace <code>java.util.UUID</code> with <code>UUID</code> in method parameter


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/55/files#diff-3e0ada09690e8983c34cfca6d6c998c9de1fe4f4d2b8e1060b29c16dd8648b59">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TestPluginLifecycle.java</strong><dd><code>Add collection imports and simplify references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java

<li>Add <code>java.util.HashSet</code> and <code>java.util.Map</code> imports<br> <li> Replace <code>java.util.Map</code>, <code>java.util.Set</code>, and <code>java.util.HashSet</code> with <br>simple names


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/55/files#diff-e53f6b74644d40561c60d4c9e6471281d829159da1ee761d14c9e5e9e92f5386">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>