### PR TITLE
Fix null checks for DataManager.getPlayerDataSafe

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/DataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/DataManager.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 
 import org.bukkit.entity.Player;
 
+import fr.neatmonster.nocheatplus.logging.StaticLog;
+
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 
@@ -269,8 +271,11 @@ public class DataManager {
      * 
      * @param player
      * @return null in case of failures.
-     */
+    */
     public static IPlayerData getPlayerDataSafe(final Player player) {
+        if (player == null) {
+            return null;
+        }
         try {
             return getPlayerData(player);
         }
@@ -287,7 +292,7 @@ public class DataManager {
             return getPlayerData(player.getName());
         }
         catch (UnsupportedOperationException e) {
-            // ignore - giving up on retrieval
+            StaticLog.logWarning("All player data retrieval methods failed for player: " + player.getName());
         }
         // Failure.
         return null;


### PR DESCRIPTION
### **User description**
## Summary
- add StaticLog import
- check for null Player in `getPlayerDataSafe`
- log a warning if all player data retrieval attempts fail

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685b5318c7ac83299f8eb15d34a4e29d


___

### **PR Type**
Bug fix


___

### **Description**
- Add null check for Player parameter in `getPlayerDataSafe`

- Import StaticLog for warning messages

- Log warning when all player data retrieval attempts fail


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataManager.java</strong><dd><code>Add null safety and error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/DataManager.java

<li>Add StaticLog import for logging functionality<br> <li> Add null check for Player parameter at method start<br> <li> Replace silent failure with warning log when all retrieval methods <br>fail


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/56/files#diff-91d4d3cc15e4bdc53e15346477f3453a141dab6235915ec7f220db67cdd88d8f">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>