### PR TITLE
Fix set-back update condition

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -444,8 +444,8 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         // Reset to setBack.
         resetPlayerPositions(setBack);
         adjustMediumProperties(setBack);
-        // Only setSetBack if no set back location is there.
-        if (setBack == null) {
+        // Only store a set-back location if none has been stored yet.
+        if (this.setBack == null && setBack != null) {
             setSetBack(setBack);
         }
         // vehicleSetBacks.resetAllLazily(setBack); // Not good: Overrides older set back locations.


### PR DESCRIPTION
## Summary
- fix the conditional that stores set-back location in `MovingData#onSetBack`

## Testing
- `mvn -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c073df88329ac98f3b59a641a16