### PR TITLE
Remove unused distance variables

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -675,12 +675,12 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         Location newTo = null;
         final PlayerMoveData thisMove = data.playerMoves.getCurrentMove();
-        final double xDistance = to.getX() - from.getX();
-        final double zDistance = to.getZ() - from.getZ();
         final String playerName = player.getName(); // Could switch to UUID here (needs more changes).
         final long time = System.currentTimeMillis();
         final PlayerMoveData lastMove = data.playerMoves.getFirstPastMove();
         data.resetTeleported();
+        // Horizontal distances are calculated on-demand in dedicated handlers
+        // (e.g. checkPastStateHorizontalPush).
 
         debugOutput(player, moveInfo, cc, debug);
         


### PR DESCRIPTION
## Summary
- trim unused `xDistance` and `zDistance` declarations
- explain that horizontal distances are computed in dedicated handlers

## Testing
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_b_685c3c07a8808329bb5dcaae69f258b3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove unused `xDistance` and `zDistance` variables from the `checkPlayerMove` method in `MovingListener.java`.

### Why are these changes being made?

These variables were redundant as horizontal distances are calculated on-demand in dedicated handlers, streamlining the code and improving maintainability without impacting functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->