### PR TITLE
Refactor block break listener

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -119,146 +119,138 @@ public class BlockBreakListener extends CheckListener {
     public void onBlockBreak(final BlockBreakEvent event) {
         final long now = System.currentTimeMillis();
         final Player player = event.getPlayer();
+        if (player == null || !player.isOnline()) {
+            return;
+        }
         final IPlayerData pData = DataManager.getPlayerData(player);
 
-        if (!pData.isCheckActive(CheckType.BLOCKBREAK, player)) return;
-
-        // Illegal enchantments hotfix check.
-        // Legacy compatibility: encapsulate fully in dedicated handler.
-        if (Items.checkIllegalEnchantmentsAllHands(player, pData)) {
-            event.setCancelled(true);
-            counters.addPrimaryThread(idCancelDIllegalItem, 1);
-        }
-        else if (MovingUtil.hasScheduledPlayerSetBack(player)) {
-            event.setCancelled(true);
+        if (!pData.isCheckActive(CheckType.BLOCKBREAK, player)) {
+            return;
         }
 
-        // Cancelled events only leads to resetting insta break.
-        if (event.isCancelled()) {
+        if (initialCancelChecks(event, player, pData)) {
             isInstaBreak = AlmostBoolean.NO;
             return;
         }
 
         // Note: instaBreak might need invalidation on certain occasions.
 
-
         final Block block = event.getBlock();
-        boolean cancelled = false;
-        if (BlockProperties.isScaffolding(block.getType())) return;
-        // Do the actual checks, if still needed. It's a good idea to make computationally cheap checks first, because
-        // it may save us from doing the computationally expensive checks.
+        if (block == null || BlockProperties.isScaffolding(block.getType())) {
+            return;
+        }
+        final BreakCheckResult result = performBreakChecks(player, block, pData);
 
+        finalizeBreak(event, player, block, pData, result, now);
+    }
+
+    private boolean initialCancelChecks(final BlockBreakEvent event, final Player player,
+            final IPlayerData pData) {
+        if (Items.checkIllegalEnchantmentsAllHands(player, pData)) {
+            event.setCancelled(true);
+            counters.addPrimaryThread(idCancelDIllegalItem, 1);
+            return true;
+        }
+        if (MovingUtil.hasScheduledPlayerSetBack(player)) {
+            event.setCancelled(true);
+            return true;
+        }
+        return event.isCancelled();
+    }
+
+    private BreakCheckResult performBreakChecks(final Player player, final Block block,
+            final IPlayerData pData) {
+        final BreakCheckResult result = new BreakCheckResult();
         final BlockBreakConfig cc = pData.getGenericInstance(BlockBreakConfig.class);
         final BlockBreakData data = pData.getGenericInstance(BlockBreakData.class);
+        result.data = data;
         final BlockInteractData bdata = pData.getGenericInstance(BlockInteractData.class);
-        /*
-         * Re-check if this is a block interacted with before. With instantly
-         * broken blocks, this may be off by one orthogonally.
-         */
         final int tick = TickTask.getTick();
         final boolean isInteractBlock = !bdata.getLastIsCancelled() && bdata.matchesLastBlock(tick, block);
-        int skippedRedundantChecks = 0;
-
-
         final GameMode gameMode = player.getGameMode();
 
-        // Has the player broken a block that was not damaged before?
-        final boolean wrongBlockEnabled = wrongBlock.isEnabled(player, pData);
-        if (wrongBlockEnabled && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
-            cancelled = true;
+        if (wrongBlock.isEnabled(player, pData)
+                && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
+            result.cancelled = true;
         }
 
-        // Has the player broken more blocks per second than allowed?
-        if (!cancelled && frequency.isEnabled(player, pData) 
+        if (!result.cancelled && frequency.isEnabled(player, pData)
                 && frequency.check(player, tick, cc, data, pData)) {
-            cancelled = true;
+            result.cancelled = true;
         }
 
-        // Has the player broken blocks faster than possible?
-        if (!cancelled && gameMode != GameMode.CREATIVE
-                && fastBreak.isEnabled(player, pData) 
+        if (!result.cancelled && gameMode != GameMode.CREATIVE
+                && fastBreak.isEnabled(player, pData)
                 && fastBreak.check(player, block, isInstaBreak, cc, data, pData)) {
-            cancelled = true;
+            result.cancelled = true;
         }
 
-        // Did the arm of the player move before breaking this block?
-        if (!cancelled && noSwing.isEnabled(player, pData) 
+        if (!result.cancelled && noSwing.isEnabled(player, pData)
                 && noSwing.check(player, data, pData)) {
-            cancelled = true;
+            result.cancelled = true;
         }
 
-        final FlyingQueueHandle flyingHandle;
         final boolean reachEnabled = reach.isEnabled(player, pData);
         final boolean directionEnabled = direction.isEnabled(player, pData);
         if (reachEnabled || directionEnabled) {
-            flyingHandle = new FlyingQueueHandle(pData);
+            result.flyingHandle = new FlyingQueueHandle(pData);
             final Location loc = player.getLocation(useLoc);
             final double eyeHeight = MovingUtil.getEyeHeight(player);
-            // Is the block really in reach distance?
-            if (!cancelled) {
+            if (!result.cancelled) {
                 if (isInteractBlock && bdata.isPassedCheck(CheckType.BLOCKINTERACT_REACH)) {
-                    skippedRedundantChecks ++;
-                }
-                else if (reachEnabled && reach.check(player, eyeHeight, block, data, cc)) {
-                    cancelled = true;
+                    result.skippedRedundantChecks++;
+                } else if (reachEnabled && reach.check(player, eyeHeight, block, data, cc)) {
+                    result.cancelled = true;
                 }
             }
-
-            // Did the player look at the block at all?
-            // Consider skipping if checks have already been run on this block (all sorts of hashes/conditions).
-            if (!cancelled) {
+            if (!result.cancelled) {
                 if (isInteractBlock && (bdata.isPassedCheck(CheckType.BLOCKINTERACT_DIRECTION)
                         || bdata.isPassedCheck(CheckType.BLOCKINTERACT_VISIBLE))) {
-                    skippedRedundantChecks ++;
-                }
-                else if (directionEnabled && direction.check(player, loc, eyeHeight, block, null,
-                        flyingHandle, data, cc, pData)) {
-                    cancelled = true;
+                    result.skippedRedundantChecks++;
+                } else if (directionEnabled && direction.check(player, loc, eyeHeight, block, null,
+                        result.flyingHandle, data, cc, pData)) {
+                    result.cancelled = true;
                 }
             }
             useLoc.setWorld(null);
         }
-        else {
-            flyingHandle = null;
+
+        if (!result.cancelled && BlockProperties.isLiquid(block.getType())
+                && !BlockProperties.isWaterPlant(block.getType())
+                && !pData.hasPermission(Permissions.BLOCKBREAK_BREAK_LIQUID, player)
+                && !NCPExemptionManager.isExempted(player, CheckType.BLOCKBREAK_BREAK)) {
+            result.cancelled = true;
         }
 
-        // Destroying liquid blocks.
-        if (!cancelled && BlockProperties.isLiquid(block.getType()) && !BlockProperties.isWaterPlant(block.getType())
-                && !pData.hasPermission(Permissions.BLOCKBREAK_BREAK_LIQUID, player) 
-                && !NCPExemptionManager.isExempted(player, CheckType.BLOCKBREAK_BREAK)){
-            cancelled = true;
-        }
+        return result;
+    }
 
-        // On cancel...
-        if (cancelled) {
-            event.setCancelled(cancelled);
-            // Reset damage position:
-            // Needs review: verify if this gets set at all.
+    private void finalizeBreak(final BlockBreakEvent event, final Player player, final Block block,
+            final IPlayerData pData, final BreakCheckResult result, final long now) {
+        final BlockBreakData data = result.data != null ? result.data
+                : pData.getGenericInstance(BlockBreakData.class);
+        if (result.cancelled) {
+            event.setCancelled(true);
             data.clickedX = block.getX();
             data.clickedY = block.getY();
             data.clickedZ = block.getZ();
+        } else if (pData.isDebugActive(CheckType.BLOCKBREAK)) {
+            debugBlockBreakResult(player, block, result.skippedRedundantChecks, result.flyingHandle, pData);
         }
-        else {
-            // Invalidate last damage position:
-            //        	data.clickedX = Integer.MAX_VALUE;
-            // Debug log (only if not cancelled, to avoid spam).
-            if (pData.isDebugActive(CheckType.BLOCKBREAK)) {
-                debugBlockBreakResult(player, block, skippedRedundantChecks, 
-                        flyingHandle, pData);
-            }
-        }
-
         if (isInstaBreak.decideOptimistically()) {
             data.wasInstaBreak = now;
-        }
-        else {
+        } else {
             data.wasInstaBreak = 0;
         }
-
-        // Adjust data.
         data.fastBreakBreakTime = now;
-        //        data.fastBreakfirstDamage = now;
         isInstaBreak = AlmostBoolean.NO;
+    }
+
+    private static final class BreakCheckResult {
+        boolean cancelled;
+        int skippedRedundantChecks;
+        FlyingQueueHandle flyingHandle;
+        BlockBreakData data;
     }
 
     private void debugBlockBreakResult(final Player player, final Block block, final int skippedRedundantChecks, 


### PR DESCRIPTION
## Summary
- reduce complexity of `onBlockBreak` by splitting prechecks and main logic
- add helper methods for initial cancellation, performing checks, and finalizing
- add small result class for checks

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685c4a25eb34832986dda45ae3220921