### PR TITLE
Refactor access classes with factory methods

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
@@ -28,10 +28,20 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 
 public class BukkitAttributeAccess implements IAttributeAccess {
 
-    public BukkitAttributeAccess() {
+    private BukkitAttributeAccess() {
+        // Empty constructor.
+    }
+
+    /**
+     * Create an instance if supported by the running server implementation.
+     *
+     * @return Instance or {@code null} if not supported.
+     */
+    public static BukkitAttributeAccess createIfSupported() {
         if (ReflectionUtil.getClass("org.bukkit.attribute.AttributeInstance") == null) {
-            throw new RuntimeException("Service not available.");
+            return null;
         }
+        return new BukkitAttributeAccess();
     }
 
     private int operationToInt(final Operation operation) {

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
@@ -23,11 +23,21 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 
 public class EntityAccessVehicleMultiPassenger implements IEntityAccessVehicle {
 
-    public EntityAccessVehicleMultiPassenger() {
+    private EntityAccessVehicleMultiPassenger() {
+        // Empty constructor.
+    }
+
+    /**
+     * Create an instance if supported by the running server implementation.
+     *
+     * @return Instance or {@code null} if not supported.
+     */
+    public static EntityAccessVehicleMultiPassenger createIfSupported() {
         // Ensure the method signature matches List<Entity> for getPassengers.
         if (ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class) == null) {
-            throw new RuntimeException("Not supported.");
+            return null;
         }
+        return new EntityAccessVehicleMultiPassenger();
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -51,19 +51,19 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     private static final BukkitShapeModel MODEL_AUTO_FETCH_LEGACY = new BukkitFetchableBound();
 
     // Blocks that are formed from multiple bounding boxes
-    private static final BukkitShapeModel MODEL_BREWING_STAND = new BukkitStatic(
+    private static final BukkitShapeModel MODEL_BREWING_STAND = BukkitStatic.ofBounds(
         // Bottom rod
         0.0625, 0.0, 0.0625, 0.9375, 0.125, 0.9375,
         // Rod
         0.4375, 0.125, 0.4375, 0.5625, 0.875, 0.5625
     );
-    private static final BukkitShapeModel MODEL_CANDLE_CAKE = new BukkitStatic(
+    private static final BukkitShapeModel MODEL_CANDLE_CAKE = BukkitStatic.ofBounds(
         // Cake
         0.0625, 0.0, 0.0625, 0.9375, 0.5, 0.9375,
         // Candle
         0.4375, 0.5, 0.4375, 0.5625, 0.875, 0.5625
     );
-    private static final BukkitShapeModel MODEL_LECTERN = new BukkitStatic(
+    private static final BukkitShapeModel MODEL_LECTERN = BukkitStatic.ofBounds(
         // Post
         0.0, 0.0, 0.0, 1.0, 0.125, 1.0,
         // Lectern
@@ -109,29 +109,29 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     private static final BukkitShapeModel MODEL_WALL_HEAD = new BukkitWallHead();
 
     // Static blocks (various height and inset values).
-    private static final BukkitShapeModel MODEL_CAMPFIRE = new BukkitStatic(0.0, 0.4375);
+    private static final BukkitShapeModel MODEL_CAMPFIRE = BukkitStatic.ofInsetAndHeight(0.0, 0.4375);
     private static final BukkitShapeModel MODEL_BAMBOO = new BukkitBamboo();
     private static final BukkitShapeModel MODEL_WATER_PLANTS = new BukkitWaterPlant();
-    private static final BukkitShapeModel MODEL_LILY_PAD = new BukkitStatic(0.0625, 0.09375);
-    private static final BukkitShapeModel MODEL_FLOWER_POT = new BukkitStatic(0.3125, 0.375);
+    private static final BukkitShapeModel MODEL_LILY_PAD = BukkitStatic.ofInsetAndHeight(0.0625, 0.09375);
+    private static final BukkitShapeModel MODEL_FLOWER_POT = BukkitStatic.ofInsetAndHeight(0.3125, 0.375);
     private static final BukkitShapeModel MODEL_LANTERN = new BukkitLantern();
-    private static final BukkitShapeModel MODEL_CONDUIT = new BukkitStatic(0.3125, 0.3125, 0.3125, 0.6875, 0.6875, 0.6875);
-    private static final BukkitShapeModel MODEL_GROUND_HEAD = new BukkitStatic(0.25, 0.5);
-    private static final BukkitShapeModel MODEL_SINGLE_CHEST = new BukkitStatic(0.0625, 0.875);
-    private static final BukkitShapeModel MODEL_HONEY_BLOCK = new BukkitStatic(0.0625, 0.9375);
-    private static final BukkitShapeModel MODEL_SCULK_SHRIEKER = new BukkitStatic(0.0, 0.5);
+    private static final BukkitShapeModel MODEL_CONDUIT = BukkitStatic.ofBounds(0.3125, 0.3125, 0.3125, 0.6875, 0.6875, 0.6875);
+    private static final BukkitShapeModel MODEL_GROUND_HEAD = BukkitStatic.ofInsetAndHeight(0.25, 0.5);
+    private static final BukkitShapeModel MODEL_SINGLE_CHEST = BukkitStatic.ofInsetAndHeight(0.0625, 0.875);
+    private static final BukkitShapeModel MODEL_HONEY_BLOCK = BukkitStatic.ofInsetAndHeight(0.0625, 0.9375);
+    private static final BukkitShapeModel MODEL_SCULK_SHRIEKER = BukkitStatic.ofInsetAndHeight(0.0, 0.5);
 
     // Static blocks with full height sorted by inset.
-    private static final BukkitShapeModel MODEL_INSET16_1_HEIGHT100 = new BukkitStatic(0.0625, 1.0);
+    private static final BukkitShapeModel MODEL_INSET16_1_HEIGHT100 = BukkitStatic.ofInsetAndHeight(0.0625, 1.0);
 
     // Static blocks with full xz-bounds sorted by height.
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_1 = new BukkitStatic(0.0625);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_1 = new BukkitStatic(0.125);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_3 = new BukkitStatic(0.375);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_9 = new BukkitStatic(0.5625);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT4_3 = new BukkitStatic(0.75);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_15 = new BukkitStatic(0.9375);
-    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_7 = new BukkitStatic(0.875);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_1 = BukkitStatic.ofHeight(0.0625);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_1 = BukkitStatic.ofHeight(0.125);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_3 = BukkitStatic.ofHeight(0.375);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_9 = BukkitStatic.ofHeight(0.5625);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT4_3 = BukkitStatic.ofHeight(0.75);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT16_15 = BukkitStatic.ofHeight(0.9375);
+    private static final BukkitShapeModel MODEL_XZ100_HEIGHT8_7 = BukkitStatic.ofHeight(0.875);
 
     public MCAccessBukkitModern() {
         super();

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
@@ -27,10 +27,20 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 
 public class NSBukkitAttributeAccess implements IAttributeAccess {
 
-    public NSBukkitAttributeAccess() {
+    private NSBukkitAttributeAccess() {
+        // Empty constructor.
+    }
+
+    /**
+     * Create an instance if supported by the running server implementation.
+     *
+     * @return Instance or {@code null} if not supported.
+     */
+    public static NSBukkitAttributeAccess createIfSupported() {
         if (ReflectionUtil.getClass("org.bukkit.attribute.AttributeInstance") == null) {
-            throw new RuntimeException("Service not available.");
+            return null;
         }
+        return new NSBukkitAttributeAccess();
     }
 
     private int operationToInt(final Operation operation) {

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -22,35 +22,42 @@ public class BukkitStatic implements BukkitShapeModel {
 
     private final double[] bounds;
 
-    /**
-     * Initialize with the given height and with full xz-bounds.
-     * 
-     * @param height
-     */
-    public BukkitStatic(double height) {
-        this(0.0, height);
+    private BukkitStatic(double... bounds) {
+        this.bounds = bounds;
     }
 
     /**
-     * Initialize with the given height and xz-inset.
-     * 
+     * Create a shape model using full xz-bounds for the given height.
+     *
+     * @param height
+     * @return New instance.
+     */
+    public static BukkitStatic ofHeight(double height) {
+        return ofInsetAndHeight(0.0, height);
+    }
+
+    /**
+     * Create a shape model with the given xz-inset and height.
+     *
      * @param xzInset
      * @param height
+     * @return New instance.
      */
-    public BukkitStatic(double xzInset, double height) {
-        this(xzInset, 0.0, xzInset, 1.0 - xzInset, height, 1.0 - xzInset);
+    public static BukkitStatic ofInsetAndHeight(double xzInset, double height) {
+        return ofBounds(xzInset, 0.0, xzInset, 1.0 - xzInset, height, 1.0 - xzInset);
     }
 
     /**
-     * Initialize with the given bounds 
-     * 
+     * Create a shape model from the given bounds.
+     *
+     * @param bounds The bounds, length must be a multiple of 6.
+     * @return New instance.
      */
-    public BukkitStatic(double ...bounds) {
+    public static BukkitStatic ofBounds(double... bounds) {
         if (bounds.length % 6 != 0) {
             throw new IllegalArgumentException("The length must be a multiple of 6");
         }
-        this.bounds = bounds;
-
+        return new BukkitStatic(bounds);
     }
 
     @Override

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
@@ -36,7 +36,9 @@ public class AttributeAccessFactory {
         final IAttributeAccess fallBackReflect = new DummyAttributeAccess();
         IAttributeAccess fallBackDedicated = null;
         try {
-            fallBackDedicated = ServerVersion.compareMinecraftVersion("1.21") < 0 ? new BukkitAttributeAccess() : new NSBukkitAttributeAccess();
+            fallBackDedicated = ServerVersion.compareMinecraftVersion("1.21") < 0
+                    ? BukkitAttributeAccess.createIfSupported()
+                    : NSBukkitAttributeAccess.createIfSupported();
         }
         catch (Throwable t) {
             // ignore - dedicated access not available for this server version

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.compat.registry;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
+import fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleMultiPassenger;
 
 /**
  * Set up more fine grained entity access providers, registered as generic
@@ -52,10 +53,11 @@ public class EntityAccessFactory {
         //}, IEntityAccessLastPositionAndLook.class, config, false);
 
         // IEntityAccessVehicle
-        RegistryHelper.registerFirstAvailable(new String[] {
-                "fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleMultiPassenger",
-                "fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleLegacy",
-        }, IEntityAccessVehicle.class, false);
+        IEntityAccessVehicle vehicleAccess = EntityAccessVehicleMultiPassenger.createIfSupported();
+        if (vehicleAccess == null) {
+            vehicleAccess = new fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleLegacy();
+        }
+        RegistryHelper.registerGenericInstance(IEntityAccessVehicle.class, vehicleAccess);
     }
 
 }


### PR DESCRIPTION
## Summary
- hide constructors in Bukkit compatibility access classes
- provide factory methods to create instances safely
- use new factories in factories and MCAccess
- update static block model creation helpers

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c34f62a0c8329919214b85ad5083e