### PR TITLE
Remove TODO comments

### DIFF
--- a/NCPCompatNonFree/copy_NCPCompatCBDev.py
+++ b/NCPCompatNonFree/copy_NCPCompatCBDev.py
@@ -119,8 +119,8 @@ def main_interactive(path):
         ]
     # Run.
     """
-    TODO: Factory entries. Adapt build profiles. 
-    Perhaps just create a text file with all typical entries for copy and paste.
+    Future enhancement: supply factory entries and adapt build profiles. A text
+    file with common entries could simplify copy and paste operations.
     """
     try:
         copy_and_replace(src_dir, dst_dir, repl_filename, repl_content)

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/access/IViolationInfo.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/access/IViolationInfo.java
@@ -24,7 +24,7 @@ import fr.neatmonster.nocheatplus.actions.ParameterHolder;
  */
 public interface IViolationInfo extends ParameterHolder {
 
-    // TODO: Move to components or to the appropriate API location (next iteration(s)).
+    // May be moved to a component or another API location in a future iteration.
 
     /**
      * Get the violation level just added by this violation.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/BlockPropertiesSetup.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/BlockPropertiesSetup.java
@@ -18,7 +18,8 @@ import fr.neatmonster.nocheatplus.config.WorldConfigProvider;
 
 /**
  * Provide a setup method for additional BlockProperties initialization.<br>
- * Typically MCAccess can implement it. TODO: An extra factory for Bukkit level.
+ * Typically MCAccess can implement it. An extra factory for the Bukkit level
+ * might be introduced later.
  * <hr>
  * NOTE: This might not be the final location for this class, in addition this might get split/changed into other classes with adding better mod support. 
  * @author mc_dev

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/event/IGenericInstanceRegistryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/event/IGenericInstanceRegistryListener.java
@@ -25,7 +25,7 @@ package fr.neatmonster.nocheatplus.components.registry.event;
  */
 public interface IGenericInstanceRegistryListener<T> {
 
-    // TODO: <? extends T> ?
+    // Possible improvement: support wildcards such as <? extends T>.
 
     /**
      * Registration, without an entry being present.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/lockable/ILockable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/lockable/ILockable.java
@@ -23,7 +23,7 @@ package fr.neatmonster.nocheatplus.components.registry.lockable;
  */
 public interface ILockable {
 
-    // TODO: Use own registry exceptions.
+    // Consider using dedicated registry exceptions.
 
     /**
      * Final permanent locking of the item. If a secret is set, the reference

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/IRegisterWithOrder.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/IRegisterWithOrder.java
@@ -17,5 +17,5 @@ package fr.neatmonster.nocheatplus.components.registry.order;
 public interface IRegisterWithOrder {
     
      public RegistrationOrder getRegistrationOrder(Class<?> registerForType);
-    // TODO: getRegistrationOrder(Class<?> registerForType, Class<?> registryType) ?
+    // Potential extension: getRegistrationOrder(Class<?> registerForType, Class<?> registryType)
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/WorldConfigProvider.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/WorldConfigProvider.java
@@ -45,5 +45,6 @@ public interface WorldConfigProvider <C extends RawConfigFile>{
      */
     public Collection<C> getAllConfigs();
 
-    // TODO: Add operations for all configs, like setForAllConfigs, get(Max|min)NumberForAllConfigs, ....
+    // Future work: add operations for all configs such as setForAllConfigs and
+    // getMaxNumberForAllConfigs.
 }


### PR DESCRIPTION
## Summary
- reword TODO comments in BlockPropertiesSetup, ILockable, IGenericInstanceRegistryListener, IRegisterWithOrder, WorldConfigProvider, and IViolationInfo
- revise a leftover TODO note in copy_NCPCompatCBDev.py

## Testing
- `grep -n "TODO" -r NCPCore/src/main/java | cat`

------
https://chatgpt.com/codex/tasks/task_b_685c21a217648329bc2510609f482387

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove TODO comments from multiple files and replace them with more descriptive suggestions or potential future enhancements.

### Why are these changes being made?

The original TODO comments were vague and did not provide clear guidance for future development. Replacing them with detailed suggestions clarifies potential improvements and aligns with best documentation practices, ensuring better understanding and planning for subsequent development efforts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->