### PR TITLE
Fix ReflectHelper null handling

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectHelper.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectHelper.java
@@ -102,12 +102,14 @@ public class ReflectHelper {
             this.reflectMaterial = new ReflectMaterial(this.reflectBase);
             this.reflectWorld = new ReflectWorld(reflectBase, reflectMaterial, reflectBlockPosition);
             ReflectBlock reflectBlockLatest = null;
-            try {
-                reflectBlockLatest = new ReflectBlock(this.reflectBase, this.reflectBlockPosition,
-                        reflectMaterial, reflectWorld);
-            }
-            catch (Throwable t) {
-                // ignore - using ReflectBlockSix fallback
+            if (this.reflectBlockPosition != null) {
+                try {
+                    reflectBlockLatest = new ReflectBlock(this.reflectBase, this.reflectBlockPosition,
+                            reflectMaterial, reflectWorld);
+                }
+                catch (Throwable t) {
+                    // ignore - using ReflectBlockSix fallback
+                }
             }
             if (reflectBlockLatest == null) {
                 // More lenient constructor.


### PR DESCRIPTION
## Summary
- guard against missing `BlockPosition` when creating `ReflectBlock`
- run `mvn verify` to ensure tests and static analysis pass

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34e5ca748329a3fcc2d3fd920724

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add null check for `reflectBlockPosition` before attempting reflection in `ReflectHelper` constructor for better null handling.

### Why are these changes being made?

The change is made to ensure that `reflectBlockPosition` is not null before it's used to avoid unnecessary exceptions, thus improving the stability of the code by avoiding reflection with a null parameter. This change is a preemptive measure to prevent errors by using a more cautious approach.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->