### PR TITLE
Fix thread visibility for player task flags

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerData.java
@@ -153,11 +153,16 @@ public class PlayerData implements IPlayerData {
     private final InstanceMapLOW dataCache = new InstanceMapLOW(lock, 24);
 
     /** If is Bedrock Player. This is set if CompatNoCheatPlus is present. */
-    private boolean bedrockPlayer = false;
-    private boolean requestUpdateInventory = false;
-    private boolean requestPlayerSetBack = false;
+    private volatile boolean bedrockPlayer = false;
 
-    private boolean frequentPlayerTaskShouldBeScheduled = false;
+    /** Request to update the players inventory on the main thread. */
+    private volatile boolean requestUpdateInventory = false;
+
+    /** Request to set back the player on the main thread. */
+    private volatile boolean requestPlayerSetBack = false;
+
+    /** Indicates if a frequent player task should be scheduled. */
+    private volatile boolean frequentPlayerTaskShouldBeScheduled = false;
     /** Actually queried ones. */
     private final DualSet<RegisteredPermission> updatePermissions = new DualSet<RegisteredPermission>(lock);
     /** Possibly needed in future. */


### PR DESCRIPTION
## Summary
- ensure frequent player task flags are visible across threads

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c075e008329997856c0ad97b717