### PR TITLE
Refactor field access to use getters

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -70,7 +70,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     //////////////////////////////////////////////
     // Violation levels                         //
     //////////////////////////////////////////////
-    public double creativeFlyVL = 0.0;
+    private double creativeFlyVL = 0.0;
     public double morePacketsVL = 0.0;
     public double noFallVL = 0.0;
     public double survivalFlyVL = 0.0;
@@ -96,7 +96,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
      */
     public int keepfrictiontick = 0;
     /** Countdown for ending a bunnyfly phase(= phase after bunnyhop). 10(max) represents a bunnyhop, 9-1 represent the tick at which this bunnfly phase currently is. */
-    public int bunnyhopDelay;
+    private int bunnyhopDelay;
     /** bunnyHopDelay phase before applying a LostGround case (set in SurvivalFly.bunnyHop()) */ 
     public int lastbunnyhopDelay = 0;
     /** Ticks after landing on ground (InAir->Ground). Mainly used in SurvivalFly. */
@@ -1527,6 +1527,42 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
             morePacketsSetBackResetTime = 0;
             setBackResetTime = 0;
         }
+    }
+
+    /**
+     * Get the current bunnyhop delay.
+     *
+     * @return the bunnyhop delay
+     */
+    public int getBunnyhopDelay() {
+        return bunnyhopDelay;
+    }
+
+    /**
+     * Set the bunnyhop delay.
+     *
+     * @param bunnyhopDelay the new bunnyhop delay
+     */
+    public void setBunnyhopDelay(final int bunnyhopDelay) {
+        this.bunnyhopDelay = bunnyhopDelay;
+    }
+
+    /**
+     * Get the creative fly violation level.
+     *
+     * @return the creative fly violation level
+     */
+    public double getCreativeFlyVL() {
+        return creativeFlyVL;
+    }
+
+    /**
+     * Set the creative fly violation level.
+     *
+     * @param creativeFlyVL the new violation level
+     */
+    public void setCreativeFlyVL(final double creativeFlyVL) {
+        this.creativeFlyVL = creativeFlyVL;
     }
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -1619,7 +1619,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         final PlayerMoveData lastMove = data.playerMoves.getFirstPastMove();
         final double amount = guessVelocityAmount(player, data.playerMoves.getCurrentMove(), lastMove, data, cc);
         data.clearActiveHorVel(); // Clear active velocity due to adding actual speed here.
-        data.bunnyhopDelay = 0; // Remove bunny hop due to add velocity 
+        data.setBunnyhopDelay(0); // Remove bunny hop due to add velocity
         if (amount > 0.0) data.addHorizontalVelocity(new AccountEntry(tick, amount, cc.velocityActivationCounter, MovingData.getHorVelValCount(amount)));
         data.addVerticalVelocity(new SimpleEntry(lastMove.yDistance, cc.velocityActivationCounter));
         data.addVerticalVelocity(new SimpleEntry(0.0, cc.velocityActivationCounter));

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ExtremeMoveHandler.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ExtremeMoveHandler.java
@@ -84,8 +84,8 @@ public final class ExtremeMoveHandler {
         } else {
             check = creativeFly;
             actions = cc.creativeFlyActions;
-            data.creativeFlyVL += violation;
-            vL = data.creativeFlyVL;
+            data.setCreativeFlyVL(data.getCreativeFlyVL() + violation);
+            vL = data.getCreativeFlyVL();
         }
         final ViolationData vd = new ViolationData(check, player, vL, violation, actions);
         if (vd.needsParameters()) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGround.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGround.java
