### PR TITLE
Use tolerance for shape comparison

### DIFF
--- a/NCPCompatBukkit/pom.xml
+++ b/NCPCompatBukkit/pom.xml
@@ -28,6 +28,12 @@
             <version>1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairs.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairs.java
@@ -202,14 +202,15 @@ public class BukkitStairs implements BukkitShapeModel {
         return list;
     }
 
-    private boolean sameshape(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, double tminX,
-            double tminY, double tminZ, double tmaxX, double tmaxY, double tmaxZ) {
+    private boolean sameshape(double minX, double minY, double minZ, double maxX, double maxY, double maxZ,
+            double tminX, double tminY, double tminZ, double tmaxX, double tmaxY, double tmaxZ) {
         final double dx = maxX - minX;
         final double dy = maxY - minY;
         final double dz = maxZ - minZ;
         final double tdx = tmaxX - tminX;
         final double tdy = tmaxY - tminY;
         final double tdz = tmaxZ - tminZ;
-        return dx == tdx && dy == tdy && dz == tdz;
+        final double tol = 1e-9;
+        return Math.abs(dx - tdx) < tol && Math.abs(dy - tdy) < tol && Math.abs(dz - tdz) < tol;
     }
 }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairsTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairsTest.java
@@ -1,0 +1,42 @@
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class BukkitStairsTest {
+
+    private boolean invokeSameShape(double minX, double minY, double minZ,
+            double maxX, double maxY, double maxZ,
+            double tminX, double tminY, double tminZ,
+            double tmaxX, double tmaxY, double tmaxZ) throws Exception {
+        BukkitStairs stairs = new BukkitStairs();
+        Method m = BukkitStairs.class.getDeclaredMethod("sameshape", double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class, double.class, double.class, double.class,
+                double.class, double.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(stairs, minX, minY, minZ, maxX, maxY, maxZ,
+                tminX, tminY, tminZ, tmaxX, tmaxY, tmaxZ);
+    }
+
+    @Test
+    public void testSameShapeExact() throws Exception {
+        assertTrue(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0, 1.0, 1.0));
+    }
+
+    @Test
+    public void testSameShapeTolerance() throws Exception {
+        assertTrue(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0 + 1e-10, 1.0, 1.0));
+    }
+
+    @Test
+    public void testDifferentShape() throws Exception {
+        assertFalse(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0 + 1e-6, 1.0, 1.0));
+    }
+}


### PR DESCRIPTION
## Summary
- use a small tolerance when comparing stair shapes
- add a regression test for same shape comparisons
- enable test library for Bukkit compatibility module

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34faf4b48329b790b42da20126c5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a tolerance level for shape comparison in `BukkitStairs` and add unit tests for this function.

### Why are these changes being made?

The changes aim to make the `sameshape` method in the `BukkitStairs` class more robust by allowing for small floating-point variances, which is crucial to prevent minor precision issues from causing false negatives in shape comparisons. Adding tests ensures the function behaves correctly both with exact values and within the new tolerance level.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->