### PR TITLE
Add tests for ReflectBlockSix name detection

### DIFF
--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSixTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSixTest.java
@@ -1,0 +1,89 @@
+package fr.neatmonster.nocheatplus.compat.cbreflect.reflect;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class ReflectBlockSixTest {
+
+    private static sun.misc.Unsafe getUnsafe() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (sun.misc.Unsafe) f.get(null);
+    }
+
+    private static String[] guess(Class<?> clazz) throws Exception {
+        sun.misc.Unsafe u = getUnsafe();
+        ReflectBlockSix instance = (ReflectBlockSix) u.allocateInstance(ReflectBlockSix.class);
+        Method m = ReflectBlockSix.class.getDeclaredMethod("guessBoundsMethodNames", Class.class);
+        m.setAccessible(true);
+        return (String[]) m.invoke(instance, clazz);
+    }
+
+    public static class MockSuccess {
+        public double d() { return 0; }
+        public double a() { return 0; }
+        public double f() { return 0; }
+        public double c() { return 0; }
+        public double e() { return 0; }
+        public double b() { return 0; }
+    }
+
+    public static class MockTooFew {
+        public double a() { return 0; }
+        public double b() { return 0; }
+        public double c() { return 0; }
+        public double d() { return 0; }
+        public double e() { return 0; }
+    }
+
+    public static class MockTooMany {
+        public double a() { return 0; }
+        public double b() { return 0; }
+        public double c() { return 0; }
+        public double d() { return 0; }
+        public double e() { return 0; }
+        public double f() { return 0; }
+        public double g() { return 0; }
+    }
+
+    public static class MockMultiple {
+        public double a() { return 0; }
+        public double b() { return 0; }
+        public double c() { return 0; }
+        public double d() { return 0; }
+        public double e() { return 0; }
+        public double f() { return 0; }
+        public double k() { return 0; }
+        public double l() { return 0; }
+        public double m() { return 0; }
+        public double n() { return 0; }
+        public double o() { return 0; }
+        public double p() { return 0; }
+    }
+
+    @Test
+    public void testGuessBoundsSuccess() throws Exception {
+        String[] names = guess(MockSuccess.class);
+        assertArrayEquals(new String[]{"a", "b", "c", "d", "e", "f"}, names);
+    }
+
+    @Test
+    public void testGuessBoundsTooFew() throws Exception {
+        assertNull(guess(MockTooFew.class));
+    }
+
+    @Test
+    public void testGuessBoundsTooMany() throws Exception {
+        assertNull(guess(MockTooMany.class));
+    }
+
+    @Test
+    public void testGuessBoundsMultipleSequences() throws Exception {
+        assertNull(guess(MockMultiple.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ReflectBlockSixTest` verifying name sequence detection logic

## Testing
- `mvn test`
- `mvn verify`
- `mvn -q checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685c540e9fac83298c42babcd4377467

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add unit tests for the `ReflectBlockSix` class to verify the accuracy and correctness of method name detection logic using different mock classes.

### Why are these changes being made?

These changes address the need for robust testing of the `ReflectBlockSix` class's private method `guessBoundsMethodNames`, ensuring that the method correctly identifies sequences of method names under various conditions. This testing is essential for validating the method's behavior and identifying potential issues when dealing with different class structures.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->