### PR TITLE
Add unmodifiable views for block tracker and event registry

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -109,6 +109,7 @@ import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.Direction;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
 import fr.neatmonster.nocheatplus.components.data.ICheckData;
@@ -198,7 +199,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
     private IGenericInstanceHandle<IAttributeAccess> attributeAccess = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstanceHandle(IAttributeAccess.class);
 
-    private final BlockChangeTracker blockChangeTracker;
+    private final IBlockChangeTracker blockChangeTracker;
 
     /** Statistics / debugging counters. */
     private final Counters counters = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(Counters.class);
@@ -1106,7 +1107,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 }
                 if (verticalBounce == BounceType.NO_BOUNCE && useBlockChangeTracker && BounceUtil
                         .checkPastStateBounceDescend(player, pFrom, pTo, thisMove, lastMove, tick, data, cc,
-                                blockChangeTracker) != BounceType.NO_BOUNCE) {
+                                (BlockChangeTracker) blockChangeTracker) != BounceType.NO_BOUNCE) {
                     checkNf = false;
                 }
             }
@@ -1115,7 +1116,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                     && BounceUtil.onPreparedBounceSupport(player, from, to, thisMove, lastMove, tick, data))
                     || useBlockChangeTracker && thisMove.yDistance <= 1.515) {
                 verticalBounce = BounceUtil.checkPastStateBounceAscend(player, pFrom, pTo, thisMove, lastMove, tick,
-                        pData, this, data, cc, blockChangeTracker);
+                        pData, this, data, cc, (BlockChangeTracker) blockChangeTracker);
                 if (verticalBounce != BounceType.NO_BOUNCE) {
                     checkNf = false;
                 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -46,6 +46,7 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.BridgeEnchant;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.components.modifier.IAttributeAccess;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
@@ -74,7 +75,7 @@ public class CreativeFly extends Check {
      * </ul>
      */
     private final List<String> tags = new LinkedList<String>();
-    private final BlockChangeTracker blockChangeTracker;
+    private final IBlockChangeTracker blockChangeTracker;
     private IGenericInstanceHandle<IAttributeAccess> attributeAccess = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstanceHandle(IAttributeAccess.class);
     /** Default result for invalid elytra handling parameters. */
     private static final double[] INVALID_ELYTRA_RESULT = new double[] {Double.NaN, Double.NaN};
@@ -248,7 +249,7 @@ public class CreativeFly extends Check {
                 }
             } else if (LostGround.lostGround(player, from, to, hDistance, yDistance, sprinting,
                     lastMove, data, cc,
-                    useBlockChangeTracker ? blockChangeTracker : null, tags)) {
+                    useBlockChangeTracker ? (BlockChangeTracker) blockChangeTracker : null, tags)) {
                 return true;
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
@@ -28,6 +28,7 @@ import fr.neatmonster.nocheatplus.checks.ViolationData;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.collision.Axis;
 import fr.neatmonster.nocheatplus.utilities.collision.ICollidePassable;
@@ -62,7 +63,7 @@ public class Passable extends Check {
     }
 
     private final ICollidePassable rayTracing = new PassableAxisTracing();
-    private final BlockChangeTracker blockTracker;
+    private final IBlockChangeTracker blockTracker;
 
     public Passable() {
         super(CheckType.MOVING_PASSABLE);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -57,6 +57,7 @@ import fr.neatmonster.nocheatplus.compat.BridgePotionEffect;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.Direction;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.components.modifier.IAttributeAccess;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
 import fr.neatmonster.nocheatplus.logging.Streams;
@@ -92,7 +93,7 @@ public class SurvivalFly extends Check {
     private final Set<String> reallySneaking = new HashSet<String>(30);
     /** For temporary use: LocUtil.clone before passing deeply, call setWorld(null) after use. */
     private final Location useLoc = new Location(null, 0, 0, 0);
-    private final BlockChangeTracker blockChangeTracker;
+    private final IBlockChangeTracker blockChangeTracker;
     private final AuxMoving aux = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(AuxMoving.class);
     private IGenericInstanceHandle<IAttributeAccess> attributeAccess = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstanceHandle(IAttributeAccess.class);
     //private final Plugin plugin = Bukkit.getPluginManager().getPlugin("NoCheatPlus");
@@ -214,7 +215,7 @@ public class SurvivalFly extends Check {
         }
         if (isSamePos) {
             if (useBlockChangeTracker && from.isOnGroundOpportune(cc.yOnGround, 0L,
-                    blockChangeTracker, data.blockChangeRef, tick)) {
+                    (BlockChangeTracker) blockChangeTracker, data.blockChangeRef, tick)) {
                 tags.add("pastground_from");
                 return true;
             }
@@ -226,7 +227,7 @@ public class SurvivalFly extends Check {
         }
         return LostGround.lostGround(player, from, to, hDistance, yDistance, sprinting,
                 lastMove, data, cc,
-                useBlockChangeTracker ? blockChangeTracker : null, tags);
+                useBlockChangeTracker ? (BlockChangeTracker) blockChangeTracker : null, tags);
     }
 
     /** Validate player movement parameters and log if invalid. */
@@ -850,7 +851,7 @@ public class SurvivalFly extends Check {
                                          final PlayerMoveData thisMove, int tick,
                                          final MovingData data, final MovingConfig cc) {
 
-        if (to.isOnGroundOpportune(cc.yOnGround, 0L, blockChangeTracker, data.blockChangeRef, tick)) {
+        if (to.isOnGroundOpportune(cc.yOnGround, 0L, (BlockChangeTracker) blockChangeTracker, data.blockChangeRef, tick)) {
             tags.add("pastground_to");
             return true;
         }
@@ -1225,7 +1226,7 @@ public class SurvivalFly extends Check {
                  * (Full blocks: slightly more possible, ending up just above
                  * the block. Bounce allows other end positions.)
                  */
-                if (from.matchBlockChange(blockChangeTracker, data.blockChangeRef, Direction.Y_POS, Math.min(yDistance, 1.0))) {
+                if (from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef, Direction.Y_POS, Math.min(yDistance, 1.0))) {
                     if (yDistance > 1.0) {
                         //
                         //                        final BlockChangeEntry entry = blockChangeTracker.getBlockChangeEntryMatchFlags(data.blockChangeRef,
@@ -1268,7 +1269,7 @@ public class SurvivalFly extends Check {
         }
         // Push (/pull) down.
         else if (yDistance < 0.0 && yDistance >= -1.0) {
-            if (from.matchBlockChange(blockChangeTracker, data.blockChangeRef, Direction.Y_NEG, -yDistance)) {
+            if (from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef, Direction.Y_NEG, -yDistance)) {
                 tags.add("blkmv_y_neg");
                 final double maxDistYNeg = yDistance; // from.getY() - from.getBlockY();
                 return new double[]{maxDistYNeg, 0.0};
@@ -2621,13 +2622,13 @@ public class SurvivalFly extends Check {
             final double xDistance = to.getX() - from.getX();
             final double zDistance = to.getZ() - from.getZ();
             if (Math.abs(xDistance) > 0.485 && Math.abs(xDistance) < 1.025
-                && from.matchBlockChange(blockChangeTracker, data.blockChangeRef,
+                && from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef,
                         xDistance < 0 ? Direction.X_NEG : Direction.X_POS, 0.05)) {
                 hAllowedDistance = thisMove.hDistance; // MAGIC
                 hDistanceAboveLimit = 0.0;
             }
             else if (Math.abs(zDistance) > 0.485 && Math.abs(zDistance) < 1.025
-                    && from.matchBlockChange(blockChangeTracker, data.blockChangeRef,
+                    && from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef,
                         zDistance < 0 ? Direction.Z_NEG : Direction.Z_POS, 0.05)) {
                 hAllowedDistance = thisMove.hDistance; // MAGIC
                 hDistanceAboveLimit = 0.0;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/BlockChangeTracker.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/BlockChangeTracker.java
@@ -64,7 +64,7 @@ import fr.neatmonster.nocheatplus.utilities.ds.map.CoordHash;
  * @author asofold
  *
  */
-public class BlockChangeTracker {
+public class BlockChangeTracker implements IBlockChangeTracker {
 
     public static enum Direction {
         NONE(BlockFace.SELF),

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/IBlockChangeTracker.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/IBlockChangeTracker.java
@@ -1,0 +1,29 @@
+package fr.neatmonster.nocheatplus.compat.blocks.changetracker;
+
+import java.util.UUID;
+
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+import fr.neatmonster.nocheatplus.components.location.IGetPosition;
+
+public interface IBlockChangeTracker {
+    BlockChangeEntry getBlockChangeEntry(BlockChangeReference ref, int tick, UUID worldId,
+                                         int x, int y, int z, BlockChangeTracker.Direction direction);
+
+    BlockChangeEntry getBlockChangeEntryMatchFlags(BlockChangeReference ref, int tick, UUID worldId,
+                                                   int x, int y, int z, BlockChangeTracker.Direction direction,
+                                                   long matchFlags);
+
+    boolean hasActivityShuffled(UUID worldId, IGetPosition pos1, IGetPosition pos2, double margin);
+
+    boolean hasActivity(UUID worldId, int minX, int minY, int minZ,
+                        int maxX, int maxY, int maxZ);
+
+    boolean hasActivityShuffled(UUID worldId, double x1, double y1, double z1,
+                                double x2, double y2, double z2, double margin);
+
+    boolean isOnGround(BlockCache blockCache, BlockChangeReference ref, int tick, UUID worldId,
+                       double minX, double minY, double minZ,
+                       double maxX, double maxY, double maxZ,
+                       long ignoreFlags);
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/UnmodifiableBlockChangeTracker.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/UnmodifiableBlockChangeTracker.java
@@ -1,0 +1,52 @@
+package fr.neatmonster.nocheatplus.compat.blocks.changetracker;
+
+import java.util.UUID;
+
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
+import fr.neatmonster.nocheatplus.components.location.IGetPosition;
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+
+public class UnmodifiableBlockChangeTracker implements IBlockChangeTracker {
+
+    private final BlockChangeTracker delegate;
+
+    public UnmodifiableBlockChangeTracker(BlockChangeTracker delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BlockChangeEntry getBlockChangeEntry(BlockChangeReference ref, int tick, UUID worldId,
+                                                int x, int y, int z, BlockChangeTracker.Direction direction) {
+        return delegate.getBlockChangeEntry(ref, tick, worldId, x, y, z, direction);
+    }
+
+    @Override
+    public BlockChangeEntry getBlockChangeEntryMatchFlags(BlockChangeReference ref, int tick, UUID worldId,
+                                                          int x, int y, int z, BlockChangeTracker.Direction direction,
+                                                          long matchFlags) {
+        return delegate.getBlockChangeEntryMatchFlags(ref, tick, worldId, x, y, z, direction, matchFlags);
+    }
+
+    @Override
+    public boolean hasActivityShuffled(UUID worldId, IGetPosition pos1, IGetPosition pos2, double margin) {
+        return delegate.hasActivityShuffled(worldId, pos1, pos2, margin);
+    }
+
+    @Override
+    public boolean hasActivity(UUID worldId, int minX, int minY, int minZ, int maxX, int maxY, int maxZ) {
+        return delegate.hasActivity(worldId, minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    @Override
+    public boolean hasActivityShuffled(UUID worldId, double x1, double y1, double z1, double x2, double y2,
+                                       double z2, double margin) {
+        return delegate.hasActivityShuffled(worldId, x1, y1, z1, x2, y2, z2, margin);
+    }
+
+    @Override
+    public boolean isOnGround(BlockCache blockCache, BlockChangeReference ref, int tick, UUID worldId,
+                              double minX, double minY, double minZ, double maxX, double maxY, double maxZ,
+                              long ignoreFlags) {
+        return delegate.isOnGround(blockCache, ref, tick, worldId, minX, minY, minZ, maxX, maxY, maxZ, ignoreFlags);
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/NoCheatPlusAPI.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/NoCheatPlusAPI.java
@@ -19,12 +19,12 @@ import java.util.Map;
 import java.util.Set;
 
 import fr.neatmonster.nocheatplus.actions.ActionFactoryFactory;
-import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.components.registry.ComponentRegistry;
 import fr.neatmonster.nocheatplus.components.registry.ComponentRegistryProvider;
 import fr.neatmonster.nocheatplus.components.registry.GenericInstanceRegistry;
 import fr.neatmonster.nocheatplus.components.registry.setup.RegistrationContext;
-import fr.neatmonster.nocheatplus.event.mini.EventRegistryBukkit;
+import fr.neatmonster.nocheatplus.event.mini.IEventRegistry;
 import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.permissions.PermissionRegistry;
 import fr.neatmonster.nocheatplus.players.IPlayerDataManager;
@@ -185,7 +185,7 @@ public interface NoCheatPlusAPI extends ComponentRegistry<Object>, ComponentRegi
      * Get the block change tracker (pistons, other).
      * @return
      */
-    public BlockChangeTracker getBlockChangeTracker();
+    public IBlockChangeTracker getBlockChangeTracker();
 
     /**
      * Get the registry to register events with the
@@ -200,7 +200,7 @@ public interface NoCheatPlusAPI extends ComponentRegistry<Object>, ComponentRegi
      * 
      * @return
      */
-    public EventRegistryBukkit getEventRegistry();
+    public IEventRegistry getEventRegistry();
 
     /**
      * Get the internal permission registry, holding internal id mappings and

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/EventRegistryBukkit.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/EventRegistryBukkit.java
@@ -31,6 +31,7 @@ import org.bukkit.plugin.Plugin;
 import fr.neatmonster.nocheatplus.components.registry.feature.ComponentWithName;
 import fr.neatmonster.nocheatplus.components.registry.order.RegistrationOrder;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+import fr.neatmonster.nocheatplus.event.mini.IEventRegistry;
 
 /**
  * A MultiListenerRegistry that registers Bukkit types with a Spigot/CraftBukkit
@@ -57,7 +58,7 @@ import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
  * @author asofold
  *
  */
-public class EventRegistryBukkit extends MultiListenerRegistry<Event, EventPriority> {
+public class EventRegistryBukkit extends MultiListenerRegistry<Event, EventPriority> implements IEventRegistry {
 
     /**
      * Node for events that implement the Cancellable interface (Bukkit).

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/EventRegistryBukkitView.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/EventRegistryBukkitView.java
@@ -1,0 +1,46 @@
+package fr.neatmonster.nocheatplus.event.mini;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+import fr.neatmonster.nocheatplus.components.registry.order.RegistrationOrder;
+
+public class EventRegistryBukkitView implements IEventRegistry {
+
+    private final EventRegistryBukkit delegate;
+
+    public EventRegistryBukkitView(EventRegistryBukkit delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void register(Listener listener) {
+        delegate.register(listener);
+    }
+
+    @Override
+    public void register(Listener listener, RegistrationOrder order) {
+        delegate.register(listener, order);
+    }
+
+    @Override
+    public void register(Listener listener, Plugin plugin) {
+        delegate.register(listener, plugin);
+    }
+
+    @Override
+    public void register(Listener listener, RegistrationOrder order, Plugin plugin) {
+        delegate.register(listener, order, plugin);
+    }
+
+    @Override
+    public <E extends Event> void register(Class<E> eventClass, MiniListener<E> listener) {
+        delegate.register(eventClass, listener);
+    }
+
+    @Override
+    public <E extends Event> void register(MiniListener<E> listener) {
+        delegate.register(listener);
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/IEventRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/IEventRegistry.java
@@ -1,0 +1,16 @@
+package fr.neatmonster.nocheatplus.event.mini;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+import fr.neatmonster.nocheatplus.components.registry.order.RegistrationOrder;
+
+public interface IEventRegistry {
+    void register(Listener listener);
+    void register(Listener listener, RegistrationOrder order);
+    void register(Listener listener, Plugin plugin);
+    void register(Listener listener, RegistrationOrder order, Plugin plugin);
+    <E extends Event> void register(Class<E> eventClass, MiniListener<E> listener);
+    <E extends Event> void register(MiniListener<E> listener);
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/ICollidePassable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/ICollidePassable.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeReference;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 
@@ -46,7 +47,7 @@ public interface ICollidePassable extends ICollideBlocks, ISetMargins {
      * @param worldId
      *            the UUID of the world this takes place in.
      */
-    public void setBlockChangeTracker(BlockChangeTracker blockChangeTracker, 
+    public void setBlockChangeTracker(IBlockChangeTracker blockChangeTracker,
             BlockChangeReference blockChangeReference, int tick, UUID worldId);
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableAxisTracing.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableAxisTracing.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeReference;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
@@ -26,7 +27,7 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 public class PassableAxisTracing extends AxisTracing implements ICollidePassable {
 
     private BlockCache blockCache;
-    private BlockChangeTracker blockChangeTracker = null;
+    private IBlockChangeTracker blockChangeTracker = null;
     private BlockChangeReference blockChangeRef = null;
     private int tick;
     private UUID worldId;
@@ -45,7 +46,7 @@ public class PassableAxisTracing extends AxisTracing implements ICollidePassable
     }
 
     @Override
-    public void setBlockChangeTracker(BlockChangeTracker blockChangeTracker, 
+    public void setBlockChangeTracker(IBlockChangeTracker blockChangeTracker,
             BlockChangeReference blockChangeReference, int tick, UUID worldId) {
         this.blockChangeTracker = blockChangeTracker;
         this.blockChangeRef = blockChangeReference;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableRayTracing.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableRayTracing.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeReference;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -38,7 +39,7 @@ public class PassableRayTracing extends RayTracing implements ICollidePassable {
     }
 
     @Override
-    public void setBlockChangeTracker(BlockChangeTracker blockChangeTracker,
+    public void setBlockChangeTracker(IBlockChangeTracker blockChangeTracker,
             BlockChangeReference blockChangeReference, int tick, UUID worldId) {
         // (Not supported.)
     }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -76,6 +76,8 @@ import fr.neatmonster.nocheatplus.compat.Folia;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeListener;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.UnmodifiableBlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.meta.BridgeCrossPluginLoader;
 import fr.neatmonster.nocheatplus.compat.registry.AttributeAccessFactory;
 import fr.neatmonster.nocheatplus.compat.registry.DefaultComponentFactory;
@@ -108,6 +110,8 @@ import fr.neatmonster.nocheatplus.config.ConfPaths;
 import fr.neatmonster.nocheatplus.config.ConfigFile;
 import fr.neatmonster.nocheatplus.config.ConfigManager;
 import fr.neatmonster.nocheatplus.event.mini.EventRegistryBukkit;
+import fr.neatmonster.nocheatplus.event.mini.IEventRegistry;
+import fr.neatmonster.nocheatplus.event.mini.EventRegistryBukkitView;
 import fr.neatmonster.nocheatplus.event.mini.MiniListener;
 import fr.neatmonster.nocheatplus.hooks.ExemptionSettings;
 import fr.neatmonster.nocheatplus.hooks.NCPExemptionManager;
@@ -1560,13 +1564,13 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     }
 
     @Override
-    public BlockChangeTracker getBlockChangeTracker() {
-        return blockChangeTracker;
+    public IBlockChangeTracker getBlockChangeTracker() {
+        return new UnmodifiableBlockChangeTracker(blockChangeTracker);
     }
 
     @Override
-    public EventRegistryBukkit getEventRegistry() {
-        return eventRegistry;
+    public IEventRegistry getEventRegistry() {
+        return new EventRegistryBukkitView(eventRegistry);
     }
 
     @Override

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/PluginTests.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/PluginTests.java
@@ -25,8 +25,10 @@ import fr.neatmonster.nocheatplus.actions.ActionFactory;
 import fr.neatmonster.nocheatplus.actions.ActionFactoryFactory;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.bukkit.MCAccessBukkit;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
+import fr.neatmonster.nocheatplus.event.mini.IEventRegistry;
 import fr.neatmonster.nocheatplus.components.registry.ComponentRegistry;
 import fr.neatmonster.nocheatplus.components.registry.DefaultGenericInstanceRegistry;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
@@ -198,12 +200,12 @@ public class PluginTests {
         }
 
         @Override
-        public BlockChangeTracker getBlockChangeTracker() {
+        public IBlockChangeTracker getBlockChangeTracker() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public EventRegistryBukkit getEventRegistry() {
+        public IEventRegistry getEventRegistry() {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## Summary
- introduce `IBlockChangeTracker` and `IEventRegistry` interfaces
- add `UnmodifiableBlockChangeTracker` and `EventRegistryBukkitView` wrappers
- update `NoCheatPlusAPI` and plugin getters to return the new views
- adjust listeners and utilities to use the interfaces
- run maven verify to ensure tests and static analysis pass

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3c09e7a48329bffcd8fd13be0587