### PR TITLE
Add configurable log level

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -81,6 +81,8 @@ public abstract class ConfPaths {
     @GlobalConfig
     private static final String LOGGING                                  = "logging.";
     public static final String  LOGGING_ACTIVE                           = LOGGING + SUB_ACTIVE;
+    /** Minimum log level, e.g. INFO, WARNING, SEVERE. */
+    public static final String  LOGGING_LEVEL                            = LOGGING + "level";
     public static final String  LOGGING_MAXQUEUESIZE                     = LOGGING + "maxqueuesize";
 
     private static final String LOGGING_BACKEND                          = LOGGING + "backend.";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -53,6 +53,7 @@ public class DefaultConfig extends ConfigFile {
         //        not set(ConfPaths.CONFIGVERSION_CREATED, -1);
         //        not set(ConfPaths.CONFIGVERSION_SAVED, -1);
         set(ConfPaths.LOGGING_ACTIVE, true, 785);
+        set(ConfPaths.LOGGING_LEVEL, "INFO", 1200);
         set(ConfPaths.LOGGING_MAXQUEUESIZE, 5000, 785);
         set(ConfPaths.LOGGING_EXTENDED_STATUS, false, 785);
         set(ConfPaths.LOGGING_EXTENDED_COMMANDS_ACTIONS, false, 1090);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/BukkitLogManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/BukkitLogManager.java
@@ -63,6 +63,8 @@ public class BukkitLogManager extends AbstractLogManager implements INotifyReloa
     };
 
     protected final Plugin plugin;
+    /** Minimum log level for emitted log messages. */
+    private volatile Level minLevel = Level.INFO;
 
     /**
      * This will create all default loggers as well.
@@ -72,6 +74,7 @@ public class BukkitLogManager extends AbstractLogManager implements INotifyReloa
         super(new BukkitLogNodeDispatcher(plugin), Streams.defaultPrefix, Streams.INIT);
         this.plugin = plugin;
         ConfigFile config = ConfigManager.getConfigFile();
+        updateLogLevel(config);
         createDefaultLoggers(config);
         getLogNodeDispatcher().setMaxQueueSize(config.getInt(ConfPaths.LOGGING_MAXQUEUESIZE));
     }
@@ -209,12 +212,46 @@ public class BukkitLogManager extends AbstractLogManager implements INotifyReloa
         return null;
     }
 
+    /**
+     * Update the minimum log level from configuration.
+     * @param config Configuration file to read from.
+     */
+    private void updateLogLevel(ConfigFile config) {
+        String name = config.getString(ConfPaths.LOGGING_LEVEL, "INFO");
+        Level level;
+        try {
+            level = Level.parse(name.toUpperCase());
+        } catch (Exception e) {
+            level = Level.INFO;
+        }
+        minLevel = level;
+        StaticLog.setMinimumLevel(level);
+    }
+
+    @Override
+    public void log(StreamID streamID, Level level, String message) {
+        if (level.intValue() < minLevel.intValue()) {
+            return;
+        }
+        super.log(streamID, level, message);
+    }
+
+    @Override
+    public void log(StreamID streamID, Level level, Throwable t) {
+        if (level.intValue() < minLevel.intValue()) {
+            return;
+        }
+        super.log(streamID, level, t);
+    }
+
     @Override
     public void onReload() {
         // Hard clear and re-do loggers. Might result in loss of content.
         // TODO: Register for "early onReload call", needs API addition.
         clear(0L, true); // Can not afford to wait.
-        createDefaultLoggers(ConfigManager.getConfigFile());
+        ConfigFile config = ConfigManager.getConfigFile();
+        updateLogLevel(config);
+        createDefaultLoggers(config);
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/StaticLog.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/StaticLog.java
@@ -38,6 +38,9 @@ public class StaticLog {
 
     private static StreamID streamID = Streams.INIT;
 
+    /** Minimum log level to output. */
+    private static volatile Level minimumLevel = Level.INFO;
+
     /** The Constant logOnce. */
     // TODO: Quick and dirty - should probably use an access ordered LinkedHashSet, to expire the eldest half :p.
     private static final Set<Integer> logOnce = Collections.synchronizedSet(new HashSet<Integer>());
@@ -56,6 +59,16 @@ public class StaticLog {
             throw new NullPointerException("StreamID must not be null, use setUseLogManager(false) instead.");
         }
         StaticLog.streamID = streamID;
+    }
+
+    /**
+     * Set the minimum log level to output.
+     * @param level the minimum level (null ignored)
+     */
+    public static void setMinimumLevel(Level level) {
+        if (level != null) {
+            minimumLevel = level;
+        }
     }
 
     public static void logDebug(final String msg) {
@@ -102,6 +115,9 @@ public class StaticLog {
      * @param msg
      */
     public static void log(final StreamID streamID, final Level level, final String msg) {
+        if (level.intValue() < minimumLevel.intValue()) {
+            return;
+        }
         if (useLogManager) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().log(streamID, level, msg);
         } else {


### PR DESCRIPTION
### **User description**
## Summary
- add `logging.level` option
- update default config with new log level
- respect configured log level in BukkitLogManager and StaticLog

## Testing
- `mvn -q test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685b531548a4832991b6ba39492bb535


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable log level option to control minimum logging output

- Update default configuration with new `logging.level` setting

- Implement log level filtering in BukkitLogManager and StaticLog

- Add level validation and fallback to INFO for invalid configurations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConfPaths.java</strong><dd><code>Add logging level configuration path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java

<li>Add <code>LOGGING_LEVEL</code> configuration path constant<br> <li> Include documentation comment for minimum log level setting


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/64/files#diff-2dbe47936f8ebfc431bc07eaff66097f45c07ca03fea6a87d31e5d048d065e77">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DefaultConfig.java</strong><dd><code>Set default log level configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java

<li>Set default log level to "INFO" in configuration<br> <li> Add build number 1200 for the new setting


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/64/files#diff-e13bc6d760e2af7842a590792ebb501aaf9438bd4e14a2e5a6d141c61443183d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BukkitLogManager.java</strong><dd><code>Implement log level filtering in BukkitLogManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/BukkitLogManager.java

<li>Add <code>minLevel</code> field to track minimum log level<br> <li> Implement <code>updateLogLevel()</code> method with validation and fallback<br> <li> Override <code>log()</code> methods to filter messages below minimum level<br> <li> Update log level on configuration reload


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/64/files#diff-2dfd7e45aad47013fc716447de281f6b589e2e8849faebb5043c1725fa2733e4">+38/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StaticLog.java</strong><dd><code>Add log level filtering to StaticLog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/StaticLog.java

<li>Add <code>minimumLevel</code> field with default INFO level<br> <li> Add <code>setMinimumLevel()</code> method for level configuration<br> <li> Filter log messages below minimum level in <code>log()</code> method


</details>


  </td>
  <td><a href="https://github.com/rafalohaki/NoCheatPlus/pull/64/files#diff-9c3ee22b464c8947ee4924b117fb726b821ca5323d51c49aa07e20744fc98cdd">+33/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>