### PR TITLE
Add null check for bounds and remove NPE catch

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
@@ -204,6 +204,9 @@ public class MCAccessCBReflect extends MCAccessBukkit {
         }
         try {
             final double[] bounds = helper.getBoundsTemp(player);
+            if (bounds == null) {
+                return AlmostBoolean.MAYBE;
+            }
             if (LocUtil.isBadCoordinate(bounds)) {
                 return AlmostBoolean.YES;
             }
@@ -219,9 +222,6 @@ public class MCAccessCBReflect extends MCAccessBukkit {
             }
         }
         catch (ReflectFailureException e) {
-            // Ignore.
-        }
-        catch (NullPointerException ne) {
             // Ignore.
         }
         return AlmostBoolean.MAYBE;


### PR DESCRIPTION
## Summary
- guard against helper.getBoundsTemp returning null
- remove unused catch block

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34fbbfe08329b61890e30c4dee48

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a null check for `bounds` and remove the catch block for `NullPointerException` in the `isIllegalBounds` method.

### Why are these changes being made?

The change ensures that the method `isIllegalBounds` gracefully handles potential null values by checking for nullability immediately, thus preventing a `NullPointerException` and eliminating the need for a catch block for it, leading to cleaner and more robust code. This approach improves code readability, reduces error handling overhead and adheres to best practices in null safety.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->