### PR TITLE
Fix PMD violations

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -15,7 +15,6 @@
 package fr.neatmonster.nocheatplus;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,7 +51,6 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import java.io.File;
-import org.bukkit.scheduler.BukkitScheduler;
 
 import fr.neatmonster.nocheatplus.actions.ActionFactory;
 import fr.neatmonster.nocheatplus.actions.ActionFactoryFactory;
@@ -61,7 +59,6 @@ import fr.neatmonster.nocheatplus.checks.blockinteract.BlockInteractListener;
 import fr.neatmonster.nocheatplus.checks.blockplace.BlockPlaceListener;
 import fr.neatmonster.nocheatplus.checks.chat.ChatConfig;
 import fr.neatmonster.nocheatplus.checks.chat.ChatListener;
-import fr.neatmonster.nocheatplus.checks.combined.CombinedData;
 import fr.neatmonster.nocheatplus.checks.combined.CombinedListener;
 import fr.neatmonster.nocheatplus.checks.fight.FightListener;
 import fr.neatmonster.nocheatplus.checks.inventory.InventoryListener;
@@ -124,7 +121,6 @@ import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
 import fr.neatmonster.nocheatplus.logging.StreamID;
 import fr.neatmonster.nocheatplus.logging.Streams;
-import fr.neatmonster.nocheatplus.logging.details.IGetStreamId;
 import fr.neatmonster.nocheatplus.permissions.PermissionRegistry;
 import fr.neatmonster.nocheatplus.permissions.PermissionUtil;
 import fr.neatmonster.nocheatplus.permissions.PermissionUtil.CommandProtectionEntry;
@@ -140,7 +136,6 @@ import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 import fr.neatmonster.nocheatplus.utilities.Misc;
 import fr.neatmonster.nocheatplus.utilities.OnDemandTickListener;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
-import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.entity.PassengerUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
@@ -459,7 +454,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                     result.add((ComponentRegistry<T>) registry);
                 }
                 catch(Throwable t) {
-                    // Ignore.
+                    StaticLog.logDebug(t);
                 }
             }
         }
