### PR TITLE
Fix lock handling with try-finally

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetData.java
@@ -127,13 +127,16 @@ public class NetData extends ACheckData {
     public boolean addFlyingQueue(final DataPacketFlying packetData) {
         boolean res = false;
         lock.lock();
-        packetData.setSequence(++maxSequence);
-        flyingQueue.addFirst(packetData);
-        if (flyingQueue.size() > flyingQueueMaxSize) {
-            flyingQueue.removeLast();
-            res = true;
+        try {
+            packetData.setSequence(++maxSequence);
+            flyingQueue.addFirst(packetData);
+            if (flyingQueue.size() > flyingQueueMaxSize) {
+                flyingQueue.removeLast();
+                res = true;
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
         return res;
     }
 
@@ -142,8 +145,11 @@ public class NetData extends ACheckData {
      */
     public void clearFlyingQueue() {
         lock.lock();
-        flyingQueue.clear();
-        lock.unlock();
+        try {
+            flyingQueue.clear();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -153,13 +159,15 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying[] copyFlyingQueue() {
         lock.lock();
-        /*
-         * Packet inversion is acute on 1.11.2 (dig is processed
-         * before flying). Synchronizing with the current position might be added.
-         */
-        final DataPacketFlying[] out = flyingQueue.toArray(new DataPacketFlying[flyingQueue.size()]);
-        lock.unlock();
-        return out;
+        try {
+            /*
+             * Packet inversion is acute on 1.11.2 (dig is processed
+             * before flying). Synchronizing with the current position might be added.
+             */
+            return flyingQueue.toArray(new DataPacketFlying[flyingQueue.size()]);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -169,9 +177,11 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying getCurrentFlyingPacket() {
         lock.lock();
-        final DataPacketFlying latest = flyingQueue.isEmpty() ? null : flyingQueue.getFirst();
-        lock.unlock();
-        return latest;
+        try {
+            return flyingQueue.isEmpty() ? null : flyingQueue.getFirst();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -181,9 +191,11 @@ public class NetData extends ACheckData {
      */
     public DataPacketFlying getPastFlyingPacketInQueue(final int index) {
         lock.lock();
-        final DataPacketFlying packet = flyingQueue.isEmpty() ? null : flyingQueue.get(index);
-        lock.unlock();
-        return packet;
+        try {
+            return flyingQueue.isEmpty() ? null : flyingQueue.get(index);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/model/TeleportQueue.java
@@ -111,9 +111,12 @@ public class TeleportQueue {
      */
     public void onTeleportEvent(final double x, final double y, final double z, final float yaw, final float pitch) {
         lock.lock();
-        lastAck = null;
-        expectOutgoing = new DataLocation(x, y, z, yaw, pitch);
-        lock.unlock();
+        try {
+            lastAck = null;
+            expectOutgoing = new DataLocation(x, y, z, yaw, pitch);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -134,53 +137,56 @@ public class TeleportQueue {
         CountableLocation res = null;
         final long time = System.currentTimeMillis();
         lock.lock();
-        lastAckReference.lastOutgoingId = teleportId;
-        if (lastAckReference.maxConfirmedId > lastAckReference.lastOutgoingId) {
-            lastAckReference.maxConfirmedId = Integer.MIN_VALUE; // Some data loss accepted here.
-        }
-        // Only register this location, if it matches the location from a Bukkit event.
-        if (expectOutgoing != null) {
-            if (expectOutgoing.isSameLocation(x, y, z, yaw, pitch)) {
-                // Add to queue.
-                if (!expectIncoming.isEmpty()) {
-                    // Lazy expiration check.
-                    final Iterator<CountableLocation> it = expectIncoming.iterator();
-                    while (it.hasNext()) {
-                        final CountableLocation ref = it.next();
-                        if (time < ref.time) {
-                            // Time ran backwards. Force keep entries.
-                            ref.time = time;
-                        }
-                        else if (time - maxAge > ref.time) {
-                            it.remove();
-                        } else {
-                            break;
-                        }
-                    }
-                    if (!expectIncoming.isEmpty()) {
-                        final CountableLocation last = expectIncoming.getLast();
-                        if (last.isSameLocation(x, y, z, yaw, pitch)) {
-                            last.time = time;
-                            last.count ++;
-                            last.teleportId = teleportId;
-                            res = last;
-                        }
-                    }
-                }
-                // Add a new entry, if not merged with last.
-                if (res == null) {
-                    res = new CountableLocation(x, y, z, yaw, pitch, 1, time, teleportId);
-                    expectIncoming.addLast(res);
-                    // Don't exceed maxQueueSize.
-                    if (expectIncoming.size() > maxQueueSize) {
-                        expectIncoming.removeFirst();
-                    }
-                }
+        try {
+            lastAckReference.lastOutgoingId = teleportId;
+            if (lastAckReference.maxConfirmedId > lastAckReference.lastOutgoingId) {
+                lastAckReference.maxConfirmedId = Integer.MIN_VALUE; // Some data loss accepted here.
             }
-            // Reset in any case.
-            expectOutgoing = null;
+            // Only register this location, if it matches the location from a Bukkit event.
+            if (expectOutgoing != null) {
+                if (expectOutgoing.isSameLocation(x, y, z, yaw, pitch)) {
+                    // Add to queue.
+                    if (!expectIncoming.isEmpty()) {
+                        // Lazy expiration check.
+                        final Iterator<CountableLocation> it = expectIncoming.iterator();
+                        while (it.hasNext()) {
+                            final CountableLocation ref = it.next();
+                            if (time < ref.time) {
+                                // Time ran backwards. Force keep entries.
+                                ref.time = time;
+                            }
+                            else if (time - maxAge > ref.time) {
+                                it.remove();
+                            } else {
+                                break;
+                            }
+                        }
+                        if (!expectIncoming.isEmpty()) {
+                            final CountableLocation last = expectIncoming.getLast();
+                            if (last.isSameLocation(x, y, z, yaw, pitch)) {
+                                last.time = time;
+                                last.count ++;
+                                last.teleportId = teleportId;
+                                res = last;
+                            }
+                        }
+                    }
+                    // Add a new entry, if not merged with last.
+                    if (res == null) {
+                        res = new CountableLocation(x, y, z, yaw, pitch, 1, time, teleportId);
+                        expectIncoming.addLast(res);
+                        // Don't exceed maxQueueSize.
+                        if (expectIncoming.size() > maxQueueSize) {
+                            expectIncoming.removeFirst();
+                        }
+                    }
+                }
+                // Reset in any case.
+                expectOutgoing = null;
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
         return res;
     }
 
@@ -203,44 +209,46 @@ public class TeleportQueue {
             return AlmostBoolean.NO;
         }
         lock.lock();
-        if (teleportId == lastAckReference.lastOutgoingId) {
-            lastAckReference.maxConfirmedId = teleportId;
-            // Abort here for efficiency.
-            expectIncoming.clear();
-            lock.unlock();
-            return AlmostBoolean.YES;
-        }
-        AlmostBoolean ackState = AlmostBoolean.NO;
-        for (CountableLocation ref : expectIncoming) {
-            // No expiration checks here.
-            if (ref.teleportId == teleportId) {
-                // Match an outdated id.
-                // Remove all preceding older entries and this one.
-                while (ref != expectIncoming.getFirst()) {
+        try {
+            if (teleportId == lastAckReference.lastOutgoingId) {
+                lastAckReference.maxConfirmedId = teleportId;
+                // Abort here for efficiency.
+                expectIncoming.clear();
+                return AlmostBoolean.YES;
+            }
+            AlmostBoolean ackState = AlmostBoolean.NO;
+            for (CountableLocation ref : expectIncoming) {
+                // No expiration checks here.
+                if (ref.teleportId == teleportId) {
+                    // Match an outdated id.
+                    // Remove all preceding older entries and this one.
+                    while (ref != expectIncoming.getFirst()) {
+                        expectIncoming.removeFirst();
+                    }
                     expectIncoming.removeFirst();
+                    // The count doesn't count anymore.
+                    ref.count = 0;
+                    ackState = AlmostBoolean.YES;
+                    break;
                 }
-                expectIncoming.removeFirst();
-                // The count doesn't count anymore.
-                ref.count = 0;
-                ackState = AlmostBoolean.YES;
-                break;
             }
-        }
-        // Update lastAckReference only if within the safe area.
-        if (teleportId < lastAckReference.lastOutgoingId 
-                && teleportId > lastAckReference.maxConfirmedId) {
-            // Allow update.
-            lastAckReference.maxConfirmedId = teleportId;
-            if (ackState == AlmostBoolean.NO) {
-                // Adjust to maybe, as long as the id is increasing within unique range.
-                ackState = AlmostBoolean.MAYBE;
+            // Update lastAckReference only if within the safe area.
+            if (teleportId < lastAckReference.lastOutgoingId
+                    && teleportId > lastAckReference.maxConfirmedId) {
+                // Allow update.
+                lastAckReference.maxConfirmedId = teleportId;
+                if (ackState == AlmostBoolean.NO) {
+                    // Adjust to maybe, as long as the id is increasing within unique range.
+                    ackState = AlmostBoolean.MAYBE;
+                }
             }
+            else {
+                lastAckReference.maxConfirmedId = Integer.MIN_VALUE;
+            }
+            return ackState;
+        } finally {
+            lock.unlock();
         }
-        else {
-            lastAckReference.maxConfirmedId = Integer.MIN_VALUE;
-        }
-        lock.unlock();
-        return ackState;
     }
 
     /**
@@ -262,14 +270,14 @@ public class TeleportQueue {
         final AckResolution res;
 
         lock.lock();
-        if (expectIncoming.isEmpty()) {
-            res = AckResolution.IDLE;
-        } else {
-            res = getAckResolution(packetData);
+        try {
+            if (expectIncoming.isEmpty()) {
+                return AckResolution.IDLE;
+            }
+            return getAckResolution(packetData);
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-
-        return res;
     }
 
     /**
@@ -315,9 +323,12 @@ public class TeleportQueue {
 
     public void clear() {
         lock.lock();
-        expectIncoming.clear();
-        expectOutgoing = null;
-        lock.unlock();
+        try {
+            expectIncoming.clear();
+            expectOutgoing = null;
+        } finally {
+            lock.unlock();
+        }
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/DefaultGenericInstanceRegistry.java
@@ -80,8 +80,11 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
 
         private void setFlag(long flag) {
             lock.lock();
-            accessFlags |= flag;
-            lock.unlock();
+            try {
+                accessFlags |= flag;
+            } finally {
+                lock.unlock();
+            }
         }
 
         public void denyOverrideInstance() {
@@ -100,19 +103,21 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
          */
         public T unregisterInstance() {
             lock.lock();
-            if ((accessFlags & DENY_REMOVE_INSTANCE) != 0) {
-                lock.unlock();
-                throw new RegistrationLockedException();
-            }
-            T oldInstance = this.instance;
-            this.instance = null;
-            if (!listeners.isEmpty()) {
-                for (IGenericInstanceRegistryListener<T> listener : listeners) {
-                    ((IGenericInstanceRegistryListener<T>) listener).onGenericInstanceRemove(registeredFor, oldInstance);
+            try {
+                if ((accessFlags & DENY_REMOVE_INSTANCE) != 0) {
+                    throw new RegistrationLockedException();
                 }
+                T oldInstance = this.instance;
+                this.instance = null;
+                if (!listeners.isEmpty()) {
+                    for (IGenericInstanceRegistryListener<T> listener : listeners) {
+                        ((IGenericInstanceRegistryListener<T>) listener).onGenericInstanceRemove(registeredFor, oldInstance);
+                    }
+                }
+                return oldInstance;
+            } finally {
+                lock.unlock();
             }
-            lock.unlock();
-            return oldInstance;
         }
 
         /**
@@ -124,36 +129,40 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
          */
         public T registerInstance(T instance) {
             lock.lock();
-            if ((accessFlags & DENY_OVERRIDE_INSTANCE) != 0) {
+            try {
+                if ((accessFlags & DENY_OVERRIDE_INSTANCE) != 0) {
+                    throw new RegistrationLockedException();
+                }
+                T oldInstance = this.instance;
+                this.instance = instance;
+                if (!listeners.isEmpty()) {
+                    if (oldInstance == null) {
+                        for (IGenericInstanceRegistryListener<T> listener : listeners) {
+                            listener.onGenericInstanceOverride(registeredFor, instance, oldInstance);
+                        }
+                    }
+                    else {
+                        for (IGenericInstanceRegistryListener<T> listener : listeners) {
+                            listener.onGenericInstanceRegister(registeredFor, instance);
+                        }
+                    }
+                }
+                return oldInstance;
+            } finally {
                 lock.unlock();
-                throw new RegistrationLockedException();
             }
-            T oldInstance = this.instance;
-            this.instance = instance;
-            if (!listeners.isEmpty()) {
-                if (oldInstance == null) {
-                    for (IGenericInstanceRegistryListener<T> listener : listeners) {
-                        listener.onGenericInstanceOverride(registeredFor, instance, oldInstance);
-                    }
-                }
-                else {
-                    for (IGenericInstanceRegistryListener<T> listener : listeners) {
-                        listener.onGenericInstanceRegister(registeredFor, instance);
-                    }
-                }
-            }
-            lock.unlock();
-            return oldInstance;
         }
 
         public IGenericInstanceHandle<T> getHandle() {
             lock.lock();
-            if (uniqueHandle == null || uniqueHandle.isDisabled()) {
-                updateUniqueHandle();
+            try {
+                if (uniqueHandle == null || uniqueHandle.isDisabled()) {
+                    updateUniqueHandle();
+                }
+                return uniqueHandle.getNewHandle();
+            } finally {
+                lock.unlock();
             }
-            IGenericInstanceHandle<T> handle = uniqueHandle.getNewHandle();
-            lock.unlock();
-            return handle;
         }
 
         /**
@@ -172,16 +181,19 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
 
         public void unregisterListener(IGenericInstanceRegistryListener<T> listener) {
             lock.lock();
-            IGenericInstanceHandle<T> disable = null;
-            if (listener == uniqueHandle) {
-                disable = uniqueHandle;
-                uniqueHandle = null;
+            try {
+                IGenericInstanceHandle<T> disable = null;
+                if (listener == uniqueHandle) {
+                    disable = uniqueHandle;
+                    uniqueHandle = null;
+                }
+                this.listeners.remove(listener);
+                if (disable != null) {
+                    disable.disableHandle();
+                }
+            } finally {
+                lock.unlock();
             }
-            this.listeners.remove(listener);
-            if (disable != null) {
-                disable.disableHandle();
-            }
-            lock.unlock();
         }
 
         public T getInstance() {
@@ -242,31 +254,36 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
     @SuppressWarnings("unchecked")
     private <T> Registration<T> createEmptyRegistration(Class<T> registeredFor) {
         lock.lock();
-        Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
-        if (registration == null) {
-            try {
-                // NOTE: individual locks or configuration may be considered here.
-                registration = new Registration<T>(registeredFor, null, this, this, lock);
-                this.registrations.put(registeredFor, registration);
+        try {
+            Registration<T> registration = (Registration<T>) registrations.get(registeredFor); // Re-check.
+            if (registration == null) {
+                try {
+                    // NOTE: individual locks or configuration may be considered here.
+                    registration = new Registration<T>(registeredFor, null, this, this, lock);
+                    this.registrations.put(registeredFor, registration);
+                }
+                catch (Throwable t) {
+                    throw new IllegalArgumentException(t); // Might document.
+                }
             }
-            catch (Throwable t) {
-                lock.unlock();
-                throw new IllegalArgumentException(t); // Might document.
-            }
+            return registration;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
-        return registration;
     }
 
     @Override
     public <T> void unregisterGenericInstanceRegistryListener(Class<T> registeredFor, IGenericInstanceRegistryListener<T> listener) {
         lock.lock();
-        // (Include getRegistration, as no object creation is involved.)
-        Registration<T> registration = getRegistration(registeredFor, false);
-        if (registration != null) {
-            registration.unregisterListener(listener);
+        try {
+            // (Include getRegistration, as no object creation is involved.)
+            Registration<T> registration = getRegistration(registeredFor, false);
+            if (registration != null) {
+                registration.unregisterListener(listener);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.lock();
     }
 
     @SuppressWarnings("unchecked")
@@ -303,13 +320,17 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
     @Override
     public <T> T unregisterGenericInstance(Class<T> registeredFor) {
         lock.lock();
-        Registration<T> registration = getRegistration(registeredFor, false);
-        T registered = registration == null ? null : registration.unregisterInstance();
-        // Repeat getting for removal test.
-        if (registrations.containsKey(registeredFor) && getRegistration(registeredFor, false).canBeRemoved()) {
-            registrations.remove(registeredFor);
+        T registered;
+        try {
+            Registration<T> registration = getRegistration(registeredFor, false);
+            registered = registration == null ? null : registration.unregisterInstance();
+            // Repeat getting for removal test.
+            if (registrations.containsKey(registeredFor) && getRegistration(registeredFor, false).canBeRemoved()) {
+                registrations.remove(registeredFor);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
         if (logger != null) {
             if (registered != null) {
                 logRegistryEvent("Unregister, removed mapping for: " + registeredFor.getName());
@@ -329,13 +350,16 @@ public class DefaultGenericInstanceRegistry implements GenericInstanceRegistry, 
     public void clear() {
         // NOTE: consider firing unregister or providing a removal method
         lock.lock();
-        final Iterator<Entry<Class<?>, Registration<?>>> it = registrations.iterator();
-        while (it.hasNext()) {
-            it.next().getValue().clear();
+        try {
+            final Iterator<Entry<Class<?>, Registration<?>>> it = registrations.iterator();
+            while (it.hasNext()) {
+                it.next().getValue().clear();
+            }
+            registrations.clear();
+            logRegistryEvent("Registry cleared.");
+        } finally {
+            lock.unlock();
         }
-        registrations.clear();
-        logRegistryEvent("Registry cleared.");
-        lock.unlock();
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/FactoryOneRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/FactoryOneRegistry.java
@@ -51,8 +51,11 @@ public class FactoryOneRegistry<A> implements IFactoryOneRegistry<A> {
             outsideThreadContext("register factory");
         }
         lock.lock();
-        factories.put(registerFor, factory);
-        lock.unlock();
+        try {
+            factories.put(registerFor, factory);
+        } finally {
+            lock.unlock();
+        }
     }
 
     private void outsideThreadContext(final String tag) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/RichFactoryRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/RichFactoryRegistry.java
@@ -98,23 +98,29 @@ public class RichFactoryRegistry<A> extends RichTypeSetRegistry implements IRich
     public <T> void registerFactory(final Class<T> registerFor,
             final IFactoryOne<A, T> factory) {
         lock.lock();
-        factoryRegistry.registerFactory(registerFor, factory);
-        for (final Class<?> groupType: autoGroups) {
-            if (groupType.isAssignableFrom(registerFor)) {
-                addToGroups(registerFor, (Class<? super T>) groupType);
+        try {
+            factoryRegistry.registerFactory(registerFor, factory);
+            for (final Class<?> groupType: autoGroups) {
+                if (groupType.isAssignableFrom(registerFor)) {
+                    addToGroups(registerFor, (Class<? super T>) groupType);
+                }
             }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     @Override
     public <G> void createAutoGroup(final Class<G> groupType) {
         lock.lock();
-        createGroup(groupType);
-        final Set<Class<?>> autoGroups = new LinkedHashSet<Class<?>>(this.autoGroups);
-        autoGroups.add(groupType);
-        this.autoGroups = autoGroups;
-        lock.unlock();
+        try {
+            createGroup(groupType);
+            final Set<Class<?>> autoGroups = new LinkedHashSet<Class<?>>(this.autoGroups);
+            autoGroups.add(groupType);
+            this.autoGroups = autoGroups;
+        } finally {
+            lock.unlock();
+        }
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/RichTypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/RichTypeSetRegistry.java
@@ -64,29 +64,35 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
     public <I> void addToGroups(final Class<I> itemType, 
             final Class<? super I>... groupTypes) {
         lock.lock();
-        for (final Class<? super I> groupType : groupTypes) {
-            createGroup(groupType);
+        try {
+            for (final Class<? super I> groupType : groupTypes) {
+                createGroup(groupType);
+            }
+            groupedTypes.addToGroups(itemType, groupTypes);
+        } finally {
+            lock.unlock();
         }
-        groupedTypes.addToGroups(itemType, groupTypes);
-        lock.unlock();
     }
 
     @Override
     public <I> void addToGroups(CheckType checkType, Class<I> itemType,
             Class<? super I>... groupTypes) {
         lock.lock();
-        for (final Class<? super I> groupType : groupTypes) {
-            createGroup(groupType);
+        try {
+            for (final Class<? super I> groupType : groupTypes) {
+                createGroup(groupType);
+            }
+            TypeSetRegistry reg = groupedTypesByCheckType.get(checkType);
+            if (reg == null) {
+                reg = new TypeSetRegistry(lock);
+                updateRegistry(reg);
+                groupedTypesByCheckType.put(checkType, reg);
+            }
+            reg.addToGroups(itemType, groupTypes);
+            groupedTypes.addToGroups(itemType, groupTypes);
+        } finally {
+            lock.unlock();
         }
-        TypeSetRegistry reg = groupedTypesByCheckType.get(checkType);
-        if (reg == null) {
-            reg = new TypeSetRegistry(lock);
-            updateRegistry(reg);
-            groupedTypesByCheckType.put(checkType, reg);
-        }
-        reg.addToGroups(itemType, groupTypes);
-        groupedTypes.addToGroups(itemType, groupTypes);
-        lock.unlock();
     }
 
     @Override
@@ -98,15 +104,18 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
     public <I> void addToExistingGroups(final CheckType checkType,
             final Class<I> itemType) {
         lock.lock();
-        TypeSetRegistry reg = groupedTypesByCheckType.get(checkType);
-        if (reg == null) {
-            reg = new TypeSetRegistry(lock);
-            updateRegistry(reg);
-            groupedTypesByCheckType.put(checkType, reg);
+        try {
+            TypeSetRegistry reg = groupedTypesByCheckType.get(checkType);
+            if (reg == null) {
+                reg = new TypeSetRegistry(lock);
+                updateRegistry(reg);
+                groupedTypesByCheckType.put(checkType, reg);
+            }
+            reg.addToExistingGroups(itemType);
+            groupedTypes.addToExistingGroups(itemType);
+        } finally {
+            lock.unlock();
         }
-        reg.addToExistingGroups(itemType);
-        groupedTypes.addToExistingGroups(itemType);
-        lock.unlock();
     }
 
     /**
@@ -131,20 +140,26 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
     public <I> void addToGroups(final Collection<CheckType> checkTypes,
             final Class<I> itemType, final Class<? super I>... groupTypes) {
         lock.lock();
-        for (final CheckType checkType : checkTypes) {
-            addToGroups(checkType, itemType, groupTypes);
+        try {
+            for (final CheckType checkType : checkTypes) {
+                addToGroups(checkType, itemType, groupTypes);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     @Override
     public <I> void addToExistingGroups(final Collection<CheckType> checkTypes,
             final Class<I> itemType) {
         lock.lock();
-        for (final CheckType checkType : checkTypes) {
-            addToExistingGroups(checkType, itemType);
+        try {
+            for (final CheckType checkType : checkTypes) {
+                addToExistingGroups(checkType, itemType);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/TypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/TypeSetRegistry.java
@@ -99,19 +99,21 @@ public class TypeSetRegistry {
      */
     public <I> void addToGroups(final Class<I> itemType, final Class<? super I>... groupTypes) {
         lock.lock();
-        for (final Class<? super I> groupType : groupTypes) {
-            if (!groupType.isAssignableFrom(itemType)) {
-                lock.unlock();
-                throw new IllegalArgumentException("Can't assign " + itemType.getName() + " to " + groupType.getName() + "!");
+        try {
+            for (final Class<? super I> groupType : groupTypes) {
+                if (!groupType.isAssignableFrom(itemType)) {
+                    throw new IllegalArgumentException("Can't assign " + itemType.getName() + " to " + groupType.getName() + "!");
+                }
+                @SuppressWarnings("unchecked")
+                GroupNode<? super I> node = (GroupNode<? super I>) groupedTypes.get(groupType);
+                if (node == null) {
+                    node = newGroupNode(groupType);
+                }
+                node.add(groupType, itemType);
             }
-            @SuppressWarnings("unchecked")
-            GroupNode<? super I> node = (GroupNode<? super I>) groupedTypes.get(groupType);
-            if (node == null) {
-                node = newGroupNode(groupType);
-            }
-            node.add(groupType, itemType);
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     /**
@@ -121,10 +123,13 @@ public class TypeSetRegistry {
      */
     public <G> void createGroup(final Class<G> groupType) {
         lock.lock();
-        if (!groupedTypes.containsKey(groupType)) {
-            newGroupNode(groupType);
+        try {
+            if (!groupedTypes.containsKey(groupType)) {
+                newGroupNode(groupType);
+            }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     private <G> GroupNode<G> newGroupNode(Class<G> groupType) {
@@ -140,16 +145,19 @@ public class TypeSetRegistry {
      */
     public void addToExistingGroups(final Class<?> itemType) {
         lock.lock();
-        // Sort in all existing registered group types.
-        for (final Entry<Class<?>, GroupNode<?>> entry : groupedTypes.iterable()) {
-            final Class<?> groupType = entry.getKey();
-            if (groupType.isAssignableFrom(itemType)) {
-                // Consider wrapping in a try/catch to handle unexpected issues
-                final GroupNode<?> group = entry.getValue();
-                group.add(groupType, itemType);
+        try {
+            // Sort in all existing registered group types.
+            for (final Entry<Class<?>, GroupNode<?>> entry : groupedTypes.iterable()) {
+                final Class<?> groupType = entry.getKey();
+                if (groupType.isAssignableFrom(itemType)) {
+                    // Consider wrapping in a try/catch to handle unexpected issues
+                    final GroupNode<?> group = entry.getValue();
+                    group.add(groupType, itemType);
+                }
             }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     /**
@@ -171,12 +179,15 @@ public class TypeSetRegistry {
      */
     public void updateGroupTypes(TypeSetRegistry refReg) {
         lock.lock(); // Ensure no interruption - iterator is not using lock, thus no dead locks.
-        for (final Entry<Class<?>, GroupNode<?>> entry : refReg.groupedTypes.iterable()) {
-            if (!this.groupedTypes.containsKey(entry.getKey())) {
-                entry.getValue().createGroup(this);
+        try {
+            for (final Entry<Class<?>, GroupNode<?>> entry : refReg.groupedTypes.iterable()) {
+                if (!this.groupedTypes.containsKey(entry.getKey())) {
+                    entry.getValue().createGroup(this);
+                }
             }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionRegistry.java
@@ -94,17 +94,18 @@ public class PermissionRegistry {
      */
     public void addRegisteredPermission(final RegisteredPermission registeredPermission) {
         lock.lock();
-        if (infosString.containsKey(registeredPermission.getLowerCaseStringRepresentation())) {
+        try {
+            if (infosString.containsKey(registeredPermission.getLowerCaseStringRepresentation())) {
+                throw new AlreadyRegisteredException("String representation already registered: "
+                        + registeredPermission.getLowerCaseStringRepresentation());
+            }
+            if (infosInt.containsKey(registeredPermission.getId())) {
+                throw new AlreadyRegisteredException("Id already registered: " + registeredPermission.getId());
+            }
+            internalPut(registeredPermission);
+        } finally {
             lock.unlock();
-            throw new AlreadyRegisteredException("String representation already registered: " 
-                    + registeredPermission.getLowerCaseStringRepresentation());
         }
-        if (infosInt.containsKey(registeredPermission.getId())) {
-            lock.unlock();
-            throw new AlreadyRegisteredException("Id already registered: " + registeredPermission.getId());
-        }
-        internalPut(registeredPermission);
-        lock.unlock();
     }
 
     /**
@@ -139,22 +140,17 @@ public class PermissionRegistry {
         PermissionInfo info = infosString.get(RegisteredPermission.toLowerCaseStringRepresentation(stringRepresentation));
         if (info == null) {
             lock.lock();
-            // Must check again (asynchronicity).
-            info = infosString.get(RegisteredPermission.toLowerCaseStringRepresentation(stringRepresentation));
-            if (info != null) {
-                lock.unlock();
-                return info;
-            }
-            final RegisteredPermission registeredPermission;
             try {
-                registeredPermission = new RegisteredPermission(nextId, stringRepresentation);
-            }
-            catch (NullPointerException e) {
+                // Must check again (asynchronicity).
+                info = infosString.get(RegisteredPermission.toLowerCaseStringRepresentation(stringRepresentation));
+                if (info != null) {
+                    return info;
+                }
+                final RegisteredPermission registeredPermission = new RegisteredPermission(nextId, stringRepresentation);
+                info = internalPut(registeredPermission);
+            } finally {
                 lock.unlock();
-                throw e;
             }
-            info = internalPut(registeredPermission);
-            lock.unlock();
         }
         return info;
     }
@@ -173,9 +169,12 @@ public class PermissionRegistry {
     public Set<RegisteredPermission> updateSettings(final PermissionSettings settings) {
         final Set<RegisteredPermission> changed = new LinkedHashSet<RegisteredPermission>();
         // Ensure outdated policies don't get applied from here on.
-        lock.lock(); 
-        this.settings = settings;
-        lock.unlock();
+        lock.lock();
+        try {
+            this.settings = settings;
+        } finally {
+            lock.unlock();
+        }
         // Since we can't know rule changes at this stage, all have to be updated.
         // (Lazy iteration, we'll hit all previously registered ones. Asynchronous registration shouldn't happen anyway.)
         final Iterator<Entry<Integer, PermissionInfo>> it = infosInt.iterator();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerCheckTypeTree.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerCheckTypeTree.java
@@ -322,11 +322,14 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
 
     private void exemptAsynchronous(final PlayerCheckTypeTreeNode node, final ExemptionContext context) {
         lock.lock();
-        visitWithDescendants(node, node1 -> {
-            node1.exemptAsynchronous(context);
-            return true;
-        });
-        lock.unlock();
+        try {
+            visitWithDescendants(node, node1 -> {
+                node1.exemptAsynchronous(context);
+                return true;
+            });
+        } finally {
+            lock.unlock();
+        }
     }
 
     public void unexempt(final CheckType checkType, final ExemptionContext context) {
@@ -351,11 +354,14 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
 
     private void unexemptAsynchronous(final PlayerCheckTypeTreeNode node, final ExemptionContext context) {
         lock.lock();
-        visitWithDescendants(node, node1 -> {
-            node1.unexemptAsynchronous(context);
-            return true;
-        });
-        lock.unlock();
+        try {
+            visitWithDescendants(node, node1 -> {
+                node1.unexemptAsynchronous(context);
+                return true;
+            });
+        } finally {
+            lock.unlock();
+        }
     }
 
     public void unexemptAll(final CheckType checkType, final ExemptionContext context) {
@@ -380,11 +386,14 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
 
     private void unexemptAllAsynchronous(final PlayerCheckTypeTreeNode node, final ExemptionContext context) {
         lock.lock();
-        visitWithDescendants(node, node1 -> {
-            node1.unexemptAllAsynchronous(context);
-            return true;
-        });
-        lock.unlock();
+        try {
+            visitWithDescendants(node, node1 -> {
+                node1.unexemptAllAsynchronous(context);
+                return true;
+            });
+        } finally {
+            lock.unlock();
+        }
     }
 
     public boolean isExempted(final CheckType checkType, final ExemptionContext context) {
@@ -405,11 +414,12 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
     }
 
     private boolean isExemptedAsynchronous(final PlayerCheckTypeTreeNode node, final ExemptionContext context) {
-        final boolean res;
         lock.lock();
-        res = node.isExemptedPrimaryThread(context);
-        lock.unlock();
-        return res;
+        try {
+            return node.isExemptedPrimaryThread(context);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -431,11 +441,14 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
             throw new IllegalArgumentException("Invalid check type.");
         }
         lock.lock();
-        visitWithDescendants(node, node1 -> {
-            node1.clearAllExemptions();
-            return true;
-        });
-        lock.unlock();
+        try {
+            visitWithDescendants(node, node1 -> {
+                node1.clearAllExemptions();
+                return true;
+            });
+        } finally {
+            lock.unlock();
+        }
     }
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Counters.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Counters.java
@@ -157,10 +157,11 @@ public class Counters {
             lock = syLocks[id];
         }
         lock.lock();
-
-        syCounts[id].count += count;
-
-        lock.unlock();
+        try {
+            syCounts[id].count += count;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -170,12 +171,13 @@ public class Counters {
      */
     private void addLock(final int id) {
         globalLock.lock();
-
-        if (syLocks[id] == null) {
-            syLocks[id] = new ReentrantLock();
+        try {
+            if (syLocks[id] == null) {
+                syLocks[id] = new ReentrantLock();
+            }
+        } finally {
+            globalLock.unlock();
         }
-
-        globalLock.unlock();
     }
 
     /**
@@ -187,15 +189,16 @@ public class Counters {
      */
     public void resetAll() {
         globalLock.lock();
-
-        for (int i = 0; i < ptCounts.length; i ++) {
-            ptCounts[i] = new CountEntry();
+        try {
+            for (int i = 0; i < ptCounts.length; i ++) {
+                ptCounts[i] = new CountEntry();
+            }
+            for (int i = 0; i < syCounts.length; i ++) {
+                syCounts[i] = new CountEntry();
+            }
+        } finally {
+            globalLock.unlock();
         }
-        for (int i = 0; i < syCounts.length; i ++) {
-            syCounts[i] = new CountEntry();
-        }
-
-        globalLock.unlock();
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/WorldDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/WorldDataManager.java
@@ -193,17 +193,19 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
 
     private void createDefaultWorldData() {
         lock.lock();
-        if (worldDataMap.containsKey(null)) {
+        try {
+            if (worldDataMap.containsKey(null)) {
+                return;
+            }
+            ConfigFile config = rawConfigurations.get(null);
+            if (config == null) {
+                config = new DefaultConfig();
+            }
+            worldDataMap.put(null, new WorldData(null, this));
+            updateWorldData(null, config);
+        } finally {
             lock.unlock();
-            return;
         }
-        ConfigFile config = rawConfigurations.get(null);
-        if (config == null) {
-            config = new DefaultConfig();
-        }
-        worldDataMap.put(null, new WorldData(null, this));
-        updateWorldData(null, config);
-        lock.unlock();
     }
 
     /**
@@ -237,17 +239,21 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
          * Minimal locking is used, to prevent deadlocks, in case WorldData
          * instances will hold individual locks.
          */
+        final WorldData defaultWorldData;
         lock.lock();
-        final Map<String, ConfigFile> rawConfigurations = new LinkedHashMap<String, ConfigFile>(rawWorldConfigs.size());
-        for (final Entry<String, ConfigFile> entry : rawWorldConfigs.entrySet()) {
-            final String worldName = entry.getKey();
-            rawConfigurations.put(worldName == null ? null : worldName.toLowerCase(), entry.getValue());
+        try {
+            final Map<String, ConfigFile> rawConfigurations = new LinkedHashMap<String, ConfigFile>(rawWorldConfigs.size());
+            for (final Entry<String, ConfigFile> entry : rawWorldConfigs.entrySet()) {
+                final String worldName = entry.getKey();
+                rawConfigurations.put(worldName == null ? null : worldName.toLowerCase(), entry.getValue());
+            }
+            this.rawConfigurations = rawConfigurations;
+            final ConfigFile defaultConfig = this.rawConfigurations.get(null);
+            defaultWorldData = internalGetDefaultWorldData(); // Always the same instance.
+            defaultWorldData.update(defaultConfig);
+        } finally {
+            lock.unlock(); // From here on, new instances have a proper config set.
         }
-        this.rawConfigurations = rawConfigurations;
-        final ConfigFile defaultConfig = this.rawConfigurations.get(null);
-        final WorldData defaultWorldData = internalGetDefaultWorldData(); // Always the same instance.
-        defaultWorldData.update(defaultConfig);
-        lock.unlock(); // From here on, new instances have a proper config set.
         // Update all given
         for (final Entry<String, ConfigFile> entry : rawConfigurations.entrySet()) {
             final String worldName = entry.getKey();
@@ -267,9 +273,12 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
                     && !rawConfigurations.containsKey(worldName)) {
                 final WorldData ref = entry.getValue();
                 lock.lock();
-                defaultWorldData.addChild(ref); // Redundant calls are ok.
-                ref.adjustToParent(defaultWorldData); // Inherit specific overrides and more.
-                lock.unlock();
+                try {
+                    defaultWorldData.addChild(ref); // Redundant calls are ok.
+                    ref.adjustToParent(defaultWorldData); // Inherit specific overrides and more.
+                } finally {
+                    lock.unlock();
+                }
             }
         }
     }
@@ -302,15 +311,18 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
     public void updateAllWorldData() {
         // ILockable or an access object might be used
         lock.lock();
-        final WorldData defaultWorldData = internalGetDefaultWorldData();
-        defaultWorldData.update();
-        for (final Entry<String, WorldData> entry : worldDataMap.iterable()) {
-            final WorldData ref = entry.getValue();
-            if (ref != defaultWorldData) {
-                ref.update();
+        try {
+            final WorldData defaultWorldData = internalGetDefaultWorldData();
+            defaultWorldData.update();
+            for (final Entry<String, WorldData> entry : worldDataMap.iterable()) {
+                final WorldData ref = entry.getValue();
+                if (ref != defaultWorldData) {
+                    ref.update();
+                }
             }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     /**
@@ -326,39 +338,45 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
             final ConfigFile rawConfiguration) {
         final WorldData defaultWorldData = internalGetDefaultWorldData();
         lock.lock(); // Locking here might be moved outside (pros and cons).
-        final String lcName = worldName == null ? null : worldName.toLowerCase();
-        WorldData data = worldDataMap.get(lcName);
-        boolean skipUpdate = false;
-        if (data == null) {
-            data = new WorldData(worldName, defaultWorldData, factoryRegistry);
-            worldDataMap.put(data.getWorldNameLowerCase(), data);
-            if (rawConfiguration == defaultWorldData.getRawConfiguration()) {
-                defaultWorldData.addChild(data);
-                skipUpdate = true;
+        try {
+            final String lcName = worldName == null ? null : worldName.toLowerCase();
+            WorldData data = worldDataMap.get(lcName);
+            boolean skipUpdate = false;
+            if (data == null) {
+                data = new WorldData(worldName, defaultWorldData, factoryRegistry);
+                worldDataMap.put(data.getWorldNameLowerCase(), data);
+                if (rawConfiguration == defaultWorldData.getRawConfiguration()) {
+                    defaultWorldData.addChild(data);
+                    skipUpdate = true;
+                }
             }
+            if (!skipUpdate) {
+                data.update(rawConfiguration); // Parent/child state is updated  here.
+            }
+            return data;
+        } finally {
+            lock.unlock();
         }
-        if (!skipUpdate) {
-            data.update(rawConfiguration); // Parent/child state is updated  here.
-        }
-        lock.unlock();
-        return data;
     }
 
     @Override
     public void overrideCheckActivation(final CheckType checkType, final AlmostBoolean active, 
             final OverrideType overrideType, final boolean overrideChildren) {
         lock.lock();
-        final IWorldData defaultWorldData = getDefaultWorldData();
-        defaultWorldData.overrideCheckActivation(checkType, active, overrideType, overrideChildren);
-        // Override flags.
-        // If possible, skip derived from default, since default data is done first.
-        for (final Entry<String, WorldData> entry : worldDataMap.iterable()) {
-            final IWorldData worldData = entry.getValue();
-            if (worldData != defaultWorldData) {
-                worldData.overrideCheckActivation(checkType, active, overrideType, overrideChildren);
+        try {
+            final IWorldData defaultWorldData = getDefaultWorldData();
+            defaultWorldData.overrideCheckActivation(checkType, active, overrideType, overrideChildren);
+            // Override flags.
+            // If possible, skip derived from default, since default data is done first.
+            for (final Entry<String, WorldData> entry : worldDataMap.iterable()) {
+                final IWorldData worldData = entry.getValue();
+                if (worldData != defaultWorldData) {
+                    worldData.overrideCheckActivation(checkType, active, overrideType, overrideChildren);
+                }
             }
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- guarantee unlocks in NetData, TeleportQueue and more
- wrap lock usage with try/finally in PermissionRegistry, Counters, PlayerCheckTypeTree, WorldDataManager
- update registry classes to use try/finally

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3cf7452c8329b9fe6ec5b6ab857b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor lock handling to use try-finally blocks to ensure that locks are always released after execution.

### Why are these changes being made?
These changes improve the reliability and robustness of the code by ensuring that locks are always released, even if an exception occurs within the locked section, preventing potential deadlocks and ensuring the correct functioning of the program.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->