### PR TITLE
Fix some spotbugs warnings

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -360,9 +360,11 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     public int allowLoginAll() {
         int denied = 0;
         final long now = System.currentTimeMillis();
-        for (final String playerName : denyLoginNames.keySet()) {
-            final Long time = denyLoginNames.get(playerName);
-            if (time != null && time > now) denied ++;
+        for (final Map.Entry<String, Long> entry : denyLoginNames.entrySet()) {
+            final Long time = entry.getValue();
+            if (time != null && time > now) {
+                denied++;
+            }
         }
         denyLoginNames.clear();
         return denied;
@@ -1012,8 +1014,12 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
 
         // Register the commands handler.
         final PluginCommand command = getCommand("nocheatplus");
-        final NoCheatPlusCommand commandHandler = new NoCheatPlusCommand(this, notifyReload);
-        command.setExecutor(commandHandler);
+        if (command != null) {
+            final NoCheatPlusCommand commandHandler = new NoCheatPlusCommand(this, notifyReload);
+            command.setExecutor(commandHandler);
+        } else {
+            getLogger().severe("Command 'nocheatplus' not registered; cannot set executor.");
+        }
         // (CommandHandler is TabExecutor.)
 
         // Tell the permission registry which permissions should get updated. This might be restricted by check settings later.

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
@@ -109,7 +109,9 @@ public class AllViolationsHook implements NCPHook, ILast, IStats {
             // TODO: Better mix the debug flag into IViolationInfo, for best performance AND consistency.
             // TODO: (If debug is not in IViolationInfo, switch to PlayerData.isDebug(CheckType).)
             final IPlayerData pData = DataManager.getPlayerData(player);
-            debugSet = pData.isDebugActive(checkType);
+            if (pData != null) {
+                debugSet = pData.isDebugActive(checkType);
+            }
             if (config.debugOnly && !debugSet) {
                 return false;
             }
@@ -127,7 +129,8 @@ public class AllViolationsHook implements NCPHook, ILast, IStats {
         builder.append("[VL] [" + checkType.toString() + "] ");
         builder.append("[" + ChatColor.YELLOW + playerName);
         builder.append(ChatColor.WHITE + "] ");
-        final String displayName = ChatColor.stripColor(player.getDisplayName()).trim();
+        final String rawDisplayName = player.getDisplayName();
+        final String displayName = rawDisplayName != null ? ChatColor.stripColor(rawDisplayName).trim() : playerName;
         if (!playerName.equals(displayName)) {
             builder.append("[->" + ChatColor.YELLOW + displayName + ChatColor.WHITE + "] ");
         }


### PR DESCRIPTION
## Summary
- fix allowLoginAll iteration to use entrySet
- check null command when registering nocheatplus command
- guard AllViolationsHook against null player data
- avoid NPE if display name is null

## Testing
- `mvn verify`

------
https://chatgpt.com/codex/tasks/task_b_685b697e9a6483299c85a26977b5711d