### PR TITLE
Refactor passenger teleport helpers

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -321,70 +321,97 @@ public class PassengerUtil {
      * @param data
      * @return
      */
-    private final boolean teleportPlayerPassenger(final Player player, final Entity vehicle, final Location location, final boolean vehicleTeleported, final MovingData data, final boolean debug) {
+    private boolean teleportPlayerPassenger(final Player player, final Entity vehicle,
+                                            final Location location, final boolean vehicleTeleported,
+                                            final MovingData data, final boolean debug) {
+        if (player == null || vehicle == null || location == null) {
+            return false;
+        }
+
         final boolean playerTeleported;
         if (player.isOnline() && !player.isDead()) {
             final MovingConfig cc = DataManager.getGenericInstance(player, MovingConfig.class);
+
             // Mask player teleport as a set back.
             data.prepareSetBack(location);
-            playerTeleported = Folia.teleportEntity(player, LocUtil.clone(location), BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION);
+            playerTeleported = Folia.teleportEntity(player, LocUtil.clone(location),
+                    BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION);
             data.resetTeleported(); // Cleanup, just in case.
-            // Workarounds.
-            // Allow re-use of certain workarounds. Hack/shouldbedoneelsewhere?
+
+            // Allow re-use of certain workarounds.
             data.ws.resetConditions(WRPT.G_RESET_NOTINAIR);
 
-            if (playerTeleported && vehicleTeleported && player.getLocation(useLoc2).distance(vehicle.getLocation(useLoc)) < 1.5) {
-
-                // Still set as passenger.
-                // NOTE: VehicleEnter fires, unknown TP fires.
-                boolean scheduledelay = cc.schedulevehicleSetPassenger;
-                if (data.vehicleSetPassengerTaskId == null) {
-                    if (vehicle.getType() == EntityType.BOAT) {
-                        if (!handleVehicle.getHandle().addPassenger(player, vehicle)) {
-                            // Not schedule set passenger for boat due to location async
-                            // Re-add to vehicle then reject. Fix boat teleported but player didn't
-                        } 
-                        else vehicle.eject();
-                    } 
-                    else if (scheduledelay) {
-
-                        data.vehicleSetPassengerTaskId = Folia.runSyncDelayedTaskForEntity(player, plugin, (arg) -> new VehicleSetPassengerTask(handleVehicle, vehicle, player).run(), null, 2L);
-                        if (data.vehicleSetPassengerTaskId == null) {
-
-                            if (debug) CheckUtils.debug(player, CheckType.MOVING_VEHICLE, "Failed to schedule set passenger!");
-                            scheduledelay = false;
-                        } 
-                        else if (debug) CheckUtils.debug(player, CheckType.MOVING_VEHICLE, "Schedule set passenger task id: " + data.vehicleSetPassengerTaskId);
-                    }
-
-                    if (!scheduledelay) {
-                        if (debug) {
-                            CheckUtils.debug(player, CheckType.MOVING_VEHICLE, "Attempt set passenger directly");
-                        }
-
-                        handleVehicle.getHandle().addPassenger(player, vehicle);
-                    }
-                } 
-                else if (debug) CheckUtils.debug(player, CheckType.MOVING_VEHICLE, "Set passenger task already scheduled, skip this time.");
-                // Ensure a set back.
-                if (data.vehicleSetBacks.getFirstValidEntry(location) == null) {
-                    // At least ensure one of the entries has to match the location we teleported the vehicle to.
-                    if (debug) {
-                        CheckUtils.debug(player, CheckType.MOVING_VEHICLE, "No set back is matching the vehicle location that it has just been set back to. Reset all lazily to: " + location);
-                    }
-                    data.vehicleSetBacks.resetAllLazily(location);
-                }
-                // Set this location as past move.
-                final VehicleMoveData firstPastMove = data.vehicleMoves.getFirstPastMove();
-                if (!firstPastMove.valid || firstPastMove.toIsValid || !TrigUtil.isSamePos(firstPastMove.from, location)) {
-                    NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(AuxMoving.class).resetVehiclePositions(vehicle, location, data, cc);
-                }
+            if (playerTeleported && vehicleTeleported
+                    && player.getLocation(useLoc2).distance(vehicle.getLocation(useLoc)) < 1.5) {
+                handlePassengerScheduling(player, vehicle, cc, data, debug);
+                ensureSetBackLocation(player, location, data, debug);
+                updatePastMove(vehicle, location, data, cc);
             }
-        }
-        else {
+        } else {
             playerTeleported = false;
         }
+
         data.isVehicleSetBack = false;
         return playerTeleported;
+    }
+
+    private void handlePassengerScheduling(final Player player, final Entity vehicle,
+                                           final MovingConfig cc, final MovingData data,
+                                           final boolean debug) {
+        boolean scheduleDelay = cc.schedulevehicleSetPassenger;
+        if (data.vehicleSetPassengerTaskId == null) {
+            if (vehicle.getType() == EntityType.BOAT) {
+                if (!handleVehicle.getHandle().addPassenger(player, vehicle)) {
+                    // Not schedule set passenger for boat due to location async
+                } else {
+                    vehicle.eject();
+                }
+            } else if (scheduleDelay) {
+                data.vehicleSetPassengerTaskId = Folia.runSyncDelayedTaskForEntity(player, plugin,
+                        (arg) -> new VehicleSetPassengerTask(handleVehicle, vehicle, player).run(), null, 2L);
+                if (data.vehicleSetPassengerTaskId == null) {
+                    if (debug) {
+                        CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                                "Failed to schedule set passenger!");
+                    }
+                    scheduleDelay = false;
+                } else if (debug) {
+                    CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                            "Schedule set passenger task id: " + data.vehicleSetPassengerTaskId);
+                }
+            }
+
+            if (!scheduleDelay) {
+                if (debug) {
+                    CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                            "Attempt set passenger directly");
+                }
+                handleVehicle.getHandle().addPassenger(player, vehicle);
+            }
+        } else if (debug) {
+            CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                    "Set passenger task already scheduled, skip this time.");
+        }
+    }
+
+    private void ensureSetBackLocation(final Player player, final Location location,
+                                       final MovingData data, final boolean debug) {
+        if (data.vehicleSetBacks.getFirstValidEntry(location) == null) {
+            if (debug) {
+                CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                        "No set back is matching the vehicle location that it has just been set back to. Reset all lazily to: "
+                                + location);
+            }
+            data.vehicleSetBacks.resetAllLazily(location);
+        }
+    }
+
+    private void updatePastMove(final Entity vehicle, final Location location, final MovingData data,
+                                final MovingConfig cc) {
+        final VehicleMoveData firstPastMove = data.vehicleMoves.getFirstPastMove();
+        if (!firstPastMove.valid || firstPastMove.toIsValid || !TrigUtil.isSamePos(firstPastMove.from, location)) {
+            NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(AuxMoving.class)
+                    .resetVehiclePositions(vehicle, location, data, cc);
+        }
     }
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
@@ -1,0 +1,91 @@
+package fr.neatmonster.nocheatplus.utilities.entity;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.components.registry.event.IHandle;
+import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
+import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
+import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+
+public class PassengerUtilTest {
+
+    private static class SimpleHandle<T> implements IHandle<T> {
+        private final T handle;
+        SimpleHandle(T h){ this.handle = h; }
+        @Override public T getHandle(){ return handle; }
+        public void disableHandle(){}
+    }
+
+    private static class DummyVehicleAccess implements IEntityAccessVehicle {
+        boolean called;
+        @Override public java.util.List<Entity> getEntityPassengers(Entity e) { return Collections.emptyList(); }
+        @Override public boolean addPassenger(Entity entity, Entity vehicle) { called = true; return true; }
+    }
+
+    private sun.misc.Unsafe unsafe;
+
+    @Before
+    public void setup() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        unsafe = (sun.misc.Unsafe) f.get(null);
+    }
+
+    private PassengerUtil newUtil(DummyVehicleAccess access) throws Exception {
+        PassengerUtil util = (PassengerUtil) unsafe.allocateInstance(PassengerUtil.class);
+        Field f = PassengerUtil.class.getDeclaredField("handleVehicle");
+        f.setAccessible(true);
+        f.set(util, new SimpleHandle<>(access));
+        return util;
+    }
+
+    private MovingData newData() throws Exception {
+        return (MovingData) unsafe.allocateInstance(MovingData.class);
+    }
+
+    private MovingConfig newConfig() throws Exception {
+        MovingConfig cfg = (MovingConfig) unsafe.allocateInstance(MovingConfig.class);
+        Field f = MovingConfig.class.getDeclaredField("schedulevehicleSetPassenger");
+        f.setAccessible(true);
+        f.setBoolean(cfg, false);
+        return cfg;
+    }
+
+    @Test
+    public void testTeleportPlayerPassengerNullArgs() throws Exception {
+        PassengerUtil util = newUtil(new DummyVehicleAccess());
+        Method m = PassengerUtil.class.getDeclaredMethod("teleportPlayerPassenger", Player.class, Entity.class,
+                org.bukkit.Location.class, boolean.class, MovingData.class, boolean.class);
+        m.setAccessible(true);
+        MovingData data = newData();
+        boolean res = (boolean) m.invoke(util, null, null, null, false, data, false);
+        assertFalse(res);
+    }
+
+    @Test
+    public void testScheduleSetPassengerDirectAdd() throws Exception {
+        DummyVehicleAccess access = new DummyVehicleAccess();
+        PassengerUtil util = newUtil(access);
+        Method sched = PassengerUtil.class.getDeclaredMethod("handlePassengerScheduling", Player.class,
+                Entity.class, MovingConfig.class, MovingData.class, boolean.class);
+        sched.setAccessible(true);
+        Player player = mock(Player.class);
+        Entity vehicle = mock(Entity.class);
+        when(vehicle.getType()).thenReturn(EntityType.MINECART);
+        MovingConfig cfg = newConfig();
+        MovingData data = newData();
+        sched.invoke(util, player, vehicle, cfg, data, false);
+        assertTrue(access.called);
+    }
+}


### PR DESCRIPTION
## Summary
- split teleportPlayerPassenger into smaller helpers
- add null checks for teleport parameters
- unit tests for teleport helper methods

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685c5030d6b88329adfb68d658ec5839