### PR TITLE
Fix redundant interface in CoordHashMap

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/CoordHashMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/CoordHashMap.java
@@ -29,7 +29,7 @@ import java.util.NoSuchElementException;
  *
  * @param <V>
  */
-public class CoordHashMap<V> extends AbstractCoordHashMap<V, fr.neatmonster.nocheatplus.utilities.ds.map.AbstractCoordHashMap.HashEntry<V>> implements CoordMap<V> {
+public class CoordHashMap<V> extends AbstractCoordHashMap<V, fr.neatmonster.nocheatplus.utilities.ds.map.AbstractCoordHashMap.HashEntry<V>> {
 
     // TODO: Move parts of abstract map here.
 


### PR DESCRIPTION
## Summary
- remove redundant `implements CoordMap` from `CoordHashMap`

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check`
- `mvn -q pmd:check`
- `mvn -q spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685c034fe2a88329946d031b493ca505