### PR TITLE
Fix reflection warning in PlayerDataManager

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -518,6 +518,24 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
         }
     }
 
+    /**
+     * Fallback for reflective component registration.
+     *
+     * <p>This method prevents noisy warnings when {@link #addComponent(IRemoveData)}
+     * is invoked reflectively with objects that are not {@link IRemoveData}
+     * instances. It delegates to the specialized method if possible and otherwise
+     * returns {@code false}.</p>
+     *
+     * @param obj component instance
+     * @return {@code true} if the component was added
+     */
+    public boolean addComponent(Object obj) {
+        if (obj instanceof IRemoveData) {
+            return addComponent((IRemoveData) obj);
+        }
+        return false;
+    }
+
     @Override
     public void removeComponent(IRemoveData obj) {
         iRemoveData.remove((IRemoveData) obj);


### PR DESCRIPTION
## Summary
- add Object-based fallback for PlayerDataManager.addComponent

## Testing
- `mvn verify -DskipTests=false` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b69635c848329bd9de520480c6818

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new `addComponent` method in `PlayerDataManager` to handle reflection warnings by checking if the object is an instance of `IRemoveData`.

### Why are these changes being made?

The existing method `addComponent(IRemoveData obj)` is causing reflection warnings when invoked with non-`IRemoveData` objects. This additional overloaded method prevents these warnings by providing a type check and elegantly returns `false` for unsupported types, improving code robustness and reducing unwanted log noise.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary warning messages when adding unsupported components through reflective calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->