### PR TITLE
Fix RegisterMethodWithOrder detection

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MultiListenerRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MultiListenerRegistry.java
@@ -140,8 +140,9 @@ public abstract class MultiListenerRegistry<EB, P> extends MiniListenerRegistry<
     protected <E extends EB> MiniListener<E> register(Object listener, Method method, P basePriority, 
             RegistrationOrder defaultOrder, boolean ignoreCancelled) {
         RegistrationOrder order = null;
-        if (method.getClass().isAnnotationPresent(RegisterMethodWithOrder.class)) {
-            order = new RegistrationOrder(method.getClass().getAnnotation(RegisterMethodWithOrder.class));
+        if (method.isAnnotationPresent(RegisterMethodWithOrder.class)) {
+            RegisterMethodWithOrder annotation = method.getAnnotation(RegisterMethodWithOrder.class);
+            order = new RegistrationOrder(annotation);
         }
         if (order == null) {
             order = defaultOrder;

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/event/mini/TestMultiListenerRegistryAnnotation.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/event/mini/TestMultiListenerRegistryAnnotation.java
@@ -1,0 +1,54 @@
+package fr.neatmonster.nocheatplus.event.mini;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.components.registry.order.RegistrationOrder;
+import fr.neatmonster.nocheatplus.components.registry.order.RegistrationOrder.RegisterMethodWithOrder;
+
+public class TestMultiListenerRegistryAnnotation {
+
+    private static class DummyRegistry extends MultiListenerRegistry<Object, Integer> {
+        @Override
+        protected boolean shouldBeEventHandler(Method method) {
+            return true;
+        }
+
+        @Override
+        protected boolean getIgnoreCancelled(Method method, boolean defaultIgnoreCancelled) {
+            return defaultIgnoreCancelled;
+        }
+
+        @Override
+        protected Integer getPriority(Method method, Integer defaultPriority) {
+            return defaultPriority;
+        }
+
+        @Override
+        protected <E extends Object> void registerNode(Class<E> eventClass, MiniListenerNode<E, Integer> node,
+                Integer basePriority) {
+            // No-op for tests.
+        }
+    }
+
+    private static class DummyListener {
+        @RegisterMethodWithOrder(tag = "test")
+        public void handle(Object event) {
+        }
+    }
+
+    @Test
+    public void testAnnotationDetected() throws Exception {
+        DummyRegistry registry = new DummyRegistry();
+        Method method = DummyListener.class.getMethod("handle", Object.class);
+        RegistrationOrder order = new RegistrationOrder("default");
+        MiniListener<?> mini = registry.register(new DummyListener(), method, 0, order, false);
+        assertNotNull(mini);
+        assertTrue(mini instanceof MiniListenerWithOrder);
+        RegistrationOrder result = ((MiniListenerWithOrder<?>) mini).getRegistrationOrder();
+        assertEquals("test", result.getTag());
+    }
+}


### PR DESCRIPTION
## Summary
- detect RegisterMethodWithOrder annotations correctly
- add unit test verifying detection

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3cff9574832995ff760ded9fd280


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
