### PR TITLE
Refactor pre-check logic in MovingListener

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -824,88 +824,13 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         }
         
         // 5: Pre-checks relevant to Sf or Cf.
-        if (checkSf || checkCf) {
-            previousSetBackY = data.hasSetBack() ? data.getSetBackY() : Double.NEGATIVE_INFINITY;
-            MovingUtil.checkSetBack(player, pFrom, data, pData, this); // Ensure we have a set back set.
-
-            // 5.1: Check for special cross world teleportation issues with the end.
-            if (data.crossWorldFrom != null) {
-                if (!TrigUtil.isSamePosAndLook(pFrom, pTo) && TrigUtil.isSamePosAndLook(pTo, data.crossWorldFrom)) {
-                    // Assume to (and possibly the player location) to be set to the location the player teleported from within the other world.
-                    newTo = data.getSetBack(from); // (OK, cross-world)
-                    checkNf = false;
-                    NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, CheckUtils.getLogMessagePrefix(player, CheckType.MOVING) + " Player move end point seems to be set wrongly.");
-                }
-                // Always reset.
-                data.crossWorldFrom = null;
-            }
-
-            // 5.2: Extreme move check (sf or cf is precondition, should have their own config/actions later).
-            if (newTo == null && ((Math.abs(thisMove.yDistance) > Magic.EXTREME_MOVE_DIST_VERTICAL) || thisMove.hDistance > Magic.EXTREME_MOVE_DIST_HORIZONTAL)) {
-                // Test for friction and velocity.
-                newTo = checkExtremeMove(player, pFrom, pTo, data, cc);
-                if (newTo != null) {
-                    thisMove.flyCheck = checkSf ? CheckType.MOVING_SURVIVALFLY : CheckType.MOVING_CREATIVEFLY;
-                }
-            }
-            
-            // 5.3: Set BCT
-            // NOTE: Block change activity has to be checked *after* the extreme move checks run.
-            useBlockChangeTracker = newTo == null && cc.trackBlockMove && (checkPassable || checkSf || checkCf) && blockChangeTracker.hasActivityShuffled(from.getWorld().getUID(), pFrom, pTo, 1.5625);
-
-            // 5.4: Check jumping on things like slime blocks.
-            // Detect bounce type / use prepared bounce.
-            if (newTo == null) {
-                // Mixed ground (e.g. slime blocks + slabs), specifically on pushing.
-                // More on fall damage. What with sneaking + past states?
-                // With past states: What does jump effects do here?
-                if (thisMove.yDistance < 0.0) {
-                    // Prepare bounce: The center of the player must be above the block.
-                    // Common pre-conditions.
-                    // Check if really leads to calling the method for pistons (checkBounceEnvelope vs. push).
-                    if (!survivalFly.isReallySneaking(player) && BounceUtil.checkBounceEnvelope(player, pFrom, pTo, data, cc, pData)) {
-                        // Check other side conditions (fluids, web, max. distance to the block top (!))
-                        // Classic static bounce.
-                        if ((pTo.getBlockFlags() & BlockFlags.F_BOUNCE25) != 0L) {
-                            /* May need to adapt within this method, if "push up" happened and the trigger had been ordinary */
-                            verticalBounce = BounceType.STATIC;
-                            checkNf = false; // Skip NoFall.
-                        }
-                        
-                        if (verticalBounce == BounceType.NO_BOUNCE && useBlockChangeTracker) { 
-                            if (BounceUtil.checkPastStateBounceDescend(player, pFrom, pTo, thisMove, lastMove, tick, data, cc, blockChangeTracker) != BounceType.NO_BOUNCE) {
-                                // Not set verticalBounce, as this is ascending and it's already force used.
-                                checkNf = false; // Skip NoFall.
-                            }
-                        }
-                    }
-                }
-                else {
-                    if (
-                            // Prepared bounce support.
-                            data.verticalBounce != null && BounceUtil.onPreparedBounceSupport(player, from, to, thisMove, lastMove, tick, data)
-                            // Past state bounce (includes prepending velocity / special calls).
-                            || useBlockChangeTracker 
-                            // 0-dist moves count in: && thisMove.yDistance >= 0.415 
-                            && thisMove.yDistance <= 1.515
-                        ) {
-                        verticalBounce = BounceUtil.checkPastStateBounceAscend(player, pFrom, pTo, thisMove, lastMove, tick, pData, this, data, cc, blockChangeTracker);
-                        if (verticalBounce != BounceType.NO_BOUNCE) checkNf = false;
-                    }
-                }
-
-                // Might a bit tricky when it use to ensure no bounce check is active, not noFall checking here
-                if (useBlockChangeTracker && checkNf && !checkPastStateVerticalPush(player, pFrom, pTo, thisMove, lastMove, tick, debug, data, cc)) {
-                    checkPastStateHorizontalPush(player, pFrom, pTo, thisMove, lastMove, tick, debug, data, cc);
-                }
-            }
-        }
-        // No Sf or Cf check
-        else {
-            // Might still allow block change tracker with only passable enabled.
-            useBlockChangeTracker = false;
-            previousSetBackY = Double.NEGATIVE_INFINITY;
-        }
+        final PreCheckData preCheck = runPreChecks(player, from, to, pFrom, pTo, thisMove, lastMove,
+                checkSf, checkCf, checkPassable, tick, data, cc, pData, debug);
+        previousSetBackY = preCheck.previousSetBackY;
+        useBlockChangeTracker = preCheck.useBlockChangeTracker;
+        verticalBounce = preCheck.verticalBounce;
+        checkNf = preCheck.checkNf;
+        if (newTo == null) newTo = preCheck.newTo;
 
         // 6: Check passable first to prevent set back override.
         boolean mightSkipNoFall = false;
