### PR TITLE
Fix reflection warnings on shutdown

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -530,15 +530,30 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
      * @return {@code true} if the component was added
      */
     public boolean addComponentReflectively(Object obj) {
-    if (obj instanceof IRemoveData) {
-        return addComponent((IRemoveData) obj);
-    }
-    return false;
+        if (obj instanceof IRemoveData) {
+            return addComponent((IRemoveData) obj);
+        }
+        return false;
     }
 
     @Override
     public void removeComponent(IRemoveData obj) {
         iRemoveData.remove((IRemoveData) obj);
+    }
+
+    /**
+     * Fallback for reflective component removal.
+     *
+     * <p>This method prevents noisy warnings when {@link #removeComponent(IRemoveData)}
+     * is invoked reflectively with objects that are not {@link IRemoveData}
+     * instances. It delegates to the specialized method if possible.</p>
+     *
+     * @param obj component instance
+     */
+    public void removeComponentReflectively(Object obj) {
+        if (obj instanceof IRemoveData) {
+            removeComponent((IRemoveData) obj);
+        }
     }
 
     /**

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -635,7 +635,11 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         }
         // Remove from present registries, order prevents to remove from itself.
         for (final ComponentRegistry<?> registry : subRegistries) {
-            ReflectionUtil.invokeGenericMethodOneArg(registry, "removeComponent", obj);
+            if (registry instanceof fr.neatmonster.nocheatplus.players.PlayerDataManager) {
+                ((fr.neatmonster.nocheatplus.players.PlayerDataManager) registry).removeComponentReflectively(obj);
+            } else {
+                ReflectionUtil.invokeGenericMethodOneArg(registry, "removeComponent", obj);
+            }
         }
 
         allComponents.remove(obj);


### PR DESCRIPTION
## Summary
- allow safe removal of arbitrary components from `PlayerDataManager`
- ensure `NoCheatPlus` uses the safe removal method for player data

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685b6d7dc5d08329afb78809afdaba98