### PR TITLE
Fix farmland ground detection and add test

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_13.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_13.java
@@ -196,7 +196,8 @@ public class BlocksMC1_13 implements BlockPropertiesSetup {
 
         // Farm land. (Just in case not having multiversion plugin installed)
         BlockFlags.removeFlags(BridgeMaterial.FARMLAND, BlockFlags.F_HEIGHT100);
-        BlockFlags.addFlags(BridgeMaterial.FARMLAND, BlockFlags.F_XZ100 | BlockFlags.F_MIN_HEIGHT16_15);
+        BlockFlags.addFlags(BridgeMaterial.FARMLAND,
+                BlockFlags.F_XZ100 | BlockFlags.F_MIN_HEIGHT16_15 | BlockFlags.F_GROUND);
         
         ConfigFile config = ConfigManager.getConfigFile();
         if (config.getBoolean(ConfPaths.BLOCKBREAK_DEBUG, config.getBoolean(ConfPaths.CHECKS_DEBUG, false)))

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/special/MultiClientProtocolBlockShapePatch.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/special/MultiClientProtocolBlockShapePatch.java
@@ -60,7 +60,9 @@ public class MultiClientProtocolBlockShapePatch extends AbstractBlockPropertiesP
         BlockFlags.addFlags(BridgeMaterial.LILY_PAD, BlockFlags.F_GROUND | BlockFlags.F_HEIGHT8_1 | BlockFlags.F_GROUND_HEIGHT);
         done.add("water_lily");
 
-        BlockFlags.addFlags(BridgeMaterial.FARMLAND, BlockFlags.F_MIN_HEIGHT16_15 | BlockFlags.F_HEIGHT100 | BlockFlags.F_GROUND_HEIGHT);
+        BlockFlags.addFlags(BridgeMaterial.FARMLAND,
+                BlockFlags.F_MIN_HEIGHT16_15 | BlockFlags.F_HEIGHT100 | BlockFlags.F_GROUND_HEIGHT
+                        | BlockFlags.F_GROUND);
         done.add("soil");
 
         BlockFlags.addFlags(Material.VINE, BlockFlags.F_CLIMBUPABLE);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -4859,7 +4859,8 @@ public class BlockProperties {
 
     private static void registerSpecialStaticFlags() {
         // Flexible ground height for farmland (server uses bounding-box height)
-        BlockFlags.setFlag(BridgeMaterial.FARMLAND, BlockFlags.F_GROUND_HEIGHT);
+        BlockFlags.setFlag(BridgeMaterial.FARMLAND,
+                BlockFlags.F_GROUND_HEIGHT | BlockFlags.F_GROUND);
 
         // End-portal frames are fully solid ground
         BlockFlags.setFlag(BridgeMaterial.END_PORTAL_FRAME, BlockFlags.SOLID_GROUND);

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestFarmlandGround.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestFarmlandGround.java
@@ -1,0 +1,64 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.BridgeMaterial;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
+import fr.neatmonster.nocheatplus.utilities.location.RichBoundsLocation;
+import fr.neatmonster.nocheatplus.utilities.map.FakeBlockCache;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verify that farmland counts as ground in RichBoundsLocation.
+ */
+public class TestFarmlandGround {
+
+    public TestFarmlandGround() {
+        StaticLog.setUseLogManager(false);
+        BlockTests.initBlockProperties();
+        StaticLog.setUseLogManager(true);
+    }
+
+    private static World createWorld() {
+        InvocationHandler h = (proxy, method, args) -> {
+            if ("getName".equals(method.getName())) return "dummy";
+            Class<?> r = method.getReturnType();
+            if (r == boolean.class) return false;
+            if (r.isPrimitive()) return 0;
+            return null;
+        };
+        return (World) Proxy.newProxyInstance(World.class.getClassLoader(), new Class[]{World.class}, h);
+    }
+
+    @Test
+    public void testRichLocationOnFarmland() {
+        FakeBlockCache bc = new FakeBlockCache();
+        bc.set(0, 0, 0, BridgeMaterial.FARMLAND);
+        World world = createWorld();
+        Location loc = new Location(world, 0.5, 1.0, 0.5);
+        RichBoundsLocation rloc = new RichBoundsLocation(bc);
+        rloc.set(loc, 0.6, 1.8, 0.001);
+        assertTrue("Farmland should count as ground.", rloc.isOnGround());
+        bc.cleanup();
+    }
+}


### PR DESCRIPTION
## Summary
- mark farmland blocks as ground so on-ground checks succeed
- include farmland ground flag in static BlockProperties
- test that RichBoundsLocation considers farmland on ground

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685c475f5e688329b5a8243d39aee70e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance farmland ground detection by adding the `F_GROUND` flag to relevant block configurations and introduce a test to verify farmland is recognized as ground within the `RichBoundsLocation`.

### Why are these changes being made?

These changes address an issue where farmland blocks were not properly detected as ground in certain contexts. By including the `F_GROUND` flag for farmland and creating a corresponding test case, the detection mechanism is now improved, ensuring more accurate handling of block interactions. This solution corrects the detection logic without introducing additional complexity, providing a straightforward fix while adding automated coverage to prevent regression.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->