### PR TITLE
Fix concurrency for player request flags

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerData.java
@@ -69,6 +69,13 @@ import fr.neatmonster.nocheatplus.worlds.WorldIdentifier;
  * </ul>
  * <hr>
  * Creating PlayerData must always be thread-safe and fail-safe.
+ * <p>
+ * Thread safety: Most interaction with PlayerData happens on the primary
+ * server thread. Some request flags such as {@link #requestUpdateInventory} and
+ * {@link #requestPlayerSetBack} may be modified from asynchronous contexts and
+ * are declared {@code volatile} to guarantee visibility. Compound operations
+ * involving these flags are synchronized on {@code this} where necessary.
+ * </p>
  * <hr>
  * OLD javadocs to be cleaned up (...):<br>
  * On the medium run this is intended to carry all data for the player...
@@ -153,11 +160,11 @@ public class PlayerData implements IPlayerData {
     private final InstanceMapLOW dataCache = new InstanceMapLOW(lock, 24);
 
     /** If is Bedrock Player. This is set if CompatNoCheatPlus is present. */
-    private boolean bedrockPlayer = false;
-    private boolean requestUpdateInventory = false;
-    private boolean requestPlayerSetBack = false;
+    private volatile boolean bedrockPlayer = false;
+    private volatile boolean requestUpdateInventory = false;
+    private volatile boolean requestPlayerSetBack = false;
 
-    private boolean frequentPlayerTaskShouldBeScheduled = false;
+    private volatile boolean frequentPlayerTaskShouldBeScheduled = false;
     /** Actually queried ones. */
     private final DualSet<RegisteredPermission> updatePermissions = new DualSet<RegisteredPermission>(lock);
     /** Possibly needed in future. */
@@ -250,14 +257,19 @@ public class PlayerData implements IPlayerData {
         if (player != null) { // Common criteria ...
             if (player.isOnline()) {
                 long nanos = System.nanoTime();
-                // Set back.
-                if (requestPlayerSetBack) {
+                // Handle pending requests atomically.
+                final boolean doSetBack;
+                final boolean doInventory;
+                synchronized (this) {
+                    doSetBack = requestPlayerSetBack;
                     requestPlayerSetBack = false;
+                    doInventory = requestUpdateInventory;
+                    requestUpdateInventory = false;
+                }
+                if (doSetBack) {
                     MovingUtil.processStoredSetBack(player, "Player set back on tick: ", this);
                 }
-                // Inventory update.
-                if (requestUpdateInventory) {
-                    requestUpdateInventory = false;
+                if (doInventory) {
                     player.updateInventory();
                 }
                 // Permission updates (high priority).


### PR DESCRIPTION
## Summary
- ensure thread-safety for request flags in `PlayerData`
- document thread-safety assumptions in the class

## Testing
- `mvn -q -DskipITs install`

------
https://chatgpt.com/codex/tasks/task_b_685c3cf6243883298de7d7d17a8e9205

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Ensure thread safety in the `PlayerData` class by marking certain flags as `volatile` and synchronizing compound operations involving these flags.

### Why are these changes being made?
To address concurrency issues where player request flags, such as inventory updates and player set-backs, could be modified from asynchronous contexts, thus requiring proper synchronization to ensure data visibility and integrity across threads. This approach balances between performance and thread safety, using `volatile` for visibility and synchronization for atomicity when needed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->