### PR TITLE
Make value field private with accessors

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/bktree/BKModTree.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/bktree/BKModTree.java
@@ -41,12 +41,20 @@ public abstract class BKModTree<V, N extends Node<V, N>, L extends LookupEntry<V
 	 * @param <V>
 	 * @param <N>
 	 */
-	public static abstract class Node<V, N extends Node<V, N>>{
-		public V value;
-		
-		public Node(V value){
-			this.value = value;
-		}
+        public static abstract class Node<V, N extends Node<V, N>>{
+                private V value;
+
+                public Node(V value){
+                        this.value = value;
+                }
+
+                public V getValue() {
+                        return value;
+                }
+
+                public void setValue(V value) {
+                        this.value = value;
+                }
 		public abstract N putChild(final int distance, final N child);
 		
 		public abstract N getChild(final int distance);
@@ -216,9 +224,9 @@ public abstract class BKModTree<V, N extends Node<V, N>, L extends LookupEntry<V
 		open.add(root);
 		N insertion = null;
 		int insertionDist = 0;
-		do{
-			final N current = open.remove(open.size() - 1);
-			int distance = distance(current.value, value);
+                do{
+                        final N current = open.remove(open.size() - 1);
+                        int distance = distance(current.getValue(), value);
 			if (visit) visit(current, value, distance);
 			if (distance == 0){
 				// exact match.

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/ManagedMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/ManagedMap.java
@@ -33,9 +33,17 @@ public class ManagedMap<K, V>{
 
     protected class ValueWrap{
         public long ts;
-        public  V value;
+        private V value;
         public ValueWrap(final V value){
             ts = System.currentTimeMillis();
+            this.value = value;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+        public void setValue(final V value) {
             this.value = value;
         }
     }
@@ -59,8 +67,8 @@ public class ManagedMap<K, V>{
             return null;
         }
         else{
-            final V res = wrap.value;
-            wrap.value = value;
+            final V res = wrap.getValue();
+            wrap.setValue(value);
             wrap.ts = System.currentTimeMillis();
             return res;
         }
@@ -71,14 +79,14 @@ public class ManagedMap<K, V>{
         if (wrap == null) return null;
         else{
             wrap.ts = System.currentTimeMillis();
-            return wrap.value;
+            return wrap.getValue();
         }
     }
 
     public V remove(final K key){
         final ValueWrap wrap = map.remove(key);
         if (wrap == null) return null;
-        else return wrap.value;
+        else return wrap.getValue();
     }
 
     public void clear(){

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/analysis/engine/EnginePlayerDataMap.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/analysis/engine/EnginePlayerDataMap.java
@@ -64,11 +64,11 @@ public class EnginePlayerDataMap extends ManagedMap<String, EnginePlayerData> {
 	
 	public void clear(){
 		final long time = System.currentTimeMillis();
-		for (final ValueWrap wrap : map.values()){
-			for (final WordProcessor processor : wrap.value.processors){
-				processor.clear();
-			}
-		}
+                for (final ValueWrap wrap : map.values()){
+                        for (final WordProcessor processor : wrap.getValue().processors){
+                                processor.clear();
+                        }
+                }
 		super.clear();
 		lastAccess = lastExpired = time;
 	}


### PR DESCRIPTION
## Summary
- encapsulate value in BKModTree.Node
- encapsulate value in ManagedMap.ValueWrap
- adapt EnginePlayerDataMap to new accessors
- run mvn verify

## Testing
- `mvn -q -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c05851c83298bfadb32eb499e25

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Make the `value` field private in `Node` and `ValueWrap` classes and provide public accessor methods `getValue` and `setValue` for accessing and modifying the `value`.

### Why are these changes being made?

The change is made to encapsulate the `value` field within the respective classes, increasing encapsulation and adhering to the principle of data hiding for better maintainability and security. This allows controlled access to the `value` and helps safeguard against unauthorized or unintended modifications.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->