@@ -1063,6 +988,21 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         }
     }
 
+    private static class PreCheckData {
+        final Location newTo;
+        final boolean checkNf;
+        final boolean useBlockChangeTracker;
+        final double previousSetBackY;
+        final BounceType verticalBounce;
+        PreCheckData(Location newTo, boolean checkNf, boolean useBct, double prevSetBackY, BounceType vb) {
+            this.newTo = newTo;
+            this.checkNf = checkNf;
+            this.useBlockChangeTracker = useBct;
+            this.previousSetBackY = prevSetBackY;
+            this.verticalBounce = vb;
+        }
+    }
+
     private FlyCheckResult determineFlyCheck(final Player player, final PlayerLocation pFrom,
             final PlayerLocation pTo, final PlayerMoveData thisMove, final int multiMoveCount, final int tick,
             final MovingData data, final MovingConfig cc, final IPlayerData pData, final Location from,
@@ -1090,6 +1030,87 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             final MovingData data, final MovingConfig cc, final IPlayerData pData, final int tick,
             final boolean useBlockChangeTracker) {
         return passable.check(player, pFrom, pTo, data, cc, pData, tick, useBlockChangeTracker);
+    }
+
+    private PreCheckData runPreChecks(final Player player, final Location from, final Location to,
+            final PlayerLocation pFrom, final PlayerLocation pTo, final PlayerMoveData thisMove,
+            final PlayerMoveData lastMove,
+            final boolean checkSf, final boolean checkCf, final boolean checkPassable, final int tick,
+            final MovingData data, final MovingConfig cc, final IPlayerData pData, final boolean debug) {
+        if (player == null || pFrom == null || pTo == null) {
+            return new PreCheckData(null, true, false, Double.NEGATIVE_INFINITY, BounceType.NO_BOUNCE);
+        }
+
+        boolean checkNf = true;
+        BounceType verticalBounce = BounceType.NO_BOUNCE;
+        boolean useBlockChangeTracker;
+        double previousSetBackY;
+        Location newTo = null;
+
+        if (checkSf || checkCf) {
+            previousSetBackY = data.hasSetBack() ? data.getSetBackY() : Double.NEGATIVE_INFINITY;
+            MovingUtil.checkSetBack(player, pFrom, data, pData, this);
+
+            if (data.crossWorldFrom != null) {
+                if (!TrigUtil.isSamePosAndLook(pFrom, pTo) && TrigUtil.isSamePosAndLook(pTo, data.crossWorldFrom)) {
+                    newTo = data.getSetBack(from);
+                    checkNf = false;
+                    NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+                            CheckUtils.getLogMessagePrefix(player, CheckType.MOVING)
+                                    + " Player move end point seems to be set wrongly.");
+                }
+                data.crossWorldFrom = null;
+            }
+
+            if (newTo == null && ((Math.abs(thisMove.yDistance) > Magic.EXTREME_MOVE_DIST_VERTICAL)
+                    || thisMove.hDistance > Magic.EXTREME_MOVE_DIST_HORIZONTAL)) {
+                newTo = checkExtremeMove(player, pFrom, pTo, data, cc);
+                if (newTo != null) {
+                    thisMove.flyCheck = checkSf ? CheckType.MOVING_SURVIVALFLY : CheckType.MOVING_CREATIVEFLY;
+                }
+            }
+
+            useBlockChangeTracker = newTo == null && cc.trackBlockMove && (checkPassable || checkSf || checkCf)
+                    && blockChangeTracker.hasActivityShuffled(from.getWorld().getUID(), pFrom, pTo, 1.5625);
+
+            if (newTo == null) {
+                if (thisMove.yDistance < 0.0) {
+                    if (!survivalFly.isReallySneaking(player)
+                            && BounceUtil.checkBounceEnvelope(player, pFrom, pTo, data, cc, pData)) {
+                        if ((pTo.getBlockFlags() & BlockFlags.F_BOUNCE25) != 0L) {
+                            verticalBounce = BounceType.STATIC;
+                            checkNf = false;
+                        }
+                        if (verticalBounce == BounceType.NO_BOUNCE && useBlockChangeTracker) {
+                            if (BounceUtil.checkPastStateBounceDescend(player, pFrom, pTo, thisMove, lastMove, tick,
+                                    data, cc, blockChangeTracker) != BounceType.NO_BOUNCE) {
+                                checkNf = false;
+                            }
+                        }
+                    }
+                } else {
+                    if ((data.verticalBounce != null
+                            && BounceUtil.onPreparedBounceSupport(player, from, to, thisMove, lastMove, tick, data))
+                            || useBlockChangeTracker && thisMove.yDistance <= 1.515) {
+                        verticalBounce = BounceUtil.checkPastStateBounceAscend(player, pFrom, pTo, thisMove, lastMove,
+                                tick, pData, this, data, cc, blockChangeTracker);
+                        if (verticalBounce != BounceType.NO_BOUNCE) {
+                            checkNf = false;
+                        }
+                    }
+                }
+
+                if (useBlockChangeTracker && checkNf
+                        && !checkPastStateVerticalPush(player, pFrom, pTo, thisMove, lastMove, tick, debug, data, cc)) {
+                    checkPastStateHorizontalPush(player, pFrom, pTo, thisMove, lastMove, tick, debug, data, cc);
+                }
+            }
+        } else {
+            useBlockChangeTracker = false;
+            previousSetBackY = Double.NEGATIVE_INFINITY;
+        }
+
+        return new PreCheckData(newTo, checkNf, useBlockChangeTracker, previousSetBackY, verticalBounce);
     }
 
     private boolean finalizeMove(final Player player, final PlayerMoveEvent event, Location newTo,


### PR DESCRIPTION
## Summary
- extract complex pre-check block into `runPreChecks`
- add `PreCheckData` container class

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685b69a505f08329ab8164465becd8a6