### PR TITLE
Refactor block bounds discovery

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
@@ -151,56 +151,62 @@ public class ReflectBlockSix implements IReflectBlock {
         return methods;
     }
 
-    private String[] guessBoundsMethodNames(Class<?> clazz) {
-        // Filter accepted method names.
+    private List<String> collectCandidateBoundsMethods(Class<?> clazz) {
         List<String> names = new ArrayList<String>();
         for (Method method : clazz.getMethods()) {
-            if (method.getReturnType() == double.class && method.getParameterTypes().length == 0 && possibleNames.contains(method.getName())) {
+            if (method.getReturnType() == double.class && method.getParameterTypes().length == 0
+                    && possibleNames.contains(method.getName())) {
                 names.add(method.getName());
             }
         }
+        return names;
+    }
+
+    private int findSixConsecutiveIndex(List<String> names) {
+        int size = names.size();
+        if (size < 6) {
+            return -1;
+        }
+        if (size == 6) {
+            return 0;
+        }
+        int startIndex = -1; // Start index within list (!).
+        int lastIndex = -2; // Index of a sequence within possibleNames.
+        int currentStart = -1; // Possibly incomplete sequence.
+        for (int i = 0; i < size; i++) {
+            String name = names.get(i);
+            int nameIndex = possibleNames.indexOf(name);
+            if (nameIndex - lastIndex == 1) {
+                if (currentStart == -1) {
+                    currentStart = nameIndex - 1;
+                } else {
+                    int length = nameIndex - currentStart + 1;
+                    if (length > 6) {
+                        return -1;
+                    } else if (length == 6) {
+                        if (startIndex != -1) {
+                            return -1;
+                        }
+                        startIndex = i + 1 - length;
+                    }
+                }
+            } else {
+                currentStart = -1;
+            }
+            lastIndex = nameIndex;
+        }
+        return startIndex;
+    }
+
+    private String[] guessBoundsMethodNames(Class<?> clazz) {
+        List<String> names = collectCandidateBoundsMethods(clazz);
         if (names.size() < 6) {
             return null;
         }
-        // Sort in the expected order.
         names.sort(Comparator.comparingInt(possibleNames::indexOf));
-        // Test for a sequence of exactly 6 consecutive entries.
-        int startIndex = 0;
-        if (names.size() > 6) {
-            // Attempt to guess the start index. Currently FUTURE, as there are only six such methods.
-            startIndex = -1; // Start index within list (!).
-            int lastIndex = -2; // Index of a sequence within possibleNames.
-            int currentStart = -1; // Possibly incomplete sequence.
-            for (int i = 0; i < names.size(); i++) {
-                String name = names.get(i);
-                int nameIndex = possibleNames.indexOf(name);
-                if (nameIndex - lastIndex == 1) {
-                    if (currentStart == -1) {
-                        currentStart = nameIndex - 1;
-                    } else {
-                        int length = nameIndex - currentStart + 1;
-                        if (length > 6) {
-                            // Can't decide (too many).
-                            return null;
-                        }
-                        else if (length == 6) {
-                            if (startIndex != -1) {
-                                // Can't decide (too many).
-                                return null;
-                            } else {
-                                startIndex = i + 1 - length;
-                                // (Not reset currentStart to allow detecting too long sequences.)
-                            }
-                        }
-                    }
-                } else {
-                    currentStart = -1;
-                }
-                lastIndex = nameIndex;
-            }
-            if (startIndex == -1) {
-                return null;
-            }
+        int startIndex = findSixConsecutiveIndex(names);
+        if (startIndex < 0) {
+            return null;
         }
         String[] res = new String[6];
         for (int i = 0; i < 6; i++) {


### PR DESCRIPTION
## Summary
- move name filtering into `collectCandidateBoundsMethods`
- add `findSixConsecutiveIndex` for sequence search
- simplify `guessBoundsMethodNames`

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q checkstyle:check`
- `mvn -q pmd:check`
- `mvn -q com.github.spotbugs:spotbugs-maven-plugin:4.9.3.0:check`

------
https://chatgpt.com/codex/tasks/task_b_685c540f45c88329802df3161f2521b2