### PR TITLE
Fix shape model array exposure

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCauldron.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCauldron.java
@@ -35,7 +35,7 @@ public class BukkitCauldron implements BukkitShapeModel {
 
     @Override
     public double[] getShape(BlockCache blockCache, World world, int x, int y, int z) {
-        return bounds;
+        return bounds.clone();
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -54,9 +54,9 @@ public class BukkitStatic implements BukkitShapeModel {
     }
 
     @Override
-    public double[] getShape(final BlockCache blockCache, 
+    public double[] getShape(final BlockCache blockCache,
             final World world, final int x, final int y, final int z) {
-        return bounds;
+        return bounds.clone();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return cloned bounds for Bukkit cauldron shape
- return cloned bounds for Bukkit static shape

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34f94f7883298285d4c8b3619ad3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify methods to return a clone of the bounds array instead of the array itself in `BukkitCauldron.java` and `BukkitStatic.java`.

### Why are these changes being made?

To prevent unintended modifications to the original bounds array by external code, which could lead to data integrity issues. This approach ensures encapsulation by providing a defensive copy, eliminating potential side effects of external alterations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->