### PR TITLE
Fix bamboo shape noise

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitBamboo.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitBamboo.java
@@ -24,7 +24,7 @@ public class BukkitBamboo implements BukkitShapeModel {
             final World world, final int x, final int y, final int z) {
         
         // Taken from NMS - Offset/Noise
-        long i = (x * 3129871L) ^ z * 116129781L ^ 0;
+        long i = (x * 3129871L) ^ z * 116129781L;
         i = i * i * 42317861L + i * 11L;
         i = i >> 16;
         final double xOffset = (((i & 15L) / 15.0F) - 0.5D) * 0.5D;


### PR DESCRIPTION
## Summary
- clean up bamboo shape noise calculation by removing an unused `^ 0`
- run unit tests and static analysis

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34f6b41c8329be27f784358783d4