### PR TITLE
Use epsilon comparisons in movement checks

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -374,7 +374,7 @@ public class CreativeFly extends Check {
                     && !(thisMove.yDistance < 0.0 && lastMove.yDistance - thisMove.yDistance < 0.0001)) {
 
                 if (lastMove.yDistance < 0.0 && thisMove.yDistance < allowY
-                        || from.getY() >= to.getY() && !(thisMove.yDistance == 0.0 && allowY < 0.0)) {
+                        || from.getY() >= to.getY() && !(TrigUtil.isZero(thisMove.yDistance) && allowY < 0.0)) {
                     resultV = Math.max(resultV, 0.1);
                     tags.add("antilevitate");
 
@@ -989,7 +989,7 @@ public class CreativeFly extends Check {
     private void handleHeadObstruction(final PlayerLocation from, final PlayerMoveData lastMove,
             final double yDistance, final double yDistDiffEx, final AirGlideState state) {
         if (from != null && from.isHeadObstructed() && lastMove.yDistance > 0.0 && yDistDiffEx < 0.0
-                && (state.allowedY > 0.0 || yDistance == 0.0)) {
+                && (state.allowedY > 0.0 || TrigUtil.isZero(yDistance))) {
             state.allowedY = yDistance;
         }
     }
@@ -1035,7 +1035,7 @@ public class CreativeFly extends Check {
         return yDistance <= 0.0 && (to.isOnGround() || to.isResetCond() || thisMove.touchedGround)
                 || yDistDiffEx > -Magic.GRAVITY_MAX && yDistDiffEx < 0.0
                 || speed < 0.05 && !TrigUtil.isSamePos(lastMove.from, lastMove.to)
-                        && (hDistance == 0.0 && yDistance == 0.0 || yDistance < -Magic.GRAVITY_SPAN);
+                        && (TrigUtil.isZero(hDistance) && TrigUtil.isZero(yDistance) || yDistance < -Magic.GRAVITY_SPAN);
     }
 
     /**
@@ -1229,7 +1229,7 @@ public class CreativeFly extends Check {
                 final double maxGain = LiftOffEnvelope.NORMAL.getMinJumpGain(data.jumpAmplifier) + 0.01;
                 if (maxGain > limitV) limitV = maxGain;
             }
-            if (limitV <= 0.0 && lastMove.yDistance == 0.0) resultV = 0.1;
+            if (limitV <= 0.0 && TrigUtil.isZero(lastMove.yDistance)) resultV = 0.1;
         }
 
         return new double[] {limitV, resultV};

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -160,7 +160,7 @@ public class SurvivalFly extends Check {
         final double x = to.getX() - from.getX();
         final double y = move.yDistance;
         final double z = to.getZ() - from.getZ();
-        if (x == 0.0 && z == 0.0) {
+        if (TrigUtil.isZero(x) && TrigUtil.isZero(z)) {
             return new Distances(x, y, z, 0.0, false);
         }
         return new Distances(x, y, z, move.hDistance, true);
@@ -458,7 +458,7 @@ public class SurvivalFly extends Check {
 
         // 3: Adjust in-air counters.
         if (inAir) {
-            if (yDistance == 0.0) {
+            if (TrigUtil.isZero(yDistance)) {
                 data.sfZeroVdistRepeat ++;
             }
             else data.sfZeroVdistRepeat = 0;
@@ -619,7 +619,7 @@ public class SurvivalFly extends Check {
                     && pastMove2.setBackYDistance > pastMove3.setBackYDistance && pastMove3.setBackYDistance <= minJumpGain + jumpGainMargin
                     && pastMove3.setBackYDistance >= minJumpGain - (Magic.GRAVITY_MAX + Magic.GRAVITY_SPAN)
                     // 0: Too little dropoff
-                    || thisMove.setBackYDistance == 0.0 && lastMove.setBackYDistance < data.liftOffEnvelope.getMaxJumpHeight(data.jumpAmplifier)
+                    || TrigUtil.isZero(thisMove.setBackYDistance) && lastMove.setBackYDistance < data.liftOffEnvelope.getMaxJumpHeight(data.jumpAmplifier)
                     && pastMove2.setBackYDistance > lastMove.setBackYDistance && pastMove2.setBackYDistance - lastMove.setBackYDistance < jumpGainMargin
                     // 0: Sharp distance dropoff
                     // (Not observed nor tested though. This is just an educated guess.)
@@ -655,7 +655,7 @@ public class SurvivalFly extends Check {
         Material blockAbove = from.getTypeId(from.getBlockX(), Location.locToBlock(from.getY() + 0.1), from.getBlockZ());
 
         // Checks for no gravity when moving in a liquid
-        if (hDistanceAboveLimit <= 0.0 && yDistance == 0.0 && lastMove.yDistance == 0.0 && lastMove.toIsValid
+        if (hDistanceAboveLimit <= 0.0 && TrigUtil.isZero(yDistance) && TrigUtil.isZero(lastMove.yDistance) && lastMove.toIsValid
             && hDistance > 0.090 && lastMove.hDistance > 0.090 // Do not check lower speeds. The cheat would be purely cosmetic at that point, it wouldn't offer any advantage.
             && BlockProperties.isLiquid(to.getTypeId())
             && BlockProperties.isLiquid(from.getTypeId())
@@ -821,7 +821,7 @@ public class SurvivalFly extends Check {
                                                 thisMove, lastMove, pData, to);
             }
         } else {
-            if (cc.velocityStrictInvalidation && lastMove.hAllowedDistanceBase == 0.0 && data.hasQueuedHorVel()) {
+            if (cc.velocityStrictInvalidation && TrigUtil.isZero(lastMove.hAllowedDistanceBase) && data.hasQueuedHorVel()) {
                 data.clearAllHorVel();
                 hFreedom = 0.0;
             }
@@ -2353,7 +2353,7 @@ public class SurvivalFly extends Check {
             tags.add("ychinc");
         }
         else if (data.bunnyhopDelay < 9 && !((lastMove.touchedGround || lastMove.from.onGroundOrResetCond)
-                && lastMove.yDistance == 0D) && data.getOrUseVerticalVelocity(yDistance) == null) {
+                && TrigUtil.isZero(lastMove.yDistance)) && data.getOrUseVerticalVelocity(yDistance) == null) {
             vDistanceAboveLimit = Math.max(vDistanceAboveLimit, Math.abs(yDistance));
             tags.add("airjump");
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
@@ -32,6 +32,9 @@ import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
  */
 public class TrigUtil {
 
+    /** Epsilon for floating point comparisons. */
+    private static final double EPSILON = 1e-6;
+
     /** Used for internal calculations, no passing on, beware of nested calls. */
     private static final Vector vec1 = new Vector();
     /** Used for internal calculations, no passing on, beware of nested calls. */
@@ -468,6 +471,17 @@ public class TrigUtil {
      */
     public static int manhattan(final int x1, final int y1, final int  z1, final Block block) {
         return manhattan(x1, y1, z1, block.getX(), block.getY(), block.getZ());
+    }
+
+    /**
+     * Check if a floating point value is effectively zero.
+     *
+     * @param val
+     *            value to test
+     * @return true if |val| is below {@link #EPSILON}
+     */
+    public static boolean isZero(final double val) {
+        return Math.abs(val) < EPSILON;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add `EPSILON` constant and `isZero` helper in `TrigUtil`
- use `TrigUtil.isZero` for equality checks in `CreativeFly` and `SurvivalFly`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3d00543083298a216385e3761593

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace direct zero comparisons with epsilon-based comparisons in movement checks.

### Why are these changes being made?

Floating-point arithmetic can lead to inaccuracies; using epsilon comparisons ensures that values very close to zero are treated as zero, improving stability and precision in movement checks. This approach mitigates potential false positives in movement validation due to minute numerical discrepancies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->