@@ -545,13 +540,13 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         // Add to sub registries.
         for (final ComponentRegistry<?> registry : subRegistries) {
             final Object res = ReflectionUtil.invokeGenericMethodOneArg(registry, "addComponent", obj);
-            if (res != null && (res instanceof Boolean) && ((Boolean) res).booleanValue()) {
+            if (res != null && res instanceof Boolean && ((Boolean) res).booleanValue()) {
                 added = true;
             }
         }
 
         // Add ComponentRegistry instances after adding to sub registries to prevent adding it to itself.
-        if (allowComponentRegistry && (obj instanceof ComponentRegistry<?>)) {
+        if (allowComponentRegistry && obj instanceof ComponentRegistry<?>) {
             subRegistries.add((ComponentRegistry<?>) obj);
             added = true;
         }
@@ -1048,7 +1043,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         //        }
 
         // Log other notes.
-        logOtherNotes(config);
+        logOtherNotes();
 
         // Is the version the configuration was created with consistent with the current one?
         if (configProblemsFile != null && config.getBoolean(ConfPaths.CONFIGVERSION_NOTIFY)) {
@@ -1088,7 +1083,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
      * 
      * @param config
      */
-    private void logOtherNotes(ConfigFile config) {
+    private void logOtherNotes() {
         if (ServerVersion.compareMinecraftVersion("1.9") >= 0) {
             logManager.info(Streams.INIT, "Force disable FastHeal, FastConsume, PacketFrequency and InstantBow on Minecraft 1.9 and later.");
         }
@@ -1474,7 +1469,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     @Override
     public boolean hasFeatureTag(final String key, final String feature) {
         final Collection<String>  features = this.featureTags.get(key);
-        return features == null ? false : features.contains(feature);
+        return features != null && features.contains(feature);
     }
 
     @Override

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/meta/BridgeCrossPlugin.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/meta/BridgeCrossPlugin.java
@@ -23,6 +23,7 @@ import fr.neatmonster.nocheatplus.compat.cbreflect.reflect.ReflectBase;
 import fr.neatmonster.nocheatplus.compat.cbreflect.reflect.ReflectHelper.ReflectFailureException;
 import fr.neatmonster.nocheatplus.components.registry.feature.IPostRegisterRunnable;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 
 /**
  * Utility to probe for cross-plugin issues, such as Player delegates.
@@ -44,10 +45,10 @@ public class BridgeCrossPlugin implements IBridgeCrossPlugin, IPostRegisterRunna
             reflectBase = new ReflectBase();
         }
         catch (ReflectFailureException e2) {
-            // ignore - reflection helper not available
+            StaticLog.logDebug(e2);
         }
         catch (RuntimeException e1) {
-            // ignore - reflection helper not available (includes NPE)
+            StaticLog.logDebug(e1);
         }
         if (reflectBase != null) {
             this.playerClass = getEntityClass(reflectBase, "Player");

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
@@ -20,6 +20,7 @@ import fr.neatmonster.nocheatplus.compat.bukkit.NSBukkitAttributeAccess;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
 import fr.neatmonster.nocheatplus.components.modifier.DummyAttributeAccess;
 import fr.neatmonster.nocheatplus.components.modifier.IAttributeAccess;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 
 public class AttributeAccessFactory {
 
@@ -39,7 +40,7 @@ public class AttributeAccessFactory {
             fallBackDedicated = ServerVersion.compareMinecraftVersion("1.21") < 0 ? new BukkitAttributeAccess() : new NSBukkitAttributeAccess();
         }
         catch (Throwable t) {
-            // ignore - dedicated access not available for this server version
+            StaticLog.logDebug(t);
         }
         RegistryHelper.setupGenericInstance(new String[] {
                 "fr.neatmonster.nocheatplus.compat.cbdev.AttributeAccess",

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/DefaultComponentFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/DefaultComponentFactory.java
@@ -189,7 +189,7 @@ public class DefaultComponentFactory {
             NCPAPIProvider.getNoCheatPlusAPI().addFeatureTags("checks", Arrays.asList(HotFixFallingBlockPortalEnter.class.getSimpleName()));
         }
         catch (RuntimeException e) {
-            // ignore - server does not have the falling block portal issue
+            StaticLog.logDebug(e);
         }
 
         // ProtocolLib dependencies.

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
@@ -15,7 +15,6 @@
 package fr.neatmonster.nocheatplus.compat.registry;
 
 import fr.neatmonster.nocheatplus.compat.MCAccess;
-import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
 
 /**

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/MCAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/MCAccessFactory.java
@@ -48,12 +48,11 @@ public class MCAccessFactory {
         
         // CraftBukkit (dedicated).
         // Use CraftBukkit dedicated if the server version is below/equal to 1.12.2
-        if (GenericVersion.compareVersions(ServerVersion.getMinecraftVersion(), "1.12.2") <= 0) {
-            if (config.enableCBDedicated) {
-                mcAccess = getMCAccessCraftBukkit(throwables);
-                if (mcAccess != null) {
-                    return mcAccess;
-                }
+        if (GenericVersion.compareVersions(ServerVersion.getMinecraftVersion(), "1.12.2") <= 0
+                && config.enableCBDedicated) {
+            mcAccess = getMCAccessCraftBukkit(throwables);
+            if (mcAccess != null) {
+                return mcAccess;
             }
         }
 


### PR DESCRIPTION
## Summary
- clean up unused imports and simplify logic
- log debug messages for ignored exceptions
- collapse MCAccessFactory nested ifs
- remove unused parameter from `logOtherNotes`
- address misc PMD warnings

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: spotbugs violations)*

------
https://chatgpt.com/codex/tasks/task_b_685b606c9f7c8329a6785b5422d2cf8d