### PR TITLE
Fix javadoc wording

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/Action.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/Action.java
@@ -85,11 +85,13 @@ public abstract class Action <D extends ActionData, L extends AbstractActionList
     }
 
     /**
-     * Get an optimized copy, given the config in use. The default implementation returns this instance.<br>
-     * TODO: "Copy" does not match this.
+     * Get an optimized instance for the provided configuration. The default
+     * implementation returns this instance if no optimization is required.
+     *
      * @param config
      * @param threshold
-     * @return Can return this (unchanged), null (not to be executed ever) or a new instance (changed, optimized).
+     * @return this instance if unchanged, {@code null} if not to be executed, or
+     *         a new instance containing optimized settings.
      */
     public Action<D, L> getOptimizedCopy(final ConfigFileWithActions<D, L> config, final Integer threshold) {
         return this;


### PR DESCRIPTION
## Summary
- clarify JavaDoc for Action#getOptimizedCopy

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_b_685c19a51200832992ac2a016d248baa

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the Javadoc wording for the `getOptimizedCopy` method in the `Action` class to better describe its functionality and parameters.

### Why are these changes being made?

The original Javadoc contained wording that implied incorrect behavior and did not clearly explain the method's purpose and return conditions. By rephrasing the Javadoc, we align the documentation with the actual implementation and intent of the method, enhancing code clarity and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified the documentation for the method that returns an optimized instance in the Action class. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->