### PR TITLE
Fix empty catch blocks

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/CatchAllAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/CatchAllAdapter.java
@@ -70,7 +70,9 @@ public class CatchAllAdapter extends BaseAdapter {
     public void onPacketReceiving(PacketEvent event) {
         try {
             if (event.isPlayerTemporary()) return;
-        } catch(NoSuchMethodError e) {}
+        } catch(NoSuchMethodError e) {
+            // Ignore: method not available on older ProtocolLib versions
+        }
         final Player player = event.getPlayer();
         if (player == null) {
             counters.add(ProtocolLibComponent.idNullPlayer, 1);

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/KeepAliveAdapter.java
@@ -59,7 +59,9 @@ public class KeepAliveAdapter extends BaseAdapter {
     public void onPacketReceiving(final PacketEvent event) {
         try {
             if (event.isPlayerTemporary()) return;
-        } catch(NoSuchMethodError e) {}
+        } catch(NoSuchMethodError e) {
+            // Ignore: method not available on older ProtocolLib versions
+        }
         final long time = System.currentTimeMillis();
         final Player player = event.getPlayer();
         if (player == null) {

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/OutgoingPosition.java
@@ -56,8 +56,10 @@ public class OutgoingPosition extends BaseAdapter {
     public void onPacketSending(PacketEvent event) {
         try {
             if (event.isPlayerTemporary()) return;
-        } catch(NoSuchMethodError e) {}
-    	if (event.isCancelled()) {
+        } catch(NoSuchMethodError e) {
+            // Ignore: method not available on older ProtocolLib versions
+        }
+        if (event.isCancelled()) {
             return;
         }
         final long time = System.currentTimeMillis();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionFactory.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionFactory.java
@@ -68,6 +68,7 @@ public class ActionFactory extends AbstractActionFactory<ViolationData, ActionLi
                 }
             }
             catch (NumberFormatException e) {
+                // Ignore: malformed percentage, fallback handled below
             }
             StaticLog.logWarning("Bad probability definition for cancel action: '" + actionDefinition + "', relay to always cancelling.");
             return new CancelAction<ViolationData, ActionList>();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/VanillaBlocksFactory.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/VanillaBlocksFactory.java
@@ -48,7 +48,9 @@ public class VanillaBlocksFactory {
             setups.add(new BlocksMC1_20());
             setups.add(new BlocksMC1_21());
         }
-        catch(Throwable t){}
+        catch(Throwable t){
+            // Ignore: optional block setups may not be present
+        }
         for (final BlockPropertiesSetup setup : setups){
             try{
                 // Assume the blocks setup to message success.

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationTrace.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationTrace.java
@@ -108,20 +108,20 @@ public class TestLocationTrace {
         try {
             trace.oldestIterator();
             fail("Expect an exception on trying to get an empty iterator (oldest).");
-        } catch (IllegalArgumentException ex) {
-
+        } catch (IllegalArgumentException expected) {
+            // expected
         }
         try {
             trace.latestIterator();
             fail("Expect an exception on trying to get an empty iterator (latest).");
-        } catch (IllegalArgumentException ex) {
-
+        } catch (IllegalArgumentException expected) {
+            // expected
         }
         try {
             trace.maxAgeIterator(0);
             fail("Expect an exception on trying to get an empty iterator (maxAge).");
-        } catch (IllegalArgumentException ex) {
-
+        } catch (IllegalArgumentException expected) {
+            // expected
         }
     }
 


### PR DESCRIPTION
## Summary
- add explanatory comments for catch blocks in ProtocolLib adapters and action factory
- clarify version-specific try blocks in VanillaBlocksFactory
- expect IllegalArgumentException in `TestLocationTrace`

## Testing
- `mvn -q verify`
- `mvn verify -DskipTests -Dcheckstyle.failOnViolation=false -Dpmd.failOnViolation=false -Dspotbugs.failOnError=false`

------
https://chatgpt.com/codex/tasks/task_b_685b55a576d083299eb48ef54eed230f