### PR TITLE
Add no-arg constructor for Paper 1.21

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -155,6 +155,14 @@ import org.jetbrains.annotations.NotNull;
  * This is the main class of NoCheatPlus. The commands, events listeners and tasks are registered here.
  */
 public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
+
+    /**
+     * Required public no-argument constructor for modern plugin loading.
+     */
+    public NoCheatPlus() {
+        super();
+    }
+
     protected NoCheatPlus(JavaPluginLoader loader, PluginDescriptionFile desc, File dataFolder, File file) {
         super(loader, desc, dataFolder, file);
     }


### PR DESCRIPTION
## Summary
- add a public no-argument constructor to `NoCheatPlus`

## Testing
- `mvn -q package`


------
https://chatgpt.com/codex/tasks/task_b_685b66383e808329a1933286f34af92f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a public no-argument constructor to the `NoCheatPlus` class to support modern plugin loading for Paper 1.21.

### Why are these changes being made?

Paper 1.21 requires plugins to declare a no-argument constructor for compatibility with its new plugin loading mechanism. This adjustment ensures that `NoCheatPlus` can be loaded correctly without breaking existing functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->