### PR TITLE
Use try-finally for lock handling

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/HashMapLOW.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/HashMapLOW.java
@@ -514,9 +514,12 @@ public class HashMapLOW <K, V> {
      */
     public void clear() {
         lock.lock();
-        buckets = newBuckets(targetSize);
-        size = 0;
-        lock.unlock();
+        try {
+            buckets = newBuckets(targetSize);
+            size = 0;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -554,21 +557,24 @@ public class HashMapLOW <K, V> {
     private final V put(final K key, final V value, final boolean ifAbsent) {
         final int hashCode = getHashCode(key);
         lock.lock();
-        final int index = getBucketIndex(hashCode, buckets.length);
-        LHMBucket<K, V> bucket = buckets[index];
-        if (bucket == null) {
-            bucket = new LHMBucket<K, V>();
-            buckets[index] = bucket;
-        }
-        V oldValue = bucket.put(hashCode, key, value, ifAbsent);
-        if (oldValue == null) {
-            size ++;
-            if (size > (int) (loadFactor * (float) buckets.length)) {
-                resize();
+        try {
+            final int index = getBucketIndex(hashCode, buckets.length);
+            LHMBucket<K, V> bucket = buckets[index];
+            if (bucket == null) {
+                bucket = new LHMBucket<K, V>();
+                buckets[index] = bucket;
             }
+            V oldValue = bucket.put(hashCode, key, value, ifAbsent);
+            if (oldValue == null) {
+                size ++;
+                if (size > (int) (loadFactor * (float) buckets.length)) {
+                    resize();
+                }
+            }
+            return oldValue;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-        return oldValue;
     }
 
     /**
@@ -580,10 +586,13 @@ public class HashMapLOW <K, V> {
     public V remove(final K key) {
         final int hashCode = getHashCode(key);
         lock.lock();
-        final V value = removeUnderLock(hashCode, key);
-        // Shrink if necessary (not implemented).
-        lock.unlock();
-        return value;
+        try {
+            final V value = removeUnderLock(hashCode, key);
+            // Shrink if necessary (not implemented).
+            return value;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -617,11 +626,14 @@ public class HashMapLOW <K, V> {
      */
     public void remove(final Collection<K> keys) {
         lock.lock();
-        for (final K key : keys) {
-            final int hashCode = getHashCode(key);
-            removeUnderLock(hashCode, key);
+        try {
+            for (final K key : keys) {
+                final int hashCode = getHashCode(key);
+                removeUnderLock(hashCode, key);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     /**
@@ -651,9 +663,11 @@ public class HashMapLOW <K, V> {
      */
     public V getLocked(final K key) {
         lock.lock();
-        final V value = get(key);
-        lock.unlock();
-        return value;
+        try {
+            return get(key);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -684,9 +698,11 @@ public class HashMapLOW <K, V> {
      */
     public boolean containsKeyLocked(final K key) {
         lock.lock();
-        final boolean res = containsKey(key);
-        lock.unlock();
-        return res;
+        try {
+            return containsKey(key);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -127,14 +127,17 @@ public class NetData extends ACheckData {
     public boolean addFlyingQueue(final DataPacketFlying packetData) {
         boolean res = false;
         lock.lock();
-        packetData.setSequence(++maxSequence);
-        flyingQueue.addFirst(packetData);
-        if (flyingQueue.size() > flyingQueueMaxSize) {
-            flyingQueue.removeLast();
-            res = true;
+        try {
+            packetData.setSequence(++maxSequence);
+            flyingQueue.addFirst(packetData);
+            if (flyingQueue.size() > flyingQueueMaxSize) {
+                flyingQueue.removeLast();
+                res = true;
+            }
+            return res;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-        return res;
     }
 
     /**
@@ -142,8 +145,11 @@ public class NetData extends ACheckData {
      */
     public void clearFlyingQueue() {
         lock.lock();
-        flyingQueue.clear();
-        lock.unlock();
+        try {
+            flyingQueue.clear();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -153,13 +159,15 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying[] copyFlyingQueue() {
         lock.lock();
-        /*
-         * Packet inversion is acute on 1.11.2 (dig is processed
-         * before flying). Synchronizing with the current position might be added.
-         */
-        final DataPacketFlying[] out = flyingQueue.toArray(new DataPacketFlying[flyingQueue.size()]);
-        lock.unlock();
-        return out;
+        try {
+            /*
+             * Packet inversion is acute on 1.11.2 (dig is processed
+             * before flying). Synchronizing with the current position might be added.
+             */
+            return flyingQueue.toArray(new DataPacketFlying[flyingQueue.size()]);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -169,9 +177,11 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying getCurrentFlyingPacket() {
         lock.lock();
-        final DataPacketFlying latest = flyingQueue.isEmpty() ? null : flyingQueue.getFirst();
-        lock.unlock();
-        return latest;
+        try {
+            return flyingQueue.isEmpty() ? null : flyingQueue.getFirst();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -181,9 +191,11 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying getPastFlyingPacketInQueue(final int index) {
         lock.lock();
-        final DataPacketFlying packet = flyingQueue.isEmpty() ? null : flyingQueue.get(index);
-        lock.unlock();
-        return packet;
+        try {
+            return flyingQueue.isEmpty() ? null : flyingQueue.get(index);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
@@ -134,54 +134,57 @@ public class TeleportQueue {
         CountableLocation res = null;
         final long time = System.currentTimeMillis();
         lock.lock();
-        lastAckReference.lastOutgoingId = teleportId;
-        if (lastAckReference.maxConfirmedId > lastAckReference.lastOutgoingId) {
-            lastAckReference.maxConfirmedId = Integer.MIN_VALUE; // Some data loss accepted here.
-        }
-        // Only register this location, if it matches the location from a Bukkit event.
-        if (expectOutgoing != null) {
-            if (expectOutgoing.isSameLocation(x, y, z, yaw, pitch)) {
-                // Add to queue.
-                if (!expectIncoming.isEmpty()) {
-                    // Lazy expiration check.
-                    final Iterator<CountableLocation> it = expectIncoming.iterator();
-                    while (it.hasNext()) {
-                        final CountableLocation ref = it.next();
-                        if (time < ref.time) {
-                            // Time ran backwards. Force keep entries.
-                            ref.time = time;
-                        }
-                        else if (time - maxAge > ref.time) {
-                            it.remove();
-                        } else {
-                            break;
-                        }
-                    }
-                    if (!expectIncoming.isEmpty()) {
-                        final CountableLocation last = expectIncoming.getLast();
-                        if (last.isSameLocation(x, y, z, yaw, pitch)) {
-                            last.time = time;
-                            last.count ++;
-                            last.teleportId = teleportId;
-                            res = last;
-                        }
-                    }
-                }
-                // Add a new entry, if not merged with last.
-                if (res == null) {
-                    res = new CountableLocation(x, y, z, yaw, pitch, 1, time, teleportId);
-                    expectIncoming.addLast(res);
-                    // Don't exceed maxQueueSize.
-                    if (expectIncoming.size() > maxQueueSize) {
-                        expectIncoming.removeFirst();
-                    }
-                }
+        try {
+            lastAckReference.lastOutgoingId = teleportId;
+            if (lastAckReference.maxConfirmedId > lastAckReference.lastOutgoingId) {
+                lastAckReference.maxConfirmedId = Integer.MIN_VALUE; // Some data loss accepted here.
             }
-            // Reset in any case.
-            expectOutgoing = null;
+            // Only register this location, if it matches the location from a Bukkit event.
+            if (expectOutgoing != null) {
+                if (expectOutgoing.isSameLocation(x, y, z, yaw, pitch)) {
+                    // Add to queue.
+                    if (!expectIncoming.isEmpty()) {
+                        // Lazy expiration check.
+                        final Iterator<CountableLocation> it = expectIncoming.iterator();
+                        while (it.hasNext()) {
+                            final CountableLocation ref = it.next();
+                            if (time < ref.time) {
+                                // Time ran backwards. Force keep entries.
+                                ref.time = time;
+                            }
+                            else if (time - maxAge > ref.time) {
+                                it.remove();
+                            } else {
+                                break;
+                            }
+                        }
+                        if (!expectIncoming.isEmpty()) {
+                            final CountableLocation last = expectIncoming.getLast();
+                            if (last.isSameLocation(x, y, z, yaw, pitch)) {
+                                last.time = time;
+                                last.count ++;
+                                last.teleportId = teleportId;
+                                res = last;
+                            }
+                        }
+                    }
+                    // Add a new entry, if not merged with last.
+                    if (res == null) {
+                        res = new CountableLocation(x, y, z, yaw, pitch, 1, time, teleportId);
+                        expectIncoming.addLast(res);
+                        // Don't exceed maxQueueSize.
+                        if (expectIncoming.size() > maxQueueSize) {
+                            expectIncoming.removeFirst();
+                        }
+                    }
+                }
+                // Reset in any case.
+                expectOutgoing = null;
+            }
+            return res;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-        return res;
     }
 
     /**
@@ -203,44 +206,47 @@ public class TeleportQueue {
             return AlmostBoolean.NO;
         }
         lock.lock();
-        if (teleportId == lastAckReference.lastOutgoingId) {
-            lastAckReference.maxConfirmedId = teleportId;
-            // Abort here for efficiency.
-            expectIncoming.clear();
-            lock.unlock();
-            return AlmostBoolean.YES;
-        }
-        AlmostBoolean ackState = AlmostBoolean.NO;
-        for (CountableLocation ref : expectIncoming) {
-            // No expiration checks here.
-            if (ref.teleportId == teleportId) {
-                // Match an outdated id.
-                // Remove all preceding older entries and this one.
-                while (ref != expectIncoming.getFirst()) {
+        try {
+            if (teleportId == lastAckReference.lastOutgoingId) {
+                lastAckReference.maxConfirmedId = teleportId;
+                // Abort here for efficiency.
+                expectIncoming.clear();
+                return AlmostBoolean.YES;
+            }
+            AlmostBoolean ackState = AlmostBoolean.NO;
+            for (CountableLocation ref : expectIncoming) {
+                // No expiration checks here.
+                if (ref.teleportId == teleportId) {
+                    // Match an outdated id.
+                    // Remove all preceding older entries and this one.
+                    while (ref != expectIncoming.getFirst()) {
+                        expectIncoming.removeFirst();
+                    }
                     expectIncoming.removeFirst();
+                    // The count doesn't count anymore.
+                    ref.count = 0;
+                    ackState = AlmostBoolean.YES;
+                    break;
                 }
-                expectIncoming.removeFirst();
-                // The count doesn't count anymore.
-                ref.count = 0;
-                ackState = AlmostBoolean.YES;
-                break;
             }
-        }
-        // Update lastAckReference only if within the safe area.
-        if (teleportId < lastAckReference.lastOutgoingId 
-                && teleportId > lastAckReference.maxConfirmedId) {
-            // Allow update.
-            lastAckReference.maxConfirmedId = teleportId;
-            if (ackState == AlmostBoolean.NO) {
-                // Adjust to maybe, as long as the id is increasing within unique range.
-                ackState = AlmostBoolean.MAYBE;
+            // Update lastAckReference only if within the safe area.
+            if (teleportId < lastAckReference.lastOutgoingId
+                    && teleportId > lastAckReference.maxConfirmedId) {
+                // Allow update.
+                lastAckReference.maxConfirmedId = teleportId;
+                if (ackState == AlmostBoolean.NO) {
+                    // Adjust to maybe, as long as the id is increasing within unique range.
+                    ackState = AlmostBoolean.MAYBE;
+                }
             }
+            else {
+                lastAckReference.maxConfirmedId = Integer.MIN_VALUE;
+            }
+            return ackState;
         }
-        else {
-            lastAckReference.maxConfirmedId = Integer.MIN_VALUE;
+        finally {
+            lock.unlock();
         }
-        lock.unlock();
-        return ackState;
     }
 
     /**
@@ -262,14 +268,16 @@ public class TeleportQueue {
         final AckResolution res;
 
         lock.lock();
-        if (expectIncoming.isEmpty()) {
-            res = AckResolution.IDLE;
-        } else {
-            res = getAckResolution(packetData);
+        try {
+            if (expectIncoming.isEmpty()) {
+                res = AckResolution.IDLE;
+            } else {
+                res = getAckResolution(packetData);
+            }
+            return res;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-
-        return res;
     }
 
     /**
@@ -315,9 +323,12 @@ public class TeleportQueue {
 
     public void clear() {
         lock.lock();
-        expectIncoming.clear();
-        expectOutgoing = null;
-        lock.unlock();
+        try {
+            expectIncoming.clear();
+            expectOutgoing = null;
+        } finally {
+            lock.unlock();
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- wrap TeleportQueue lock sections in try-finally
- use try-finally in NetData queue methods
- update HashMapLOW to always unlock in finally blocks

## Testing
- `mvn -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c05b3308329b2e348ea26c6c339

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor lock handling across multiple Java classes by implementing `try-finally` blocks to ensure locks are always released even if an exception occurs.

### Why are these changes being made?

The previous implementation manually unlocked in each method, which could lead to potential issues if an exception was thrown before the `unlock()` call. Using `try-finally` ensures that locks are consistently released, improving thread safety and preventing potential deadlocks. This change also enhances code readability and maintainability by following a consistent pattern for resource management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->