### PR TITLE
Fix float comparisons flagged by SpotBugs

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
@@ -160,7 +160,7 @@ public class GodMode extends Check {
         }
         keepAlive = Math.max(keepAlive, CheckUtils.guessKeepAliveTime(player, now, maxAge, pData));
 
-        if (keepAlive != Double.MIN_VALUE && now - keepAlive > cc.godModeLagMinAge && now - keepAlive < maxAge){
+        if (keepAlive != Long.MIN_VALUE && now - keepAlive > cc.godModeLagMinAge && now - keepAlive < maxAge){
             // Assume lag.
             return false;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -153,6 +153,9 @@ import fr.neatmonster.nocheatplus.worlds.WorldFactoryArgument;
  */
 public class MovingListener extends CheckListener implements TickListener, IRemoveData, IHaveCheckType, INeedConfig, JoinLeaveListener {
 
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
+
     /** The no fall check. **/
     public final NoFall noFall = addCheck(new NoFall());
 
@@ -2578,7 +2581,10 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                     NoFall.calcReducedDamageByBlock(player, data, maxD),
                     mcAccess.getHandle().dealFallDamageFiresAnEvent().decide());
             BridgeHealth.setRawDamage(event, damageAfter);
-            if (debug) debug(player, "Adjust fall damage to: " + (damageAfter != maxD ? damageAfter : maxD));
+            if (debug) {
+                final double shown = Math.abs(damageAfter - maxD) < EPSILON ? maxD : damageAfter;
+                debug(player, "Adjust fall damage to: " + shown);
+            }
         }
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
@@ -52,6 +52,8 @@ public class MagicBunny {
     /** Divisor vs. last hDist for minimum slow down. */
     private static final double bunnyDivFriction = 160.0; // Rather in-air, blocks would differ by friction.
     private static final boolean ServerIsAtLeast1_13 = ServerVersion.compareMinecraftVersion("1.13") >= 0;
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
 
 
     /**
@@ -237,7 +239,9 @@ public class MagicBunny {
         // Bunnyhop model (singular peak up to roughly two times the allowed distance)              //
         //////////////////////////////////////////////////////////////////////////////////////////////
         // Further testing bunny spike over all sorts of speeds and attributes is necessary.
-        final double MinAccelMod = needLowerMultiplier ? 1.0274 : (!lastMove.toIsValid || lastMove.hDistance == 0.0 && lastMove.yDistance == 0.0) ? 1.11 : 1.314;
+        final double MinAccelMod = needLowerMultiplier ? 1.0274
+                : (!lastMove.toIsValid || Math.abs(lastMove.hDistance) < EPSILON && Math.abs(lastMove.yDistance) < EPSILON)
+                        ? 1.11 : 1.314;
         final double MaxAccelMod = data.momentumTick > 0 ? (data.momentumTick > 2 ? 1.76 : 1.96) : 2.15;
         final double MaxAccelMod1 = data.momentumTick > 0 ? (data.momentumTick > 2 ? 1.9 : 2.1) : 2.3;
 
@@ -265,7 +269,7 @@ public class MagicBunny {
                     // 1: Too short with head obstructed.
                     || headObstructed
                     // 1: Grounded acceleration case observed around 1.6.4; maybe drop for old servers.
-                    || (cc.sfGroundHop || yDistance == 0.0 && !lastMove.touchedGroundWorkaround && !lastMove.from.onGround)
+                    || (cc.sfGroundHop || Math.abs(yDistance) < EPSILON && !lastMove.touchedGroundWorkaround && !lastMove.from.onGround)
                     && baseSpeed > 0.0 && hDistance / baseSpeed < 1.5 && (hDistance / lastMove.hDistance < 1.35 || hDistance / baseSpeed < 1.35)
                     // 1: Landing on ground with negative yDistance left. Observed with slime blocks.
                     // Confine by typical gravity change from the previous move.
@@ -278,9 +282,9 @@ public class MagicBunny {
                     && Magic.jumpedUpSlope(data, from, 14)
                     && (
                         // 2: Keeping yDistance once or minimal change in gravity.
-                        yDistance == 0.0 
+                        Math.abs(yDistance) < EPSILON
                         && (
-                            lastMove.yDistance - yDistance == 0.0 
+                            Math.abs(lastMove.yDistance - yDistance) < EPSILON
                             || Math.abs(lastMove.yDistance - yDistance) > 0.0 && Math.abs(lastMove.yDistance - yDistance) < Magic.GRAVITY_ODD / 2.0
                         )
                         // 2: Change to descending phase 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -84,6 +84,8 @@ public class SurvivalFly extends Check {
     private final boolean ServerIsAtLeast1_9 = ServerVersion.compareMinecraftVersion("1.9") >= 0;
     private final boolean ServerIsAtLeast1_10 = ServerVersion.compareMinecraftVersion("1.10") >= 0;
     private final boolean ServerIsAtLeast1_13 = ServerVersion.compareMinecraftVersion("1.13") >= 0;
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
     /** Flag to indicate whether the buffer should be used for this move (only work inside setAllowedhDist). */
     private boolean bufferUse;
     /** To join some tags with moving check violations. */
@@ -670,13 +672,13 @@ public class SurvivalFly extends Check {
         // Checks for micro y deltas when moving above liquid.
         if (blockUnder != null && BlockProperties.isLiquid(blockUnder) && BlockProperties.isAir(blockAbove)) {
 
-            if (hDistanceAboveLimit <= 0.0
-                && hDistance > 0.11 && yDistance <= LiftOffEnvelope.LIMIT_LIQUID.getMaxJumpGain(0.0)
-                && !toOnGround && !fromOnGround
-                && lastMove.toIsValid && lastMove.yDistance == yDistance
-                || lastMove.yDistance == yDistance * -1 && lastMove.yDistance != 0.0
-                && !from.isHeadObstructed() && !to.isHeadObstructed()
-                && !Bridge1_13.isSwimming(player)) {
+                if (hDistanceAboveLimit <= 0.0
+                    && hDistance > 0.11 && yDistance <= LiftOffEnvelope.LIMIT_LIQUID.getMaxJumpGain(0.0)
+                    && !toOnGround && !fromOnGround
+                    && lastMove.toIsValid && Math.abs(lastMove.yDistance - yDistance) < EPSILON
+                    || Math.abs(lastMove.yDistance + yDistance) < EPSILON && lastMove.yDistance != 0.0
+                    && !from.isHeadObstructed() && !to.isHeadObstructed()
+                    && !Bridge1_13.isSwimming(player)) {
 
                 // Prevent being flagged if a player transitions from a block to water and the player falls into the water.
                 if (!(yDistance < 0.0 && yDistance != 0.0 && lastMove.yDistance < 0.0 && lastMove.yDistance != 0.0)) {
@@ -1300,7 +1302,7 @@ public class SurvivalFly extends Check {
         if (move == null) {
             return isMovingBackwards ? 1.0 : 1.325;
         }
-        return isMovingBackwards ? 1.0 : move.yDistance == 0.5 ? 1.85 : 1.325;
+        return isMovingBackwards ? 1.0 : Math.abs(move.yDistance - 0.5) < EPSILON ? 1.85 : 1.325;
     }
 
     private static double calcModHopSprint(final MovingData data, final PlayerMoveData move, final PlayerLocation to) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
@@ -59,6 +59,9 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
  */
 public class VehicleEnvelope extends Check {
 
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
+
     /**
      * Check specific details for re-use.
      * 
@@ -476,8 +479,8 @@ public class VehicleEnvelope extends Check {
             if (blockUnder != null && blockAbove != null && BlockProperties.isAir(blockAbove)
                 && BlockProperties.isLiquid(blockUnder) && !(strider != null && strider.isAssignableFrom(vehicle.getClass()))) {
                 if (thisMove.hDistance > 0.11D && thisMove.yDistance <= 0.1D && !thisMove.to.onGround && !thisMove.from.onGround
-                    && firstPastMove.valid && (firstPastMove.yDistance == thisMove.yDistance
-                    || firstPastMove.yDistance == thisMove.yDistance * -1)
+                    && firstPastMove.valid && (Math.abs(firstPastMove.yDistance - thisMove.yDistance) < EPSILON
+                    || Math.abs(firstPastMove.yDistance + thisMove.yDistance) < EPSILON)
                     && firstPastMove.yDistance != 0D
                     && !thisMove.headObstructed) {
                     if (!(thisMove.yDistance < 0 && thisMove.yDistance != 0 && firstPastMove.yDistance < 0 && firstPastMove.yDistance != 0)) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
@@ -34,6 +34,9 @@ public class LegacyBlocks {
     private static final BlockTrapDoor TRAPDOOR = new BlockTrapDoor();
     private static final Map<Material, Block> blocks = init(); // new HashMap<>(); //private final Map<Material, Block> block;
 
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
+
     //public LegacyBlocks() {
     //    blocks = init();
     //}
@@ -502,7 +505,7 @@ public class LegacyBlocks {
             final double tdx = tmaxX - tminX;
             final double tdy = tmaxY - tminY;
             final double tdz = tmaxZ - tminZ;
-            return dx == tdx && dy == tdy && dz == tdz;
+            return Math.abs(dx - tdx) < EPSILON && Math.abs(dy - tdy) < EPSILON && Math.abs(dz - tdz) < EPSILON;
         }
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/RayTracing.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/RayTracing.java
@@ -23,6 +23,9 @@ import org.bukkit.Location;
  */
 public abstract class RayTracing implements ICollideBlocks {
 
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
+
     //	/** End point coordinates (from, to) */
     protected double x0, y0, z0; // x1, y1, z1;
 
@@ -197,15 +200,15 @@ public abstract class RayTracing implements ICollideBlocks {
             // Determine transitions, per axis.
             transitions = 0;
             transX = transY = transZ = false;
-            if (tX == tMin && blockX != endBlockX && dX != 0.0) {
+            if (Math.abs(tX - tMin) < EPSILON && blockX != endBlockX && dX != 0.0) {
                 transX = true;
                 transitions ++;
             }
-            if (tY == tMin && blockY != endBlockY && dY != 0.0) {
+            if (Math.abs(tY - tMin) < EPSILON && blockY != endBlockY && dY != 0.0) {
                 transY = true;
                 transitions ++;
             }
-            if (tZ == tMin && blockZ != endBlockZ && dZ != 0.0) {
+            if (Math.abs(tZ - tMin) < EPSILON && blockZ != endBlockZ && dZ != 0.0) {
                 transZ = true;
                 transitions ++;
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -81,6 +81,9 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockCache.IBlockCacheNode;
 @SuppressWarnings("deprecation")
 public class BlockProperties {
 
+    /** Tolerance for floating point comparisons. */
+    private static final double EPSILON = 1.0E-6;
+
     /**
      * The Enum ToolType.
      *
@@ -3139,7 +3142,7 @@ public class BlockProperties {
                             continue;
                         }
                         // Hitting the max-edges (if allowed).
-                        if (minX == 1.0 + x || minY == LIQUID_HEIGHT_LOWERED + y || minZ == 1.0 + z) {
+                        if (Math.abs(minX - (1.0 + x)) < EPSILON || Math.abs(minY - (LIQUID_HEIGHT_LOWERED + y)) < EPSILON || Math.abs(minZ - (1.0 + z)) < EPSILON) {
                             continue;
                         }
                         return true;


### PR DESCRIPTION
## Summary
- add `EPSILON` constants for movement check classes
- replace `==` comparisons with tolerance-based checks
- handle `keepAlive` comparison with `Long.MIN_VALUE`

## Testing
- `mvn -q -e -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c08fef08329b4e79ea09a39ea1a