### PR TITLE
Fix yaw rate reset NPE

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -2122,7 +2122,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
      * @param data
      * @param cc
      */
-    private void confirmSetBack(final Player player, final boolean fakeNews, final MovingData data, 
+    private void confirmSetBack(final Player player, final boolean fakeNews, final MovingData data,
                                 final MovingConfig cc, final IPlayerData pData, final Location fallbackTeleported) {
 
         // Find the reason why it can be null even passed the precondition not null.
@@ -2136,8 +2136,21 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         data.onSetBack(moveInfo.from);
         aux.returnPlayerMoveInfo(moveInfo);
         // Reset stuff.
-        Combined.resetYawRate(player, teleported.getYaw(), System.currentTimeMillis(), true, pData); // Not sure.
+        final Float yaw = getYawForSetBack(teleported, fallbackTeleported);
+        if (yaw != null) {
+            Combined.resetYawRate(player, yaw.floatValue(), System.currentTimeMillis(), true, pData); // Not sure.
+        }
         data.resetTeleported();
+    }
+
+    private Float getYawForSetBack(final Location teleported, final Location fallback) {
+        if (teleported != null) {
+            return Float.valueOf(teleported.getYaw());
+        }
+        if (fallback != null) {
+            return Float.valueOf(fallback.getYaw());
+        }
+        return null;
     }
 
 

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestConfirmSetBack.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestConfirmSetBack.java
@@ -1,0 +1,57 @@
+package fr.neatmonster.nocheatplus.test;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.moving.MovingListener;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import static org.junit.Assert.*;
+
+public class TestConfirmSetBack {
+
+    private static World createWorld() {
+        return (World) Proxy.newProxyInstance(World.class.getClassLoader(), new Class[]{World.class}, (p,m,a) -> {
+            if ("getName".equals(m.getName())) return "dummy";
+            Class<?> r = m.getReturnType();
+            if (r == boolean.class) return false;
+            if (r.isPrimitive()) return 0;
+            return null;
+        });
+    }
+
+    private static Player createPlayer() {
+        return (Player) Proxy.newProxyInstance(Player.class.getClassLoader(), new Class[]{Player.class}, (p,m,a) -> {
+            Class<?> r = m.getReturnType();
+            if (r == boolean.class) return false;
+            if (r.isPrimitive()) return 0;
+            return null;
+        });
+    }
+
+    @Test
+    public void yawForSetBackHandlesNullTeleported() throws Exception {
+        sun.misc.Unsafe unsafe = getUnsafe();
+        MovingListener listener = (MovingListener) unsafe.allocateInstance(MovingListener.class);
+        Field ct = listener.getClass().getSuperclass().getDeclaredField("checkType");
+        ct.setAccessible(true);
+        ct.set(listener, CheckType.MOVING);
+        Method m = MovingListener.class.getDeclaredMethod("getYawForSetBack", Location.class, Location.class);
+        m.setAccessible(true);
+        World w = createWorld();
+        Location fallback = new Location(w, 1, 2, 3);
+        Float yaw = (Float) m.invoke(listener, null, fallback);
+        assertEquals(fallback.getYaw(), yaw.floatValue(), 0.0);
+    }
+
+    private static sun.misc.Unsafe getUnsafe() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (sun.misc.Unsafe) f.get(null);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent NPE in MovingListener.confirmSetBack when teleported location is null
- test yaw fallback logic for confirmSetBack

## Testing
- `mvn -q -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685c3cf562848329a67eb08852bdd0a0