### PR TITLE
Use epsilon for stair shape comparison

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
@@ -291,6 +291,11 @@ public class LegacyBlocks {
         private final double[][] top_stairs = makeshape(topslabs, octet_nnn, octet_pnn, octet_nnp, octet_pnp);
         private final double[][] bottom_stairs = makeshape(bottomslabs, octet_npn, octet_ppn, octet_npp, octet_ppp);
         private final int[] shape_by_state = new int[]{12, 5, 3, 10, 14, 13, 7, 11, 13, 7, 11, 14, 8, 4, 1, 2, 4, 1, 2, 8};
+        /**
+         * Tolerance for comparing bounding box side lengths.
+         */
+        private static final double SHAPE_TOLERANCE = 1e-9;
+
 
         public BlockStairs() {
             
@@ -502,7 +507,8 @@ public class LegacyBlocks {
             final double tdx = tmaxX - tminX;
             final double tdy = tmaxY - tminY;
             final double tdz = tmaxZ - tminZ;
-            return dx == tdx && dy == tdy && dz == tdz;
+            final double tol = SHAPE_TOLERANCE;
+            return Math.abs(dx - tdx) < tol && Math.abs(dy - tdy) < tol && Math.abs(dz - tdz) < tol;
         }
     }
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlockStairsTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlockStairsTest.java
@@ -1,0 +1,42 @@
+package fr.neatmonster.nocheatplus.compat.blocks;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class LegacyBlockStairsTest {
+
+    private boolean invokeSameShape(double minX, double minY, double minZ,
+            double maxX, double maxY, double maxZ,
+            double tminX, double tminY, double tminZ,
+            double tmaxX, double tmaxY, double tmaxZ) throws Exception {
+        LegacyBlocks.BlockStairs stairs = new LegacyBlocks.BlockStairs();
+        Method m = LegacyBlocks.BlockStairs.class.getDeclaredMethod("sameshape", double.class, double.class, double.class,
+                double.class, double.class, double.class, double.class, double.class, double.class,
+                double.class, double.class, double.class);
+        m.setAccessible(true);
+        return (boolean) m.invoke(stairs, minX, minY, minZ, maxX, maxY, maxZ,
+                tminX, tminY, tminZ, tmaxX, tmaxY, tmaxZ);
+    }
+
+    @Test
+    public void testSameShapeExact() throws Exception {
+        assertTrue(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0, 1.0, 1.0));
+    }
+
+    @Test
+    public void testSameShapeTolerance() throws Exception {
+        assertTrue(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0 + 1e-10, 1.0, 1.0));
+    }
+
+    @Test
+    public void testDifferentShape() throws Exception {
+        assertFalse(invokeSameShape(0.0, 0.0, 0.0, 1.0, 1.0, 1.0,
+                0.0, 0.0, 0.0, 1.0 + 1e-6, 1.0, 1.0));
+    }
+}


### PR DESCRIPTION
## Summary
- compare stair bounding boxes with a tolerance
- document the tolerance constant
- cover `LegacyBlocks.BlockStairs` shape equality with tests

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c0622948329831a33a1127b7192

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce an epsilon tolerance for stair shape comparison in the `LegacyBlocks.BlockStairs` class and add corresponding unit tests.

### Why are these changes being made?

The addition of a shape tolerance allows for more accurate floating-point comparison of bounding box side lengths, addressing precision issues that could lead to incorrect shape comparisons. This change enhances robustness in situations where small numerical differences exist, and the introduced tests ensure the comparison logic correctly handles both identical and nearly similar shapes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->