### PR TITLE
Add StaticLog warning to GodMode death handling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
@@ -25,6 +25,7 @@ import fr.neatmonster.nocheatplus.compat.BridgeHealth;
 import fr.neatmonster.nocheatplus.compat.Folia;
 import fr.neatmonster.nocheatplus.compat.IBridgeCrossPlugin;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
@@ -214,7 +215,7 @@ public class GodMode extends Check {
                             mcAccess.getHandle().setDead(player, 19);
                         }
                     } catch (final Exception e) {
-                        // ignore - failed to set player dead
+                        StaticLog.logWarning("Failed to set player dead: " + e.getMessage());
                     }
                 }, null, 30);
             } catch (final Exception e) {


### PR DESCRIPTION
## Summary
- import `StaticLog` in `GodMode`
- log a warning when setting player dead fails

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685b5318005883298fc179555d4a059e