### PR TITLE
Fix PlayerData assignment on login

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -648,23 +648,26 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
     private void onPlayerLogin(final PlayerLoginEvent event) {
         // Consistency check existing data.
         final Player player = event.getPlayer();
-        final UUID playerId = player.getUniqueId();
-        final PlayerData pData = getPlayerData(playerId);
-        if (pData == null) {
-            // Create an instance.
-            // NOTE: Legacy server compatibility with world retrieval?
-            getPlayerData(player);
-        }
-        else {
-            // Consistency check.
-            final String playerName = pData.getPlayerName();
-            if (!playerName.equals(player.getName())) {
-                updatePlayerName(playerId, playerName, pData, "login");
+        if (player != null) {
+            final UUID playerId = player.getUniqueId();
+            PlayerData pData = getPlayerData(playerId);
+            if (pData == null) {
+                // Create an instance.
+                // NOTE: Legacy server compatibility with world retrieval?
+                pData = getPlayerData(player);
+            } else {
+                // Consistency check.
+                final String playerName = pData.getPlayerName();
+                if (!playerName.equals(player.getName())) {
+                    updatePlayerName(playerId, playerName, pData, "login");
+                }
+                // Update world.
+                pData.updateCurrentWorld(worldDataManager.getWorldData(player.getWorld()));
             }
-            // Update world.
-            pData.updateCurrentWorld(worldDataManager.getWorldData(player.getWorld()));
+            if (pData != null) {
+                pData.removeTag(PlayerData.TAG_OPTIMISTIC_CREATE);
+            }
         }
-        pData.removeTag(PlayerData.TAG_OPTIMISTIC_CREATE);
     }
 
     private void updatePlayerName(final UUID playerId, final String playerName,


### PR DESCRIPTION
## Summary
- fix NPE risk when PlayerData is created during login
- ensure newly created PlayerData instance is assigned before removing tags

## Testing
- `mvn -q -DskipTests=false test`
- `mvn --no-transfer-progress -DskipTests=true verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c07abd88329a1d44bf2a9d9b6e4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the `onPlayerLogin` method in the `PlayerDataManager` class to improve the consistency check and proper initialization of `PlayerData` by including null checks and ensuring world data updates.

### Why are these changes being made?

These changes address a potential issue where a `null` player object might cause unintended behavior and ensure that `PlayerData` is correctly initialized and updated with current world data, thereby maintaining data consistency on player login.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->