### PR TITLE
Remove outdated TODO comments

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/MoreInventory.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/MoreInventory.java
@@ -49,7 +49,6 @@ public class MoreInventory extends Check{
     public boolean check(final Player player, final MovingData mData, final IPlayerData pData, final InventoryType type, 
     	                 final Inventory inv, final boolean PoYdiff) {
         
-        // TODO: bring in the moving subcheck in invMove.
         if (type == InventoryType.CRAFTING 
             && (player.isSprinting() || PoYdiff || player.isBlocking() || player.isSneaking() || mData.isUsingItem)) {
             return true;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/MoveData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/MoveData.java
@@ -183,7 +183,6 @@ public class MoveData {
     public void set(final IGetLocationWithLook from, final IGetLocationWithLook to) {
         setPositions(from, to);
         resetBase();
-        // TODO: this.from/this.to setExtraProperties ?
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/FlyingFrequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/FlyingFrequency.java
@@ -29,7 +29,7 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
  */
 public class FlyingFrequency extends Check {
 
-    // Thresholds for firing moving events (CraftBukkit). TODO: Move to some model thing in NCPCore, possibly a ServerConfig?
+    // Thresholds for firing moving events (CraftBukkit).
     public static final double minMoveDistSq = 1f / 256; // PlayerConnection magic.
     public static final float minLookChange = 10f;
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/FlyingQueueHandle.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/FlyingQueueHandle.java
@@ -39,7 +39,7 @@ public class FlyingQueueHandle implements IHandle<DataPacketFlying[]> {
     private boolean currentLocationValid = true;
 
     public FlyingQueueHandle(IPlayerData pData) {
-        // TODO: PlayerData ?
+        // Reference to the associated player data.
         this.pData = pData;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_6_1.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_6_1.java
@@ -42,7 +42,7 @@ public class BlocksMC1_6_1 implements BlockPropertiesSetup{
 
         // Hay Bale
         BlockProperties.setBlockProps("HAY_BLOCK", BlockProperties.leverType);
-        BlockFlags.setFlagsAs("HAY_BLOCK", Material.STONE); // TODO: Assumption (!).
+        BlockFlags.setFlagsAs("HAY_BLOCK", Material.STONE); // Assumption: treated as stone.
 
         ConfigFile config = ConfigManager.getConfigFile();
         if (config.getBoolean(ConfPaths.BLOCKBREAK_DEBUG, config.getBoolean(ConfPaths.CHECKS_DEBUG, false)))

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/IRichTypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/IRichTypeSetRegistry.java
@@ -26,7 +26,6 @@ import fr.neatmonster.nocheatplus.checks.CheckType;
  *
  */
 public interface IRichTypeSetRegistry {
-    // TODO: package name?
 
     /**
      * Get all data types extending 'registeredFor', that have been explicitly
@@ -49,8 +48,6 @@ public interface IRichTypeSetRegistry {
      */
     public <T> Collection<Class<? extends T>> getGroupedTypes(
             Class<T> groupType, CheckType checkType);
-
-    // TODO: getFactoryTypes -> registered factory return types ?
 
     /**
      * Register types for a group type.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/IPlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/IPlayerDataManager.java
@@ -59,7 +59,6 @@ import fr.neatmonster.nocheatplus.components.registry.feature.IRemoveData;
  */
 public interface IPlayerDataManager extends ComponentRegistry<IRemoveData>, IRichFactoryRegistry<PlayerFactoryArgument> {
 
-    // TODO: Complete (...)
 
     /**
      * Fetch a PlayerData instance. If none is present and create is set, a new

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/ICollidePassable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/ICollidePassable.java
@@ -29,7 +29,6 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
  *
  */
 public interface ICollidePassable extends ICollideBlocks, ISetMargins {
-    // TODO: Add a super interface (+ asbtract impl.) for BlockCache based stuff including BlockChangeTracker.
 
     public void setBlockCache(BlockCache blockCache);
     public BlockCache getBlockCache();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/IWorldData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/IWorldData.java
@@ -86,6 +86,5 @@ public interface IWorldData extends IConfigDataAccess, IGetGenericInstance {
             Collection<Class<? extends IDataOnRemoveSubCheckData>> subCheckRemoval,
             Collection<CheckType> checkTypes);
 
-    // TODO: isDebugActive(CheckType checkType);
 
 }


### PR DESCRIPTION
## Summary
- delete leftover TODO comments in interfaces and checks
- clarify a comment in `FlyingQueueHandle`
- note assumption about hay blocks in `BlocksMC1_6_1`

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_685c1b8fc7488329856cde76f6a185ce


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
