### PR TITLE
Fix TrigUtil.manhattan recursion

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
@@ -483,8 +483,8 @@ public class TrigUtil {
      *            the z2
      * @return the double
      */
-    public static double manhattan(final double x1,final double  z1, final double x2, final double z2){
-        return manhattan(Location.locToBlock(x1), Location.locToBlock(z1), Location.locToBlock(x2), Location.locToBlock(z2));
+    public static double manhattan(final double x1, final double z1, final double x2, final double z2) {
+        return Math.abs(x1 - x2) + Math.abs(z1 - z2);
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix infinite recursion in `TrigUtil.manhattan(double,double,double,double)`

## Testing
- `mvn -q -pl NCPCore -am verify`

------
https://chatgpt.com/codex/tasks/task_b_685c343fda188329bef6cc39f8a49cf6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the `TrigUtil.manhattan` function to correctly compute the Manhattan distance between two points using absolute differences rather than recursive calls.

### Why are these changes being made?

The previous implementation mistakenly relied on a recursive approach by converting coordinates to blocks before calculation, which was unnecessary and potentially leading to stack overflow errors. The updated method directly computes the Manhattan distance, simplifying the code and enhancing performance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->