### PR TITLE
Replace blocking teleport future usage

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
@@ -282,7 +282,7 @@ public class Folia {
             Method teleportAsyncMethod = ReflectionUtil.getMethod(Entity.class, "teleportAsync", Location.class, TeleportCause.class);
             Object result = ReflectionUtil.invokeMethod(teleportAsyncMethod, entity, loc, cause);
             CompletableFuture<Boolean> res = (CompletableFuture<Boolean>) result;
-            return res.get();
+            return res.join();
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- prefer `join()` for Folia teleport to avoid checked exceptions

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: SpotBugs reports multiple issues)*

------
https://chatgpt.com/codex/tasks/task_b_685c04f698c48329aac44b0cab3dfd78