### PR TITLE
Remove outdated TODO comments

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/DefaultContentStream.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/DefaultContentStream.java
@@ -43,10 +43,8 @@ public class DefaultContentStream<C> implements ContentStream<C> {
 
     @Override
     public void addNode(LogNode<C> node) {
-        // TODO: Consider throwing things at callers, in case of duplicate logger entries?
         synchronized (nodes) {
             if (this.nodes.contains(node)) {
-                // TODO: Consider throwing something.
                 return;
             }
             ArrayList<LogNode<C>> nodes = new ArrayList<LogNode<C>>(this.nodes);

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/LogNodeDispatcher.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/LogNodeDispatcher.java
@@ -21,7 +21,7 @@ import java.util.logging.Level;
  * @author dev1mc
  *
  */
-public interface LogNodeDispatcher { // TODO: Name.
+public interface LogNodeDispatcher {
     
     <C> void dispatch(LogNode<C> node, Level level, C content);
 

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/prefixtree/CharPrefixTree.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/prefixtree/CharPrefixTree.java
@@ -132,7 +132,6 @@ public class CharPrefixTree<N extends CharNode<N>, L extends CharLookupEntry<N>>
      * @return
      */
     public boolean hasPrefixWords(final String input) {
-        // TODO build this in in a more general way (super classes + stop symbol)!
         final L result = lookup(input, false);
         if (!result.hasPrefix) return false;
         if (input.length() == result.depth) return true;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetConfig.java
@@ -45,7 +45,6 @@ public class NetConfig extends ACheckConfig {
     };
 
     public static RegisteredPermission[] getPreferKeepUpdatedPermissions() {
-        // TODO: Individual checks might want to register these, or just on permission checking.
         return preferKeepUpdatedPermissions;
     }
 
@@ -86,7 +85,6 @@ public class NetConfig extends ACheckConfig {
     public final boolean supersededFlyingCancelWaiting;
 
     public NetConfig(final IWorldData worldData) {
-        // TODO: These permissions should have default policies.
         super(worldData);
         final ConfigFile config = worldData.getRawConfiguration();
 
@@ -112,7 +110,6 @@ public class NetConfig extends ACheckConfig {
         keepAliveFrequencyStartupDelay = config.getInt(ConfPaths.NET_KEEPALIVEFREQUENCY_SECONDS) * 1000;
 
         if (ServerVersion.compareMinecraftVersion("1.9") >= 0) {
-            // TODO: Disable packet frequency or activate 'pessimistically'.
             /** Note: Disable check should use
              *    NCPAPIProvider#getNoCheatPlusAPI()#getWorldDataManager()#overrideCheckActivation()
              *  to actually disable from all worlds. 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -77,14 +77,13 @@ public class NetData extends ACheckData {
      * Detect teleport-ACK packets, consistency check to only use outgoing
      * position if there has been a PlayerTeleportEvent for it.
      */
-    public final TeleportQueue teleportQueue = new TeleportQueue(); // TODO: Consider using one lock per data instance and pass here.
+    public final TeleportQueue teleportQueue = new TeleportQueue();
 
     /**
      * Store past flying packet locations for reference (lock for
      * synchronization). Mainly meant for access to flying packets from the
      * primary thread. Latest packet is first.
      */
-    // TODO: Might extend to synchronize with moving events.
     private final LinkedList<DataPacketFlying> flyingQueue = new LinkedList<DataPacketFlying>();
     /** Maximum amount of packets to store. */
     private final int flyingQueueMaxSize = 15;
@@ -155,9 +154,8 @@ public class NetData extends ACheckData {
     public DataPacketFlying[] copyFlyingQueue() {
         lock.lock();
         /*
-         * TODO: Add a method to synchronize with the current position at the
-         * same time ? Packet inversion is acute on 1.11.2 (dig is processed
-         * before flying).
+         * Packet inversion is acute on 1.11.2 (dig is processed
+         * before flying). Synchronizing with the current position might be added.
          */
         final DataPacketFlying[] out = flyingQueue.toArray(new DataPacketFlying[flyingQueue.size()]);
         lock.unlock();
@@ -193,7 +191,7 @@ public class NetData extends ACheckData {
      */
     public void handleSystemTimeRanBackwards() {
         final long now = System.currentTimeMillis();
-        teleportQueue.clear(); // Can't handle timeouts. TODO: Might still keep.
+        teleportQueue.clear(); // Can't handle timeouts.
         lastKeepAliveTime = Math.min(lastKeepAliveTime, now);
         flyingFrequencyTimeNotOnGround = Math.min(flyingFrequencyTimeNotOnGround, now);
         flyingFrequencyTimeOnGround = Math.min(flyingFrequencyTimeOnGround, now);


### PR DESCRIPTION
## Summary
- remove leftover TODO comments in prefix tree, logging, and network checks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c0a344d308329ac4b3033c11b034f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove outdated TODO comments from the codebase.

### Why are these changes being made?

The TODO comments were identified as outdated or no longer relevant to the current state and future direction of the project. Removing them helps maintain clean and understandable code, reducing confusion and improving maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->