### PR TITLE
Fix sprint attribute null handling

### DIFF
--- a/NCPCompatBukkit/pom.xml
+++ b/NCPCompatBukkit/pom.xml
@@ -28,6 +28,18 @@
             <version>1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
@@ -71,6 +71,9 @@ public class BukkitAttributeAccess implements IAttributeAccess {
     @Override
     public double getSpeedAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        if (attrInst == null) {
+            return Double.MAX_VALUE;
+        }
         final double val = attrInst.getValue() / attrInst.getBaseValue();
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.ID_SPRINT_BOOST);
         return mod == null ? val : (val / getMultiplier(mod));
@@ -79,6 +82,9 @@ public class BukkitAttributeAccess implements IAttributeAccess {
     @Override
     public double getSprintAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        if (attrInst == null) {
+            return Double.MAX_VALUE;
+        }
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.ID_SPRINT_BOOST);
         return mod == null ? 1.0 : getMultiplier(mod);
     }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
@@ -70,6 +70,9 @@ public class NSBukkitAttributeAccess implements IAttributeAccess {
     @Override
     public double getSpeedAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        if (attrInst == null) {
+            return Double.MAX_VALUE;
+        }
         final double val = attrInst.getValue() / attrInst.getBaseValue();
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.NSID_SPRINT_BOOST);
         return mod == null ? val : (val / getMultiplier(mod));
@@ -78,6 +81,9 @@ public class NSBukkitAttributeAccess implements IAttributeAccess {
     @Override
     public double getSprintAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+        if (attrInst == null) {
+            return Double.MAX_VALUE;
+        }
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.NSID_SPRINT_BOOST);
         return mod == null ? 1.0 : getMultiplier(mod);
     }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
@@ -1,0 +1,45 @@
+package fr.neatmonster.nocheatplus.compat.bukkit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+
+public class TestBukkitAttributeAccess {
+
+    @Test
+    public void testGetSpeedAttributeMultiplierNull() {
+        Player player = mock(Player.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
+        BukkitAttributeAccess access = new BukkitAttributeAccess();
+        assertEquals(Double.MAX_VALUE, access.getSpeedAttributeMultiplier(player), 0.0);
+    }
+
+    @Test
+    public void testGetSprintAttributeMultiplierNull() {
+        Player player = mock(Player.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
+        BukkitAttributeAccess access = new BukkitAttributeAccess();
+        assertEquals(Double.MAX_VALUE, access.getSprintAttributeMultiplier(player), 0.0);
+    }
+
+    @Test
+    public void testNormalSpeed() {
+        Player player = mock(Player.class);
+        AttributeInstance inst = mock(AttributeInstance.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(inst);
+        when(inst.getValue()).thenReturn(0.1);
+        when(inst.getBaseValue()).thenReturn(0.1);
+        when(inst.getModifiers()).thenReturn(Collections.emptySet());
+        BukkitAttributeAccess access = new BukkitAttributeAccess();
+        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+    }
+}

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
@@ -1,0 +1,44 @@
+package fr.neatmonster.nocheatplus.compat.bukkit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+
+public class TestNSBukkitAttributeAccess {
+
+    @Test
+    public void testGetSpeedAttributeMultiplierNull() {
+        Player player = mock(Player.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
+        NSBukkitAttributeAccess access = new NSBukkitAttributeAccess();
+        assertEquals(Double.MAX_VALUE, access.getSpeedAttributeMultiplier(player), 0.0);
+    }
+
+    @Test
+    public void testGetSprintAttributeMultiplierNull() {
+        Player player = mock(Player.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
+        NSBukkitAttributeAccess access = new NSBukkitAttributeAccess();
+        assertEquals(Double.MAX_VALUE, access.getSprintAttributeMultiplier(player), 0.0);
+    }
+
+    @Test
+    public void testNormalSpeed() {
+        Player player = mock(Player.class);
+        AttributeInstance inst = mock(AttributeInstance.class);
+        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(inst);
+        when(inst.getValue()).thenReturn(0.1);
+        when(inst.getBaseValue()).thenReturn(0.1);
+        when(inst.getModifiers()).thenReturn(Collections.emptySet());
+        NSBukkitAttributeAccess access = new NSBukkitAttributeAccess();
+        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null attributes when getting sprint/speed multipliers
- add unit tests for BukkitAttributeAccess implementations
- include JUnit and Mockito in NCPCompatBukkit

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34f6168c83298922c2b30b199d61

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Ensure null handling for player attribute retrieval by returning `Double.MAX_VALUE` when any attribute instance is null, and add unit tests for `BukkitAttributeAccess` and `NSBukkitAttributeAccess`.

### Why are these changes being made?

This change addresses potential `NullPointerException` issues when accessing attributes that could be uninitialized or missing, ensuring robust application behavior. Adding unit tests improves code reliability by verifying correct functionality in edge cases like null attribute instances.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->