### PR TITLE
Update BlockCacheCBReflect constructor

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/BlockCacheCBReflect.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/BlockCacheCBReflect.java
@@ -32,8 +32,9 @@ public class BlockCacheCBReflect extends BlockCacheBukkit {
     protected Object nmsWorld = null;
 
     public BlockCacheCBReflect(ReflectHelper reflectHelper, World world) {
-        super(world);
+        super(null);      // Avoid premature setAccess
         this.helper = reflectHelper;
+        setAccess(world);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid premature access in `BlockCacheCBReflect` constructor by calling `setAccess` after construction
- keep helper as `final`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34fb8618832982a6339b67087fb8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `BlockCacheCBReflect` constructor to invoke the superclass constructor with `null` and call `setAccess(world)` after setting the helper.

### Why are these changes being made?

This change prevents premature access setup in the superclass constructor by passing `null` and defers the `setAccess` invocation, which is necessary due to the order of operations required for proper initialization with the provided `ReflectHelper` and `World` instances.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->