### PR TITLE
Add SpotBugs to Maven build

### DIFF
--- a/NCPBuildBase/pom.xml
+++ b/NCPBuildBase/pom.xml
@@ -39,14 +39,6 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.9.3.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/NCPCommons/pom.xml
+++ b/NCPCommons/pom.xml
@@ -41,4 +41,13 @@
         <cpd.failOnViolation>false</cpd.failOnViolation>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatBukkit/pom.xml
+++ b/NCPCompatBukkit/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatCBDev/pom.xml
+++ b/NCPCompatNonFree/NCPCompatCBDev/pom.xml
@@ -40,4 +40,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/pom.xml
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/pom.xml
@@ -30,4 +30,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCompatProtocolLib/pom.xml
+++ b/NCPCompatProtocolLib/pom.xml
@@ -46,4 +46,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPCore/pom.xml
+++ b/NCPCore/pom.xml
@@ -69,4 +69,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/NCPPlugin/pom.xml
+++ b/NCPPlugin/pom.xml
@@ -143,6 +143,10 @@
                     </filters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Compiling NoCheatPlus
 * You can compile with this Maven goal: `mvn clean package`, for a build without any of the "non free" modules, which depened on not publicly downloadable resources, such as the CraftBukkit/Spigot server jar - the reflection based compatibility module is still contained. 
 * To also (re-) build "non free" compatibility modules, use `-P nonfree_build` as well as activating the appropriate module to build via a profile such as `-P cbdev` - see the tables below for reference.
 * For a build with full compatibility modules, You can compile with this goal: `mvn clean package -P nonfree_build -P all`.
+* Static analysis with Checkstyle, PMD and SpotBugs runs automatically during the build; you can also invoke `mvn spotbugs:check` manually.
 * "Non free" jar file dependencies needed for the dedicated compat modules, which your local maven repository might be missing, can be installed manually.
 Example for Eclipse with embedded maven:
 Add a new maven build run configuration, name it appropriately, e.g. ```Install CB 1.8.8```.

--- a/pom.xml
+++ b/pom.xml
@@ -112,10 +112,17 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>	4.9.3.0</version>
+                    <version>4.9.3.0</version>
                     <configuration>
                         <failOnError>${spotbugs.failOnError}</failOnError>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Summary
- configure SpotBugs plugin in the parent `pom.xml`
- hook SpotBugs plugin into each module
- document SpotBugs usage in the build instructions
- update SpotBugs version to `4.9.3.0`

## Testing
- `mvn -q --no-transfer-progress test`
- `mvn -q --no-transfer-progress spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685b531667788329ba0643055b86fcba