### PR TITLE
Refactor Elytra boost context and add helpers

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
@@ -38,6 +38,8 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_13;
 import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.BridgeHealth;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
+import fr.neatmonster.nocheatplus.checks.moving.helper.CheckContext;
+import fr.neatmonster.nocheatplus.checks.moving.helper.ElytraBoostHandler;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
 import fr.neatmonster.nocheatplus.components.data.ICheckData;
 import fr.neatmonster.nocheatplus.components.data.IData;
@@ -364,26 +366,22 @@ public class BlockInteractListener extends CheckListener {
         //        }
         if (
                 (
-                        event.getAction() == Action.RIGHT_CLICK_AIR 
+                        event.getAction() == Action.RIGHT_CLICK_AIR
                         // Water doesn't happen, block typically is null.
-                        //                        || event.getAction() == Action.RIGHT_CLICK_BLOCK 
+                        //                        || event.getAction() == Action.RIGHT_CLICK_BLOCK
                         //                        && block != null && BlockProperties.isLiquid(block.getType())
                         // TODO: web ?
                         )
                 && event.isCancelled() && event.useItemInHand() != Result.DENY) {
             final ItemStack stack = Bridge1_9.getUsedItem(player, event);
-            if (stack != null && BridgeMisc.maybeElytraBoost(player, stack.getType())) {
-                final int power = BridgeMisc.getFireworksPower(stack);
-                final MovingData mData = pData.getGenericInstance(MovingData.class);
-                final int ticks = Math.max((1 + power) * 20, 30);
-                mData.fireworksBoostDuration = ticks;
-                mData.fireworksBoostTickNeedCheck = ticks - 1;
-                // Expiration tick: not general latency, rather a minimum margin for sudden congestion.
-                mData.fireworksBoostTickExpire = TickTask.getTick() + ticks;
-                // TODO: Invalidation mechanics: by tick/time well ?
-                // TODO: Implement using it in CreativeFly.
-                if (pData.isDebugActive(CheckType.MOVING)) {
-                    debug(player, "Elytra boost (power " + power + "): " + stack);
+            if (stack != null) {
+                final CheckContext ctx = new CheckContext(player,
+                        pData.getGenericInstance(MovingData.class));
+                final boolean boosted = ElytraBoostHandler.handleBoost(ctx, stack,
+                        TickTask.getTick());
+                if (boosted && pData.isDebugActive(CheckType.MOVING)) {
+                    debug(player, "Elytra boost (power " +
+                            BridgeMisc.getFireworksPower(stack) + "): " + stack);
                 }
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -87,6 +87,8 @@ import fr.neatmonster.nocheatplus.checks.moving.util.AuxMoving;
 import fr.neatmonster.nocheatplus.checks.moving.util.MovingUtil;
 import fr.neatmonster.nocheatplus.checks.moving.util.bounce.BounceType;
 import fr.neatmonster.nocheatplus.checks.moving.util.bounce.BounceUtil;
+import fr.neatmonster.nocheatplus.checks.moving.helper.MoveCheckContext;
+import fr.neatmonster.nocheatplus.checks.moving.helper.VelocityAdjustment;
 import fr.neatmonster.nocheatplus.checks.moving.vehicle.VehicleChecks;
 import fr.neatmonster.nocheatplus.checks.moving.velocity.AccountEntry;
 import fr.neatmonster.nocheatplus.checks.moving.velocity.SimpleEntry;
@@ -1521,12 +1523,13 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         // Test for exceptions.
         if (Bridge1_9.isWearingElytra(player) && lastMove.modelFlying != null && lastMove.modelFlying.getId().equals(MovingConfig.ID_JETPACK_ELYTRA)) {
             // Still elytra move, not forcing CreativeFly check, just pass the res to velocity
-            final double[] res = CreativeFly.guessElytraVelocityAmount(player, thisMove, lastMove, data);
+            final MoveCheckContext ctx = new MoveCheckContext(player, thisMove, lastMove, data);
+            final VelocityAdjustment res = CreativeFly.guessElytraVelocityAmount(ctx);
             //data.addVerticalVelocity(new SimpleEntry(lastMove.yDistance < -0.1034 ? (lastMove.yDistance * Magic.FRICTION_MEDIUM_AIR + 0.1034) 
             //                                        : lastMove.yDistance, cc.velocityActivationCounter));
             data.keepfrictiontick = -15;
-            data.addVerticalVelocity(new SimpleEntry(res[1], cc.velocityActivationCounter));
-            return res[0];
+            data.addVerticalVelocity(new SimpleEntry(res.vertical(), cc.velocityActivationCounter));
+            return res.horizontal();
             //if (thisMove.hDistance > defaultAmount) {
                 // Allowing the same speed won't always work on elytra (still increasing, differing modeling on client side with motXYZ).
                 // (Doesn't seem to be overly effective.)

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/CheckContext.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/CheckContext.java
@@ -1,0 +1,13 @@
+package fr.neatmonster.nocheatplus.checks.moving.helper;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+
+/**
+ * Context object shared among check helpers.
+ *
+ * @param player the player related to the check
+ * @param data moving related data of the player
+ */
+public record CheckContext(Player player, MovingData data) {}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
@@ -1,0 +1,40 @@
+package fr.neatmonster.nocheatplus.checks.moving.helper;
+
+import org.bukkit.inventory.ItemStack;
+
+import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.compat.BridgeMisc;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
+
+/**
+ * Utility class for handling Elytra firework boosts.
+ */
+public final class ElytraBoostHandler {
+
+    private ElytraBoostHandler() {
+    }
+
+    /**
+     * Process a potential Elytra boost using a firework.
+     *
+     * @param context shared context holding player and data
+     * @param stack the used item
+     * @param tick current server tick
+     * @return {@code true} if a boost has been applied
+     */
+    public static boolean handleBoost(CheckContext context, ItemStack stack, int tick) {
+        if (context == null || context.player() == null || context.data() == null) {
+            return false;
+        }
+        if (stack == null || !BridgeMisc.maybeElytraBoost(context.player(), stack.getType())) {
+            return false;
+        }
+        final int power = BridgeMisc.getFireworksPower(stack);
+        final MovingData mData = context.data();
+        final int ticks = Math.max((1 + power) * 20, 30);
+        mData.fireworksBoostDuration = ticks;
+        mData.fireworksBoostTickNeedCheck = ticks - 1;
+        mData.fireworksBoostTickExpire = tick + ticks;
+        return true;
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/MoveCheckContext.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/MoveCheckContext.java
@@ -1,0 +1,17 @@
+package fr.neatmonster.nocheatplus.checks.moving.helper;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
+
+/**
+ * Immutable context for movement related helpers.
+ *
+ * @param player the player
+ * @param thisMove data for the current move
+ * @param lastMove data for the previous move
+ * @param data player specific moving data
+ */
+public record MoveCheckContext(Player player, PlayerMoveData thisMove,
+        PlayerMoveData lastMove, MovingData data) {}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/VelocityAdjustment.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/VelocityAdjustment.java
@@ -1,0 +1,9 @@
+package fr.neatmonster.nocheatplus.checks.moving.helper;
+
+/**
+ * Simple container for horizontal and vertical velocity components.
+ *
+ * @param horizontal horizontal component
+ * @param vertical vertical component
+ */
+public record VelocityAdjustment(double horizontal, double vertical) {}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -55,6 +55,8 @@ import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.location.TrigUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
+import fr.neatmonster.nocheatplus.checks.moving.helper.MoveCheckContext;
+import fr.neatmonster.nocheatplus.checks.moving.helper.VelocityAdjustment;
 
 
 /**
@@ -1161,7 +1163,17 @@ public class CreativeFly extends Check {
         return defaultAmount;
     }
     
-    public static double[] guessElytraVelocityAmount(final Player player, final PlayerMoveData thisMove, final PlayerMoveData lastMove, final MovingData data) {
+    /**
+     * Estimate allowed velocity adjustments for Elytra gliding.
+     *
+     * @param context movement context containing player and move data
+     * @return horizontal and vertical velocity adjustments
+     */
+    public static VelocityAdjustment guessElytraVelocityAmount(final MoveCheckContext context) {
+        final Player player = context.player();
+        final PlayerMoveData thisMove = context.thisMove();
+        final PlayerMoveData lastMove = context.lastMove();
+        final MovingData data = context.data();
         final Location useLoc = new Location(null, 0, 0, 0);
         useLoc.setYaw(thisMove.to.getYaw());
         useLoc.setPitch(thisMove.to.getPitch());
@@ -1213,7 +1225,7 @@ public class CreativeFly extends Check {
                     thisMove.yDistance : lastMove.toIsValid ? lastMove.yDistance : 0;
             if (Math.round(data.fireworksBoostTickNeedCheck / 4) > data.fireworksBoostDuration 
                 && thisMove.hDistance < Math.sqrt(x*x + z*z)) {
-                return new double[] {Math.sqrt(x*x + z*z), allowedElytraYDistance};
+                return new VelocityAdjustment(Math.sqrt(x*x + z*z), allowedElytraYDistance);
             }
 
             x *= 0.99;
@@ -1222,14 +1234,14 @@ public class CreativeFly extends Check {
             z += lookvec.getZ() * 0.1D + (lookvec.getZ() * 1.5D - z) * 0.5D;
 
             if (thisMove.hDistance < lastMove.hAllowedDistance * 0.994) {
-                return new double[] {lastMove.hAllowedDistance * 0.994, allowedElytraYDistance};
+                return new VelocityAdjustment(lastMove.hAllowedDistance * 0.994, allowedElytraYDistance);
             } 
             else allowedElytraHDistance += 0.2;
         }
 
         // Adjust false
         allowedElytraHDistance += Math.sqrt(x*x + z*z) + 0.1;
-        return new double[] {allowedElytraHDistance, allowedElytraYDistance};
+        return new VelocityAdjustment(allowedElytraHDistance, allowedElytraYDistance);
     }
 
 


### PR DESCRIPTION
## Summary
- add `CheckContext` and `MoveCheckContext` records for sharing parameters
- introduce `VelocityAdjustment` record for clarity
- extract Elytra boost logic into `ElytraBoostHandler`
- use the new helpers in `CreativeFly`, `MovingListener` and `BlockInteractListener`
- document `guessElytraVelocityAmount` helper

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check` *(fails: spotbugs violations)*

------
https://chatgpt.com/codex/tasks/task_b_685b6152c2508329b40c1b4def101845