### PR TITLE
Track join timestamps per player in KeepAliveFrequency

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
@@ -37,7 +37,7 @@ public class KeepAliveFrequency extends Check implements Listener {
     /**
      * Join timestamps per player for delaying checks after login.
      */
-    private final Map<UUID, Long> joinTimestamps = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> joinTimes = new ConcurrentHashMap<>();
 
     /**
      * Checks hasBypass on violation only.
@@ -50,7 +50,7 @@ public class KeepAliveFrequency extends Check implements Listener {
     public boolean check(final Player player, final long time, final NetData data, final NetConfig cc, final IPlayerData pData) {
         data.keepAliveFreq.add(time, 1f);
         final float first = data.keepAliveFreq.bucketScore(0);
-        final long now = System.currentTimeMillis();
+        final long now = time;
 
         boolean cancel = false;
         if (!isJoinDelayActive(player, now, cc.keepAliveFrequencyStartupDelay) && first > 1f) {
@@ -59,13 +59,11 @@ public class KeepAliveFrequency extends Check implements Listener {
         }
         return cancel;
     }
-    // Event listener probably shouldn't be used here, but I don't think it will be
-    // needed to make another class just for this.
     @EventHandler
     public void playerJoin(PlayerJoinEvent e) {
         final Player player = e.getPlayer();
         if (player != null) {
-            joinTimestamps.put(player.getUniqueId(), System.currentTimeMillis());
+            joinTimes.put(player.getUniqueId(), System.currentTimeMillis());
         }
     }
 
@@ -73,7 +71,7 @@ public class KeepAliveFrequency extends Check implements Listener {
     public void playerQuit(PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         if (player != null) {
-            joinTimestamps.remove(player.getUniqueId());
+            joinTimes.remove(player.getUniqueId());
         }
     }
 
@@ -89,7 +87,7 @@ public class KeepAliveFrequency extends Check implements Listener {
         if (player == null) {
             return false;
         }
-        final Long joinTime = joinTimestamps.get(player.getUniqueId());
+        final Long joinTime = joinTimes.get(player.getUniqueId());
         return joinTime != null && now - joinTime < delay;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
@@ -26,9 +26,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
-import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
-import fr.neatmonster.nocheatplus.utilities.TickTask;
 
 public class KeepAliveFrequency extends Check implements Listener {
 
@@ -39,7 +37,7 @@ public class KeepAliveFrequency extends Check implements Listener {
     /**
      * Join timestamps per player for delaying checks after login.
      */
-    private final Map<UUID, Long> joinTimes = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> joinTimestamps = new ConcurrentHashMap<>();
 
     /**
      * Checks hasBypass on violation only.
@@ -55,7 +53,7 @@ public class KeepAliveFrequency extends Check implements Listener {
         final long now = System.currentTimeMillis();
 
         boolean cancel = false;
-        if (!isWithinJoinDelay(player, now, cc.keepAliveFrequencyStartupDelay) && first > 1f) {
+        if (!isJoinDelayActive(player, now, cc.keepAliveFrequencyStartupDelay) && first > 1f) {
             final double vl = Math.max(first - 1f, data.keepAliveFreq.score(1f) - data.keepAliveFreq.numberOfBuckets());
             cancel = executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel();
         }
@@ -67,7 +65,7 @@ public class KeepAliveFrequency extends Check implements Listener {
     public void playerJoin(PlayerJoinEvent e) {
         final Player player = e.getPlayer();
         if (player != null) {
-            joinTimes.put(player.getUniqueId(), System.currentTimeMillis());
+            joinTimestamps.put(player.getUniqueId(), System.currentTimeMillis());
         }
     }
 
@@ -75,15 +73,23 @@ public class KeepAliveFrequency extends Check implements Listener {
     public void playerQuit(PlayerQuitEvent e) {
         final Player player = e.getPlayer();
         if (player != null) {
-            joinTimes.remove(player.getUniqueId());
+            joinTimestamps.remove(player.getUniqueId());
         }
     }
 
-    private boolean isWithinJoinDelay(Player player, long now, long delay) {
+    /**
+     * Check if join delay is still active for the player.
+     *
+     * @param player The player to check for.
+     * @param now    The current system time in milliseconds.
+     * @param delay  The configured delay after join.
+     * @return True if join delay is active, false otherwise.
+     */
+    private boolean isJoinDelayActive(Player player, long now, long delay) {
         if (player == null) {
             return false;
         }
-        final Long joinTime = joinTimes.get(player.getUniqueId());
+        final Long joinTime = joinTimestamps.get(player.getUniqueId());
         return joinTime != null && now - joinTime < delay;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/KeepAliveFrequency.java
@@ -14,10 +14,15 @@
  */
 package fr.neatmonster.nocheatplus.checks.net;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -30,8 +35,11 @@ public class KeepAliveFrequency extends Check implements Listener {
     public KeepAliveFrequency() {
         super(CheckType.NET_KEEPALIVEFREQUENCY);
     }
-    
-    long timeJoin;
+
+    /**
+     * Join timestamps per player for delaying checks after login.
+     */
+    private final Map<UUID, Long> joinTimes = new ConcurrentHashMap<>();
 
     /**
      * Checks hasBypass on violation only.
@@ -44,23 +52,39 @@ public class KeepAliveFrequency extends Check implements Listener {
     public boolean check(final Player player, final long time, final NetData data, final NetConfig cc, final IPlayerData pData) {
         data.keepAliveFreq.add(time, 1f);
         final float first = data.keepAliveFreq.bucketScore(0);
-	final long now = System.currentTimeMillis();
-    	
-    	if (now - timeJoin < cc.keepAliveFrequencyStartupDelay) return false;
-        if (first > 1f) {
-            // Trigger a violation.
+        final long now = System.currentTimeMillis();
+
+        boolean cancel = false;
+        if (!isWithinJoinDelay(player, now, cc.keepAliveFrequencyStartupDelay) && first > 1f) {
             final double vl = Math.max(first - 1f, data.keepAliveFreq.score(1f) - data.keepAliveFreq.numberOfBuckets());
-            if (executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel()) {
-                return true;
-            }
+            cancel = executeActions(player, vl, 1.0, cc.keepAliveFrequencyActions).willCancel();
         }
-        return false;
+        return cancel;
     }
     // Event listener probably shouldn't be used here, but I don't think it will be
     // needed to make another class just for this.
     @EventHandler
     public void playerJoin(PlayerJoinEvent e) {
-    timeJoin = System.currentTimeMillis();
+        final Player player = e.getPlayer();
+        if (player != null) {
+            joinTimes.put(player.getUniqueId(), System.currentTimeMillis());
+        }
+    }
+
+    @EventHandler
+    public void playerQuit(PlayerQuitEvent e) {
+        final Player player = e.getPlayer();
+        if (player != null) {
+            joinTimes.remove(player.getUniqueId());
+        }
+    }
+
+    private boolean isWithinJoinDelay(Player player, long now, long delay) {
+        if (player == null) {
+            return false;
+        }
+        final Long joinTime = joinTimes.get(player.getUniqueId());
+        return joinTime != null && now - joinTime < delay;
     }
 
 }


### PR DESCRIPTION
## Summary
- maintain join timestamp per player instead of a single global value
- check join delay using `isWithinJoinDelay` helper
- clear join timestamps when a player quits

## Testing
- `mvn test`
- `mvn checkstyle:check pmd:check spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685c04f615048329bf0dfd1ba42f3545