### PR TITLE
Refactor ResourceUtil test helper

### DIFF
--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -38,13 +38,11 @@ public class ResourceUtil {
      * @return content of the resource or {@code null} if not available
      */
     public static String fetchResource(final Class<?> clazz, final String path) {
-        final String className = clazz.getSimpleName() + ".class";
-        final String classPath = clazz.getResource(className).toString();
-        if (!classPath.startsWith("jar")) {
+        final URL codeSource = clazz.getProtectionDomain().getCodeSource().getLocation();
+        if (!codeSource.toString().endsWith(".jar")) {
             return null;
         }
-        final String absPath = classPath.substring(0, classPath.lastIndexOf('!') + 1)
-                + "/" + path;
+        final String absPath = "jar:" + codeSource.toExternalForm() + "!/" + path;
         try {
             final URL url = new URL(absPath);
             try (BufferedReader reader = new BufferedReader(new InputStreamReader((InputStream) url.getContent(), StandardCharsets.UTF_8))) {

--- a/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
+++ b/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
@@ -2,7 +2,6 @@ package fr.neatmonster.nocheatplus.utilities.build;
 
 import static org.junit.Assert.*;
 
-import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -18,6 +17,7 @@ public class ResourceUtilTest {
 
     private Class<?> createJarWithResource() throws Exception {
         Path jar = Files.createTempFile("resource", ".jar");
+        jar.toFile().deleteOnExit();
         try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
             // Add ResourceUtil class from build output
             String classPath = "fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.class";
@@ -31,8 +31,9 @@ public class ResourceUtilTest {
             jos.write("KEY=VALUE\n".getBytes(StandardCharsets.UTF_8));
             jos.closeEntry();
         }
-        URLClassLoader cl = new URLClassLoader(new URL[] { jar.toUri().toURL() }, null);
-        return cl.loadClass("fr.neatmonster.nocheatplus.utilities.build.ResourceUtil");
+        try (URLClassLoader cl = new URLClassLoader(new URL[] { jar.toUri().toURL() }, null)) {
+            return cl.loadClass("fr.neatmonster.nocheatplus.utilities.build.ResourceUtil");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- remove unused `InputStream` import
- close the temporary URLClassLoader with try-with-resources
- delete temporary jar on exit
- avoid relying on an open class loader when fetching resources

## Testing
- `mvn -pl NCPBuildBase test`

------
https://chatgpt.com/codex/tasks/task_b_685c4f3dff4c83298a15473ad8200f51

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `ResourceUtil` class methods related to fetching resources and clean up `ResourceUtilTest` by improving resource management and removing unused imports.

### Why are these changes being made?

These changes enhance the code by using a cleaner and more reliable approach to determine jar file paths by utilizing `ProtectionDomain`, eliminating string manipulation errors. Additionally, the test cases are streamlined by removing unnecessary imports and ensuring `URLClassLoader` is closed appropriately, following best practices for resource management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->