### PR TITLE
Fix Cocoa bounding box check

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCocoa.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCocoa.java
@@ -39,8 +39,8 @@ public class BukkitCocoa implements BukkitShapeModel {
         final BlockState state = block.getState();
         final BlockData blockData = state.getBlockData();
 
-        if (blockData instanceof Cocoa && blockData instanceof Directional) {
-        	BlockFace face = ((Directional) blockData).getFacing();
+        if (blockData instanceof Cocoa) {
+                BlockFace face = ((Directional) blockData).getFacing();
             final Cocoa cocoa = (Cocoa) blockData;
             switch (cocoa.getAge()) {
                 case 0: // .625 .4375 .0625 max: .375 .75 .3125


### PR DESCRIPTION
## Summary
- remove redundant Directional check for Cocoa block data

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34fa10b0832986c1a2f89985dbd7