### PR TITLE
Add fillNode helper and integrate with cache

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitShapeModel;
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache.BlockCacheNode;
 import fr.neatmonster.nocheatplus.utilities.map.MaterialUtil;
 
 
@@ -48,11 +49,12 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
     public int fetchData(int x, int y, int z) {
         Material mat = getType(x, y, z);
 
-        final BukkitShapeModel shapeModel = shapeModels.get(mat);
+        BukkitShapeModel shapeModel = shapeModels.get(mat);
         if (shapeModel != null) {
-            final int data = shapeModel.getFakeData(this, world, x, y, z);
-            if (data != Integer.MAX_VALUE) {
-                return data;
+            BlockCacheNode node = (BlockCacheNode) getOrCreateBlockCacheNode(x, y, z, false);
+            shapeModel.fillNode(this, node, world, x, y, z);
+            if (node.isDataFetched()) {
+                return node.getData();
             }
         }
         return super.fetchData(x, y, z);
@@ -71,13 +73,17 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
         //final BlockData blockData = state.getBlockData();
         Material mat = getType(x, y, z);
 
-        final BukkitShapeModel shapeModel = shapeModels.get(mat);
+        BukkitShapeModel shapeModel = shapeModels.get(mat);
         if (shapeModel == null) {
             return super.fetchBounds(x, y, z);
         }
-        else {
-            return shapeModel.getShape(this, world, x, y, z);
+
+        BlockCacheNode node = (BlockCacheNode) getOrCreateBlockCacheNode(x, y, z, false);
+        shapeModel.fillNode(this, node, world, x, y, z);
+        if (node.isBoundsFetched()) {
+            return node.getBounds();
         }
+        return super.fetchBounds(x, y, z);
 
     }
     

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ShapeModel.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ShapeModel.java
@@ -33,4 +33,32 @@ public interface ShapeModel<W> {
      */
     public int getFakeData(BlockCache blockCache, W world, int x, int y, int z);
 
+    /**
+     * Fill the given cache node with shape and data if not already present.
+     *
+     * <p>This helps to avoid redundant lookups and casting operations.</p>
+     *
+     * @param blockCache the cache to use for fallback operations
+     * @param node the node to update
+     * @param world the world instance
+     * @param x block x
+     * @param y block y
+     * @param z block z
+     */
+    default void fillNode(BlockCache blockCache, BlockCache.BlockCacheNode node,
+                          W world, int x, int y, int z) {
+        if (node == null) {
+            return;
+        }
+        if (!node.isBoundsFetched()) {
+            node.setBounds(getShape(blockCache, world, x, y, z));
+        }
+        if (!node.isDataFetched()) {
+            int data = getFakeData(blockCache, world, x, y, z);
+            if (data != Integer.MAX_VALUE) {
+                node.setData(data);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `fillNode` default method in `ShapeModel`
- use `fillNode` in `BlockCacheBukkitModern`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c03850020832995dd971123573991

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `fillNode` helper method to the `ShapeModel` interface for populating cache nodes with shape and data, and integrate this helper method in `BlockCacheBukkitModern` to streamline data retrieval from cache.

### Why are these changes being made?

These changes enhance performance by reducing redundant lookups and casting operations when fetching data and bounds from the cache, thereby optimizing cache node utilization and improving overall efficiency within the `BlockCacheBukkitModern` class operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->