### PR TITLE
Fix FastConsume null check

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
@@ -107,7 +107,7 @@ public class FastConsume extends Check implements Listener, INotifyReload {
         }
         // Check exceptions.
         final InventoryConfig cc = pData.getGenericInstance(InventoryConfig.class);
-        final Material mat = stack == null ? null : stack.getType();
+        final Material mat = stack.getType();
         if (mat != null){
             if (cc.fastConsumeWhitelist){
                 if (!cc.fastConsumeItems.contains(mat)){


### PR DESCRIPTION
## Summary
- remove redundant null check in FastConsume
- run tests and static analysis

## Testing
- `mvn -q test checkstyle:check pmd:check com.github.spotbugs:spotbugs-maven-plugin:check`
- `mvn -q -pl NCPCompatBukkit spotbugs:spotbugs`

------
https://chatgpt.com/codex/tasks/task_b_685c3c0376208329a18b1a139e6b42e5