### PR TITLE
Fix null checks for potion effects

### DIFF
--- a/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/MCAccessCBDev.java
+++ b/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/MCAccessCBDev.java
@@ -203,24 +203,28 @@ public class MCAccessCBDev implements MCAccess {
 
     @Override
     public double getJumpAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(JUMP)) {
-            return mcPlayer.getEffect(JUMP).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(JUMP)) {
+            final net.minecraft.server.v1_12_R1.MobEffect effect = mcPlayer.getEffect(JUMP);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override
     public double getFasterMovementAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(FASTER_MOVEMENT)) {
-            return mcPlayer.getEffect(FASTER_MOVEMENT).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(FASTER_MOVEMENT)) {
+            final net.minecraft.server.v1_12_R1.MobEffect effect = mcPlayer.getEffect(FASTER_MOVEMENT);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
@@ -198,24 +198,28 @@ public class MCAccessSpigotCB1_10_R1 implements MCAccess {
 
     @Override
     public double getJumpAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(JUMP)) {
-            return mcPlayer.getEffect(JUMP).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(JUMP)) {
+            final net.minecraft.server.v1_10_R1.MobEffect effect = mcPlayer.getEffect(JUMP);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override
     public double getFasterMovementAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(FASTER_MOVEMENT)) {
-            return mcPlayer.getEffect(FASTER_MOVEMENT).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(FASTER_MOVEMENT)) {
+            final net.minecraft.server.v1_10_R1.MobEffect effect = mcPlayer.getEffect(FASTER_MOVEMENT);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
@@ -203,24 +203,28 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
 
     @Override
     public double getJumpAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(JUMP)) {
-            return mcPlayer.getEffect(JUMP).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(JUMP)) {
+            final net.minecraft.server.v1_11_R1.MobEffect effect = mcPlayer.getEffect(JUMP);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override
     public double getFasterMovementAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(FASTER_MOVEMENT)) {
-            return mcPlayer.getEffect(FASTER_MOVEMENT).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(FASTER_MOVEMENT)) {
+            final net.minecraft.server.v1_11_R1.MobEffect effect = mcPlayer.getEffect(FASTER_MOVEMENT);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
@@ -198,24 +198,28 @@ public class MCAccessSpigotCB1_9_R2 implements MCAccess {
 
     @Override
     public double getJumpAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(JUMP)) {
-            return mcPlayer.getEffect(JUMP).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(JUMP)) {
+            final net.minecraft.server.v1_9_R2.MobEffect effect = mcPlayer.getEffect(JUMP);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override
     public double getFasterMovementAmplifier(final Player player) {
-        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
-        if (mcPlayer.hasEffect(FASTER_MOVEMENT)) {
-            return mcPlayer.getEffect(FASTER_MOVEMENT).getAmplifier();
-        }
-        else {
+        if (player == null) {
             return Double.NEGATIVE_INFINITY;
         }
+        final EntityPlayer mcPlayer = ((CraftPlayer) player).getHandle();
+        if (mcPlayer != null && mcPlayer.hasEffect(FASTER_MOVEMENT)) {
+            final net.minecraft.server.v1_9_R2.MobEffect effect = mcPlayer.getEffect(FASTER_MOVEMENT);
+            return effect != null ? effect.getAmplifier() : Double.NEGATIVE_INFINITY;
+        }
+        return Double.NEGATIVE_INFINITY;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- validate player and effect before using potion effect data in compatibility modules
- update MCAccess implementations for newer Spigot versions

## Testing
- `mvn -q -P nonfree_build verify`

------
https://chatgpt.com/codex/tasks/task_b_685c036c01bc83298dc3528da19d56b6


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
