### PR TITLE
Refactor performBreakChecks

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -161,6 +161,10 @@ public class BlockBreakListener extends CheckListener {
     private BreakCheckResult performBreakChecks(final Player player, final Block block,
             final IPlayerData pData) {
         final BreakCheckResult result = new BreakCheckResult();
+        if (player == null || block == null) {
+            return result;
+        }
+
         final BlockBreakConfig cc = pData.getGenericInstance(BlockBreakConfig.class);
         final BlockBreakData data = pData.getGenericInstance(BlockBreakData.class);
         result.data = data;
@@ -169,60 +173,91 @@ public class BlockBreakListener extends CheckListener {
         final boolean isInteractBlock = !bdata.getLastIsCancelled() && bdata.matchesLastBlock(tick, block);
         final GameMode gameMode = player.getGameMode();
 
-        if (wrongBlock.isEnabled(player, pData)
+        applyWrongBlockCheck(result, player, block, cc, data, pData);
+        applyFrequencyCheck(result, player, tick, cc, data, pData);
+        applyFastBreakCheck(result, player, block, gameMode, cc, data, pData);
+        applyNoSwingCheck(result, player, data, pData);
+        applyReachDirectionChecks(result, player, block, isInteractBlock, bdata, cc, data, pData);
+        applyLiquidBreakCheck(result, player, block, pData);
+
+        return result;
+    }
+
+    private void applyWrongBlockCheck(final BreakCheckResult result, final Player player,
+            final Block block, final BlockBreakConfig cc, final BlockBreakData data,
+            final IPlayerData pData) {
+        if (!result.cancelled && wrongBlock.isEnabled(player, pData)
                 && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
             result.cancelled = true;
         }
+    }
 
+    private void applyFrequencyCheck(final BreakCheckResult result, final Player player,
+            final int tick, final BlockBreakConfig cc, final BlockBreakData data,
+            final IPlayerData pData) {
         if (!result.cancelled && frequency.isEnabled(player, pData)
                 && frequency.check(player, tick, cc, data, pData)) {
             result.cancelled = true;
         }
+    }
 
+    private void applyFastBreakCheck(final BreakCheckResult result, final Player player,
+            final Block block, final GameMode gameMode, final BlockBreakConfig cc,
+            final BlockBreakData data, final IPlayerData pData) {
         if (!result.cancelled && gameMode != GameMode.CREATIVE
                 && fastBreak.isEnabled(player, pData)
                 && fastBreak.check(player, block, isInstaBreak, cc, data, pData)) {
             result.cancelled = true;
         }
+    }
 
+    private void applyNoSwingCheck(final BreakCheckResult result, final Player player,
+            final BlockBreakData data, final IPlayerData pData) {
         if (!result.cancelled && noSwing.isEnabled(player, pData)
                 && noSwing.check(player, data, pData)) {
             result.cancelled = true;
         }
+    }
 
+    private void applyReachDirectionChecks(final BreakCheckResult result, final Player player,
+            final Block block, final boolean isInteractBlock, final BlockInteractData bdata,
+            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
         final boolean reachEnabled = reach.isEnabled(player, pData);
         final boolean directionEnabled = direction.isEnabled(player, pData);
-        if (reachEnabled || directionEnabled) {
-            result.flyingHandle = new FlyingQueueHandle(pData);
-            final Location loc = player.getLocation(useLoc);
-            final double eyeHeight = MovingUtil.getEyeHeight(player);
-            if (!result.cancelled) {
-                if (isInteractBlock && bdata.isPassedCheck(CheckType.BLOCKINTERACT_REACH)) {
-                    result.skippedRedundantChecks++;
-                } else if (reachEnabled && reach.check(player, eyeHeight, block, data, cc)) {
-                    result.cancelled = true;
-                }
-            }
-            if (!result.cancelled) {
-                if (isInteractBlock && (bdata.isPassedCheck(CheckType.BLOCKINTERACT_DIRECTION)
-                        || bdata.isPassedCheck(CheckType.BLOCKINTERACT_VISIBLE))) {
-                    result.skippedRedundantChecks++;
-                } else if (directionEnabled && direction.check(player, loc, eyeHeight, block, null,
-                        result.flyingHandle, data, cc, pData)) {
-                    result.cancelled = true;
-                }
-            }
-            useLoc.setWorld(null);
+        if (!(reachEnabled || directionEnabled)) {
+            return;
         }
 
+        result.flyingHandle = new FlyingQueueHandle(pData);
+        final Location loc = player.getLocation(useLoc);
+        final double eyeHeight = MovingUtil.getEyeHeight(player);
+        if (!result.cancelled) {
+            if (isInteractBlock && bdata.isPassedCheck(CheckType.BLOCKINTERACT_REACH)) {
+                result.skippedRedundantChecks++;
+            } else if (reachEnabled && reach.check(player, eyeHeight, block, data, cc)) {
+                result.cancelled = true;
+            }
+        }
+        if (!result.cancelled) {
+            if (isInteractBlock && (bdata.isPassedCheck(CheckType.BLOCKINTERACT_DIRECTION)
+                    || bdata.isPassedCheck(CheckType.BLOCKINTERACT_VISIBLE))) {
+                result.skippedRedundantChecks++;
+            } else if (directionEnabled && direction.check(player, loc, eyeHeight, block, null,
+                    result.flyingHandle, data, cc, pData)) {
+                result.cancelled = true;
+            }
+        }
+        useLoc.setWorld(null);
+    }
+
+    private void applyLiquidBreakCheck(final BreakCheckResult result, final Player player,
+            final Block block, final IPlayerData pData) {
         if (!result.cancelled && BlockProperties.isLiquid(block.getType())
                 && !BlockProperties.isWaterPlant(block.getType())
                 && !pData.hasPermission(Permissions.BLOCKBREAK_BREAK_LIQUID, player)
                 && !NCPExemptionManager.isExempted(player, CheckType.BLOCKBREAK_BREAK)) {
             result.cancelled = true;
         }
-
-        return result;
     }
 
     private void finalizeBreak(final BlockBreakEvent event, final Player player, final Block block,


### PR DESCRIPTION
## Summary
- extract block break checks into helper methods
- keep listener logic readable

## Testing
- `mvn -q -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685c4f6966dc8329936153280165f3ab

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `performBreakChecks` method in `BlockBreakListener.java` to improve code readability and maintainability by extracting various block break checks into individual helper methods.

### Why are these changes being made?

The original `performBreakChecks` method was lengthy and complex, making it difficult to read and maintain. By breaking down the method into smaller, focused helper methods, it enhances code readability, supports easier maintenance, and helps follow the single responsibility principle. These changes also make it easier to understand and modify individual check logic in the future without affecting unrelated parts of the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->