### PR TITLE
Remove TODO comment in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         rather, but since it is used for some &quot;unknown mods&quot; as well, it is not compiled with the latest
         Bukkit version always.
 
-        TODO: Better place for descriptions like this?
     </description>
     <url>https://dev.bukkit.org/projects/nocheatplus</url>
 


### PR DESCRIPTION
## Summary
- remove leftover TODO comment from parent POM

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check` *(fails: EI_EXPOSE_REP, UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS, NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE, RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE)*

------
https://chatgpt.com/codex/tasks/task_b_685be4b55d84832986d8917b1c1e5cd9