@@ -158,7 +158,7 @@ public class LostGround {
                 // Check for sprint-jumping on fences with trapdoors above (missing trapdoor's edge touch on server-side, player lands directly onto the fence)
                 // This is rather a false negative: NCP's collision differs from MC's; NCP won't detect this specific collision while MC does.
                 if (setBackYDistance > 1.0 && setBackYDistance <= 1.5 
-                    && setBackYMargin < 0.6 && data.bunnyhopDelay > 0 
+                    && setBackYMargin < 0.6 && data.getBunnyhopDelay() > 0
                     && yDistance > from.getyOnGround() && lastMove.yDistance <= Magic.GRAVITY_MAX
                     && yDistance < Magic.GRAVITY_MIN) {
                     

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
@@ -99,9 +99,9 @@ public class MagicBunny {
         ///////////////////////////////////////////////////////////////////
         // Note: Rework and simplify bunnyfly, merge bunnyslope and friction behaviour. Possibly stick to how Minecraft calculates speed.
         // (bunnyhop model is decently accurate, despite a bit convoluted)
-        if (lastMove.toIsValid && data.bunnyhopDelay > 0 && hDistance > baseSpeed) {
+        if (lastMove.toIsValid && data.getBunnyhopDelay() > 0 && hDistance > baseSpeed) {
             allowHop = false;
-            final int hopTime = BUNNYHOP_MAX_DELAY - data.bunnyhopDelay;
+            final int hopTime = BUNNYHOP_MAX_DELAY - data.getBunnyhopDelay();
 
             // Bunnyfly phase (decreasing speed due to friction)
             if (lastMove.hDistance > hDistance) { 
@@ -109,7 +109,7 @@ public class MagicBunny {
                 final double hDistDiff = lastMove.hDistance - hDistance;
                 // Slope (directly after hop but before friction): the initial/bunnyhop acceleration needs to drop sharply at first.
                 // Ensure relative speed decrease vs. hop is met somehow. 
-                if (data.bunnyhopDelay == 9 && hDistDiff >= bunnySpeedLossMod(data, headObstructed) * (lastMove.hDistance - baseSpeed)) {
+                if (data.getBunnyhopDelay() == 9 && hDistDiff >= bunnySpeedLossMod(data, headObstructed) * (lastMove.hDistance - baseSpeed)) {
                     tags.add("bunnyslope");
                     hDistanceAboveLimit = 0.0;
                 }
@@ -129,11 +129,11 @@ public class MagicBunny {
 
                     // ... one move between toonground and liftoff remains for hbuf ... 
                     // Do prolong bunnyfly if the player is yet to touch the ground
-                    if (data.bunnyhopDelay == 1 && !thisMove.to.onGround && !to.isResetCond()) {
-                        data.bunnyhopDelay++;
+                    if (data.getBunnyhopDelay() == 1 && !thisMove.to.onGround && !to.isResetCond()) {
+                        data.setBunnyhopDelay(data.getBunnyhopDelay() + 1);
                         tags.add("bunnyfly(keep)");
                     }
-                    else tags.add("bunnyfly(" + data.bunnyhopDelay + ")");
+                    else tags.add("bunnyfly(" + data.getBunnyhopDelay() + ")");
                 }
             } 
 
@@ -177,7 +177,7 @@ public class MagicBunny {
                     allowHop = double_bunny = true;
                 }
                 // Introduced with commit: https://github.com/Updated-NoCheatPlus/NoCheatPlus/commit/2ee891a427a047010f7358a7b246dd740398fa12
-                else if (data.bunnyhopDelay <= 6 && !thisMove.headObstructed
+                else if (data.getBunnyhopDelay() <= 6 && !thisMove.headObstructed
                          && (thisMove.from.onGround || thisMove.touchedGroundWorkaround)) {
                     tags.add("ediblebunny");
                     allowHop = true;  
@@ -205,7 +205,7 @@ public class MagicBunny {
         final double inc = ServerIsAtLeast1_13 ? 0.03 : 0;
         final double hopMargin = Magic.wasOnIceRecently(data) ? 1.4 : (data.momentumTick > 0 ? (data.momentumTick > 2 ? 1.0 + inc : 1.11 + inc) : 1.22 + inc);
 
-        if (lastMove.toIsValid && data.bunnyhopDelay <= 0 && data.lastbunnyhopDelay > 0
+        if (lastMove.toIsValid && data.getBunnyhopDelay() <= 0 && data.lastbunnyhopDelay > 0
             && lastMove.hDistance > hDistance && baseSpeed > 0.0 && hDistance / baseSpeed < hopMargin) {
             
             final double hDistDiff = lastMove.hDistance - hDistance;
@@ -225,7 +225,7 @@ public class MagicBunny {
                         data.sfLowJump = false;
                         tags.add("bunnyflyresume");
                         // Renew bunnyfly.
-                        data.bunnyhopDelay = data.lastbunnyhopDelay - 1;
+                        data.setBunnyhopDelay(data.lastbunnyhopDelay - 1);
                         data.lastbunnyhopDelay = 0;
                     }
                 } 
@@ -307,7 +307,7 @@ public class MagicBunny {
                    !from.isResetCond() && !to.isResetCond() 
                 )) {
                 // Set the maximum delay before the player will be allowed to bunnyhop again. Bunnyfly starts.
-                data.bunnyhopDelay = BUNNYHOP_MAX_DELAY;
+                data.setBunnyhopDelay(BUNNYHOP_MAX_DELAY);
                 hDistanceAboveLimit = 0.0;
                 thisMove.bunnyHop = true;
                 tags.add("bunnyhop");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -403,8 +403,8 @@ public class CreativeFly extends Check {
         Location setBack = null;
 
         if (result > 0.0) {
-            data.creativeFlyVL += result;
-            final ViolationData vd = new ViolationData(this, player, data.creativeFlyVL, result,
+            data.setCreativeFlyVL(data.getCreativeFlyVL() + result);
+            final ViolationData vd = new ViolationData(this, player, data.getCreativeFlyVL(), result,
                     cc.creativeFlyActions);
             if (vd.needsParameters()) {
                 vd.setParameter(ParameterName.LOCATION_FROM, String.format(Locale.US, "%.2f, %.2f, %.2f",
@@ -431,7 +431,7 @@ public class CreativeFly extends Check {
                 }
             }
             if (setBack == null) {
-                data.creativeFlyVL *= 0.97;
+                data.setCreativeFlyVL(data.getCreativeFlyVL() * 0.97);
             }
         }
         return setBack;
@@ -1655,7 +1655,7 @@ public class CreativeFly extends Check {
     private double handleBunnyHop(PlayerLocation from, PlayerLocation to, double yDistance,
             boolean flying, PlayerMoveData thisMove, PlayerMoveData lastMove, double resultH,
             MovingData data) {
-        data.bunnyhopDelay--;
+        data.setBunnyhopDelay(data.getBunnyhopDelay() - 1);
         if (!flying && resultH > 0 && resultH < 0.3) {
             if (yDistance >= 0.0 &&
                     (yDistance > 0.0
@@ -1665,11 +1665,11 @@ public class CreativeFly extends Check {
                             lastMove.touchedGround && !lastMove.bunnyHop))
                     && (!from.isResetCond() && !to.isResetCond())) {
                 tags.add("bunnyhop");
-                data.bunnyhopDelay = 9;
+                data.setBunnyhopDelay(9);
                 thisMove.bunnyHop = true;
                 return 0.0;
             }
-            else if (data.bunnyhopDelay <= 0) {
+            else if (data.getBunnyhopDelay() <= 0) {
                 tags.add("bunnyhop");
                 return 0.0;
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -851,8 +851,8 @@ public class SurvivalFly extends Check {
             } else {
                 data.clearActiveHorVel();
                 hFreedom = 0.0;
-                if (resetFrom && data.bunnyhopDelay <= 6) {
-                    data.bunnyhopDelay = 0;
+                if (resetFrom && data.getBunnyhopDelay() <= 6) {
+                    data.setBunnyhopDelay(0);
                 }
             }
 
@@ -941,7 +941,7 @@ public class SurvivalFly extends Check {
 
     /** Helper to decrease bunnyhop related counters. */
     private void decreaseBunnyhopCounters(final MovingData data) {
-        data.bunnyhopDelay--;
+        data.setBunnyhopDelay(data.getBunnyhopDelay() - 1);
         data.lastbunnyhopDelay -= data.lastbunnyhopDelay > 0 ? 1 : 0;
     }
 
@@ -1178,11 +1178,11 @@ public class SurvivalFly extends Check {
     }
 
     private void updateBunnyHopDelay(final MovingData data) {
-        if (data.bunnyhopDelay > 0) {
-            if (data.bunnyhopDelay > 6) {
-                data.lastbunnyhopDelay = data.bunnyhopDelay;
+        if (data.getBunnyhopDelay() > 0) {
+            if (data.getBunnyhopDelay() > 6) {
+                data.lastbunnyhopDelay = data.getBunnyhopDelay();
             }
-            data.bunnyhopDelay = 0;
+            data.setBunnyhopDelay(0);
         }
     }
 
@@ -2405,7 +2405,7 @@ public class SurvivalFly extends Check {
         if (lastMove.touchedGround || lastMove.to.extraPropertiesValid && lastMove.to.resetCond) {
             tags.add("ychinc");
         }
-        else if (data.bunnyhopDelay < 9 && !((lastMove.touchedGround || lastMove.from.onGroundOrResetCond)
+        else if (data.getBunnyhopDelay() < 9 && !((lastMove.touchedGround || lastMove.from.onGroundOrResetCond)
                 && TrigUtil.isZero(lastMove.yDistance)) && data.getOrUseVerticalVelocity(yDistance) == null) {
             vDistanceAboveLimit = Math.max(vDistanceAboveLimit, Math.abs(yDistance));
             tags.add("airjump");
@@ -3379,7 +3379,7 @@ public class SurvivalFly extends Check {
                 + data.liftOffEnvelope.getMaxJumpHeight(data.jumpAmplifier) + ")") : "?"));
         if (lastMove.toIsValid) {
             builder.append("\n fdsq: " + StringUtil.fdec3.format(thisMove.distanceSquared / lastMove.distanceSquared));
-            if (data.bunnyhopDelay > 0) {
+            if (data.getBunnyhopDelay() > 0) {
                 builder.append("\n Bunny ratios: " + "c/b(" + StringUtil.fdec3.format(hDistance / thisMove.hAllowedDistanceBase)
                         + ") / c/l(" + StringUtil.fdec3.format(hDistance / lastMove.hDistance) + ")");
             }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCreativeFlyHDist.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCreativeFlyHDist.java
@@ -199,6 +199,6 @@ public class TestCreativeFlyHDist {
         double[] res = invokeHdist(cf,p,from,to,thisMove.hDistance,1.0,false,false,thisMove,lastMove,model,data);
         assertEquals(0.6, res[0], 1e-6);
         assertEquals(0.0, res[1], 1e-6);
-        assertEquals(9, data.bunnyhopDelay);
+        assertEquals(9, data.getBunnyhopDelay());
     }
 }


### PR DESCRIPTION
## Summary
- add getters/setters for `bunnyhopDelay` and `creativeFlyVL`
- use these accessors across movement checks and listeners
- update unit tests for new API

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c443049bc83298329dbaa46761449

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor direct field access to use getter and setter methods for `bunnyhopDelay` and `creativeFlyVL` in the `MovingData` class and updates all relevant references in the code base.

### Why are these changes being made?
This refactoring improves encapsulation and ensures better control over the data manipulation by using getter and setter methods instead of direct field access, facilitating future changes related to data handling and validation. The primary aim is to conform to best practices for object-oriented programming by providing controlled access to class fields.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->