### PR TITLE
Refactor vertical ascend check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -496,109 +496,27 @@ public class CreativeFly extends Check {
      * @param cc
      * @return limitV, resultV (not normalized).
      */
-    private double[] vDistAscend(final PlayerLocation from, final PlayerLocation to, final double yDistance, 
-                                 final boolean flying, final PlayerMoveData thisMove, final PlayerMoveData lastMove, 
+    private double[] vDistAscend(final PlayerLocation from, final PlayerLocation to, final double yDistance,
+                                 final boolean flying, final PlayerMoveData thisMove, final PlayerMoveData lastMove,
                                  final ModelFlying model, final MovingData data, final MovingConfig cc, final boolean debug) {
 
-        final boolean ripglide = Bridge1_13.isRiptiding(from.getPlayer()) && Bridge1_9.isGlidingWithElytra(from.getPlayer());
+        final Player player = from != null ? from.getPlayer() : null;
+        final boolean ripglide = player != null && Bridge1_13.isRiptiding(player) && Bridge1_9.isGlidingWithElytra(player);
         final long now = System.currentTimeMillis();
         // Set the vertical limit.
-        double limitV = model.getVerticalAscendModSpeed() / 100.0 * ModelFlying.VERTICAL_ASCEND_SPEED; 
+        double limitV = model.getVerticalAscendModSpeed() / 100.0 * ModelFlying.VERTICAL_ASCEND_SPEED;
         double resultV = 0.0;
-        
-        // Let fly speed apply with moving upwards.
-        if (model.getApplyModifiers() && flying && yDistance > 0.0) {
-            limitV *= data.flySpeed / Magic.DEFAULT_FLYSPEED;
-        }
-        else if (model.getScaleLevitationEffect() && Bridge1_9.hasLevitation()) {
-            // Exclude modifiers for now.
-            final double levitation = Bridge1_9.getLevitationAmplifier(from.getPlayer());
-            if (levitation >= 0.0) {
-                // (Double checked.)
-                limitV += 0.046 * levitation; // (It ends up like 0.5 added extra for some levels of levitation, roughly.)
-                final double minJumpGain = LiftOffEnvelope.NORMAL.getMinJumpGain(data.jumpAmplifier) + 0.01;
-                // Bug, duplicate motion
-                if (yDistance > 0.0 && yDistance < minJumpGain && thisMove.touchedGround) {
-                    limitV = minJumpGain;
-                    data.addVerticalVelocity(new SimpleEntry(yDistance, 2));
-                }
-                tags.add("levitation:" + levitation);
-            }
-        }
 
-        // Related to elytra.
-        if (model.getVerticalAscendGliding()) {
-            limitV = Math.max(limitV, limitV = hackLytra(yDistance, limitV, thisMove, lastMove, from, data));
-        }
+        limitV = applyFlyLevitationModifiers(from, flying, yDistance, thisMove, data, model, limitV);
+        limitV = applyElytraAscend(from, yDistance, thisMove, lastMove, model, data, limitV);
+        limitV = handleRipGlide(ripglide, yDistance, lastMove, limitV);
+        applyRiptideBounce(from, yDistance, thisMove, data, debug, limitV);
+        limitV = adjustForWaterGlide(from, data, limitV);
+        limitV = applyFrictionWithGravity(model, yDistance, lastMove, flying, limitV);
+        limitV = applyJumpLiftOffGain(model, yDistance, thisMove, lastMove, data, limitV);
+        limitV = applyStepUp(cc, yDistance, lastMove, from, thisMove, to, limitV);
 
-        // "Ripglide" (riptiding+gliding phase): allow some additional speed increase
-        // Note that the ExtremeMove subcheck is skipped during such phases.
-        if (lastMove.toIsValid && ripglide && yDistance > limitV) {
-            limitV += 5.9;
-            tags.add("vripglide");
-        }
-        
-        // Riptiding right onto a bouncy block (2nd time, higher bounce distance)
-        // Note that the ExtremeMove subcheck is skipped during such phases.
-        if (Bridge1_13.isRiptiding(from.getPlayer()) && (from.getBlockFlags() & BlockFlags.F_BOUNCE25) != 0
-            && yDistance > limitV && data.sfJumpPhase <= 2
-            && yDistance > 0.0 && yDistance < 7.5  // Cap the distance: observed maximum speed -> 5.536355205897621 (+5.993) / 5.0
-            && thisMove.from.onGround && !thisMove.to.onGround) {
-            data.addVerticalVelocity(new SimpleEntry(yDistance, 4));
-            if (debug) debug(from.getPlayer(), "Riptide bounce: add velocity");
-        }
-        
-        // Gliding in water
-        if (Bridge1_9.isGlidingWithElytra(from.getPlayer()) && data.liqtick > 1) {
-            limitV = Math.max(limitV, 0.35);
-        }
-        
-        // Friction with gravity.
-        if (model.getGravity()) {
-            if (yDistance > limitV && lastMove.toIsValid) { 
-                // (Disregard gravity.)
-                double frictionDist = lastMove.yDistance * Magic.FRICTION_MEDIUM_AIR;
-                if (!flying) {
-                    frictionDist -= 0.019;
-                }
-                if (frictionDist > limitV) {
-                    limitV = frictionDist;
-                    tags.add("vfrict_g");
-                }
-            }
-        }
-
-        if (model.getGround()) {
-            // Jump lift off gain.
-            // NOTE: This assumes SurvivalFly busies about moves with from.onGroundOrResetCond.
-            if (yDistance > limitV && !thisMove.to.onGroundOrResetCond && !thisMove.from.onGroundOrResetCond && (
-                // Last move touched ground.
-                lastMove.toIsValid && lastMove.touchedGround && 
-                (lastMove.yDistance <= 0.0 || lastMove.to.extraPropertiesValid && lastMove.to.onGround)
-                // This move touched ground by a workaround.
-                || thisMove.touchedGroundWorkaround
-                )) {
-                // Allow normal jumping.
-                final double maxGain = LiftOffEnvelope.NORMAL.getMaxJumpGain(data.jumpAmplifier);
-                if (maxGain > limitV) {
-                    limitV = maxGain;
-                    tags.add("jump_gain");
-                }
-            }
-        }
-
-        // Ordinary step up.
-        if (yDistance > limitV && yDistance <= cc.sfStepHeight 
-            && (lastMove.toIsValid && lastMove.yDistance < 0.0 || from.isOnGroundOrResetCond() || thisMove.touchedGroundWorkaround)
-            && to.isOnGround()) {
-            // (Jump effect not checked yet.)
-            limitV = cc.sfStepHeight;
-            tags.add("step_up");
-        }
-
-        // Determine violation amount.
         resultV = Math.max(0.0, yDistance - limitV);
-        // Post-violation recovery.
         return new double[] {limitV, resultV};
     }
 
@@ -1461,6 +1379,133 @@ public class CreativeFly extends Check {
             }
         }
         return resultH;
+    }
+
+    /**
+     * Apply fly speed and levitation related modifiers.
+     */
+    private double applyFlyLevitationModifiers(PlayerLocation from, boolean flying, double yDistance,
+            PlayerMoveData thisMove, MovingData data, ModelFlying model, double limitV) {
+        final Player player = from != null ? from.getPlayer() : null;
+        if (model.getApplyModifiers() && flying && yDistance > 0.0) {
+            limitV *= data.flySpeed / Magic.DEFAULT_FLYSPEED;
+        } else if (model.getScaleLevitationEffect() && Bridge1_9.hasLevitation()) {
+            final double levitation = player != null ? Bridge1_9.getLevitationAmplifier(player) : -1.0;
+            if (levitation >= 0.0) {
+                limitV += 0.046 * levitation;
+                final double minJumpGain = LiftOffEnvelope.NORMAL.getMinJumpGain(data.jumpAmplifier) + 0.01;
+                if (yDistance > 0.0 && yDistance < minJumpGain && thisMove.touchedGround) {
+                    limitV = minJumpGain;
+                    data.addVerticalVelocity(new SimpleEntry(yDistance, 2));
+                }
+                tags.add("levitation:" + levitation);
+            }
+        }
+        return limitV;
+    }
+
+    /**
+     * Apply elytra ascending adjustments.
+     */
+    private double applyElytraAscend(PlayerLocation from, double yDistance, PlayerMoveData thisMove,
+            PlayerMoveData lastMove, ModelFlying model, MovingData data, double limitV) {
+        if (model.getVerticalAscendGliding()) {
+            double newLimit = hackLytra(yDistance, limitV, thisMove, lastMove, from, data);
+            limitV = Math.max(limitV, newLimit);
+        }
+        return limitV;
+    }
+
+    /**
+     * Apply additional speed allowed while riptiding and gliding.
+     */
+    private double handleRipGlide(boolean ripglide, double yDistance, PlayerMoveData lastMove, double limitV) {
+        if (lastMove.toIsValid && ripglide && yDistance > limitV) {
+            limitV += 5.9;
+            tags.add("vripglide");
+        }
+        return limitV;
+    }
+
+    /**
+     * Handle riptide bounce while on bouncy blocks.
+     */
+    private void applyRiptideBounce(PlayerLocation from, double yDistance, PlayerMoveData thisMove,
+            MovingData data, boolean debug, double limitV) {
+        final Player player = from != null ? from.getPlayer() : null;
+        if (player != null && Bridge1_13.isRiptiding(player)
+                && (from.getBlockFlags() & BlockFlags.F_BOUNCE25) != 0
+                && yDistance > limitV && data.sfJumpPhase <= 2
+                && yDistance > 0.0 && yDistance < 7.5
+                && thisMove.from.onGround && !thisMove.to.onGround) {
+            data.addVerticalVelocity(new SimpleEntry(yDistance, 4));
+            if (debug) {
+                debug(player, "Riptide bounce: add velocity");
+            }
+        }
+    }
+
+    /**
+     * Adjust vertical limit for gliding in water.
+     */
+    private double adjustForWaterGlide(PlayerLocation from, MovingData data, double limitV) {
+        final Player player = from != null ? from.getPlayer() : null;
+        if (player != null && Bridge1_9.isGlidingWithElytra(player) && data.liqtick > 1) {
+            limitV = Math.max(limitV, 0.35);
+        }
+        return limitV;
+    }
+
+    /**
+     * Apply friction with gravity influence.
+     */
+    private double applyFrictionWithGravity(ModelFlying model, double yDistance, PlayerMoveData lastMove,
+            boolean flying, double limitV) {
+        if (model.getGravity() && yDistance > limitV && lastMove.toIsValid) {
+            double frictionDist = lastMove.yDistance * Magic.FRICTION_MEDIUM_AIR;
+            if (!flying) {
+                frictionDist -= 0.019;
+            }
+            if (frictionDist > limitV) {
+                limitV = frictionDist;
+                tags.add("vfrict_g");
+            }
+        }
+        return limitV;
+    }
+
+    /**
+     * Apply jump lift off gain when leaving ground.
+     */
+    private double applyJumpLiftOffGain(ModelFlying model, double yDistance, PlayerMoveData thisMove,
+            PlayerMoveData lastMove, MovingData data, double limitV) {
+        if (model.getGround() && yDistance > limitV && !thisMove.to.onGroundOrResetCond
+                && !thisMove.from.onGroundOrResetCond
+                && (lastMove.toIsValid && lastMove.touchedGround
+                        && (lastMove.yDistance <= 0.0 || lastMove.to.extraPropertiesValid && lastMove.to.onGround)
+                        || thisMove.touchedGroundWorkaround)) {
+            final double maxGain = LiftOffEnvelope.NORMAL.getMaxJumpGain(data.jumpAmplifier);
+            if (maxGain > limitV) {
+                limitV = maxGain;
+                tags.add("jump_gain");
+            }
+        }
+        return limitV;
+    }
+
+    /**
+     * Apply step up adjustments when climbing up small blocks.
+     */
+    private double applyStepUp(MovingConfig cc, double yDistance, PlayerMoveData lastMove, PlayerLocation from,
+            PlayerMoveData thisMove, PlayerLocation to, double limitV) {
+        if (yDistance > limitV && yDistance <= cc.sfStepHeight
+                && (lastMove.toIsValid && lastMove.yDistance < 0.0 || from.isOnGroundOrResetCond()
+                        || thisMove.touchedGroundWorkaround)
+                && to.isOnGround()) {
+            limitV = cc.sfStepHeight;
+            tags.add("step_up");
+        }
+        return limitV;
     }
 
 


### PR DESCRIPTION
## Summary
- simplify CreativeFly vertical ascend logic
- extract small helper methods for clarity

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: CT_CONSTRUCTOR_THROW, NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685bfa75c0a4832986ad2814432a3707