### PR TITLE
Use scheduler fallback for Folia async tasks

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
@@ -16,7 +16,6 @@ package fr.neatmonster.nocheatplus.compat;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import org.bukkit.Bukkit;
@@ -28,7 +27,6 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
-import fr.neatmonster.nocheatplus.utilities.StringUtil;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -48,31 +46,42 @@ public class Folia {
     }
 
     /**
-     * Run an async task, either with bukkit scheduler or Java
-     * @param plugin Plugin to assign for
-     * @param run Consumer that accepts an object or null, for Folia or Paper/Spigot respectively
-     * @return An int represent for task id when running on Paper/Spigot or Thread when on Folia or null if can't schedule
+     * Run an asynchronous task. Execution is always performed via the Bukkit or
+     * Folia scheduler.
+     *
+     * @param plugin plugin to assign for
+     * @param run consumer that accepts an object or {@code null}, for Folia or
+     *            Paper/Spigot respectively
+     * @return the scheduled task object or {@code null} if scheduling fails
      */
     public static Object runAsyncTask(Plugin plugin, Consumer<Object> run) {
         if (!isFoliaServer) {
-            return Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> run.accept(null)).getTaskId();
+            return Bukkit.getScheduler().runTaskAsynchronously(plugin,
+                    () -> run.accept(null)).getTaskId();
         }
         //try {
-        //    Method getSchedulerMethod = ReflectionUtil.getMethodNoArgs(Server.class, "getAsyncScheduler", AsyncScheduler);
+        //    Method getSchedulerMethod =
+        //            ReflectionUtil.getMethodNoArgs(Server.class, "getAsyncScheduler", AsyncScheduler);
         //    Object asyncScheduler = getSchedulerMethod.invoke(Bukkit.getServer());
-
+        //
         //    Class<?> schedulerClass = asyncScheduler.getClass();
         //    Method executeMethod = schedulerClass.getMethod("runNow", Plugin.class, Consumer.class);
-
+        //
         //    Object taskInfo = executeMethod.invoke(asyncScheduler, plugin, run);
         //    return taskInfo;
         //}
         //catch (Exception e) {
             // Second attempt, should be happened during onDisable calling from BukkitLogNodeDispatcher
-            Thread thread = Executors.defaultThreadFactory().newThread(() -> run.accept(null));
-            if (thread == null) return null;
-            thread.start();
-            return thread;
+            try {
+                return Bukkit.getScheduler().runTaskAsynchronously(plugin,
+                        () -> run.accept(null));
+            } catch (Exception ex) {
+                LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+                logManager.warning(Streams.STATUS,
+                        "Failed to schedule async task: " + ex.getClass().getSimpleName());
+                logManager.warning(Streams.STATUS, ex);
+            }
+            return null;
         //}
     }
 


### PR DESCRIPTION
## Summary
- use the Bukkit scheduler when Folia async scheduling fails
- document that async tasks always run via scheduler
- remove unused imports

## Testing
- `mvn -q test`
- `mvn -q org.apache.maven.plugins:maven-checkstyle-plugin:3.3.0:check` *(fails: Could not transfer artifact)*
- `mvn -q org.apache.maven.plugins:maven-pmd-plugin:3.21.0:check` *(fails: Could not transfer artifact)*
- `mvn -q com.github.spotbugs:spotbugs-maven-plugin:4.9.3.0:check` *(fails: Missing classes)*

------
https://chatgpt.com/codex/tasks/task_b_685b6e6ae5a8832989e48ca55be0d463

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Replace the manual thread execution approach with standardized Bukkit/Folia scheduler for running asynchronous tasks.

### Why are these changes being made?
The update ensures consistent task scheduling practices between Folia and Bukkit by leveraging their respective built-in schedulers, which enhances reliability and error handling, as opposed to manually creating and managing threads which can lead to complexity and errors. This change simplifies the code and improves maintainability by using platform-supported methods.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->