### PR TITLE
Improve logging for block modeling

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkit.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkit.java
@@ -56,7 +56,8 @@ public class MCAccessBukkit extends MCAccessBukkitBase implements BlockPropertie
             }
         }
         if (!itchyBlocks.isEmpty()) {
-            StaticLog.logDebug("The following blocks can not be modeled correctly: " + StringUtil.join(itchyBlocks, ", "));
+            StaticLog.logWarning("The following blocks can not be modeled correctly, falling back to passable: " +
+                    StringUtil.join(itchyBlocks, ", "));
         }
     }
 


### PR DESCRIPTION
## Summary
- warn rather than debug when block shapes can't be modeled

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685b5315c6fc832988e83123f075e852