### PR TITLE
Remove leftover TODO comments

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionList.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/ActionList.java
@@ -21,8 +21,6 @@ import fr.neatmonster.nocheatplus.permissions.RegisteredPermission;
  * A list of actions, that associates actions to thresholds. It allows to
  * retrieve all actions that match a certain threshold.
  * <hr>
- * TODO: refactor to an array of Actions entries (threshold + Action[]) + sort
- * that one.
  */
 public class ActionList extends AbstractActionList<ViolationData, ActionList>{
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/PenaltyAction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/PenaltyAction.java
@@ -46,7 +46,6 @@ public class PenaltyAction<D extends ActionData, L extends AbstractActionList<D,
     private final PenaltyNode rootNode;
     private final String penaltyId;
 
-    // TODO: executesAlways +- making sense.
 
     /**
      * 
@@ -55,7 +54,6 @@ public class PenaltyAction<D extends ActionData, L extends AbstractActionList<D,
      * @param rootNode
      */
     public PenaltyAction(String penaltyId, PenaltyNode rootNode) {
-        // TODO: name vs toString (!).
         super("penalty", 0, 0);
         this.rootNode = rootNode;
         this.penaltyId = penaltyId;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/PlayerMoveData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/model/PlayerMoveData.java
@@ -71,7 +71,6 @@ public class PlayerMoveData extends MoveData {
     /** This move was allowed to jump. Set in SurvivalFly.check(vdistrel) */
     public boolean allowjump;
 
-    // TODO: verVel/horvel used?
 
     // Meta stuff.
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/AccountEntry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/AccountEntry.java
@@ -42,7 +42,6 @@ public class AccountEntry {
     // Activation conditions.
     ///////////////////////////
 
-    // TODO: Add more conditions (max tick, real time?)
 
     /**
      * Maximum count before activation.
@@ -53,7 +52,6 @@ public class AccountEntry {
     // Invalidation conditions.
     ///////////////////////////
 
-    // TODO: Add more conditions (max tick, real time?)
 
     /**
      * Count .

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/SimpleEntry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/velocity/SimpleEntry.java
@@ -41,7 +41,6 @@ public class SimpleEntry {
     /** Count down for invalidation. */
     public int actCount;
 
-    // TODO: Add more conditions (max tick, real time ?)
 
     public SimpleEntry(double value, int actCount) {
         this(TickTask.getTick(), value, actCount);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/Order.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/Order.java
@@ -18,7 +18,6 @@ import java.util.Comparator;
 
 /**
  * Utilities for sorting out order. <br>
- * TODO: DEPRECATE and later remove.
  * 
  * @author asofold
  *

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/Streams.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/Streams.java
@@ -55,7 +55,6 @@ public class Streams {
      */
     public static final StreamID STATUS = new StreamID(defaultPrefix + "status");
     
-    // TODO: Consider TRACE.
     
     // Raw default streams ---
     

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionInfo.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionInfo.java
@@ -24,7 +24,6 @@ package fr.neatmonster.nocheatplus.permissions;
  */
 public class PermissionInfo extends PermissionPolicy {
 
-    // TODO: Consider IPermissionPolicy with read only access.
 
     private final RegisteredPermission registeredPermission;
 

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsConfig.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsConfig.java
@@ -36,8 +36,6 @@ public class AllViolationsConfig {
     /** Only log if the player is being "debugged". Currently incomplete. */
     public final boolean debugOnly;
 
-    // TODO: More config on what to print (uuid, etc., default tags). 
-    // TODO: More filtering like in TestNCP.
 
     public AllViolationsConfig(ConfigFile config) {
         allToTrace = config.getBoolean(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE);


### PR DESCRIPTION
## Summary
- remove stray TODO comments in various core classes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685c1bc1f3f88329b6ab67cea9383651

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove all leftover TODO comments from the codebase in various Java classes across multiple packages.

### Why are these changes being made?

These TODO comments were outdated and not planned for implementation, leading to potential confusion during code maintenance. Cleaning up these comments increases code clarity and ensures the codebase reflects current development priorities. This approach helps maintain a clean and understandable code environment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->