### PR TITLE
Add bypass-exempt safeguard to NoFall

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
@@ -436,7 +436,7 @@ public class NoFall extends Check {
         }
         // Callers usually check bypass and exemption beforehand, but guard here
         // to avoid processing if invoked directly without those checks.
-        if (pData.hasBypass(type, player) || pData.isExempted(type)) {
+        if (shouldSkipCheck(pData, player)) {
             return;
         }
 
@@ -499,6 +499,13 @@ public class NoFall extends Check {
             debug(player, "NoFall: mc=" + mcFallDistance +" / nf=" + data.noFallFallDistance + (oldNFDist < data.noFallFallDistance ? " (+" + (data.noFallFallDistance - oldNFDist) + ")" : "") + " | ymax=" + data.noFallMaxY);
         }
 
+    }
+
+    /**
+     * Decide if the check should return early due to bypass or exemption.
+     */
+    private boolean shouldSkipCheck(final IPlayerData pData, final Player player) {
+        return pData.hasBypass(type, player) || pData.isExempted(type);
     }
 
     private void handleGroundTransitions(final Player player, final double previousSetBackY,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/NoFall.java
@@ -434,6 +434,11 @@ public class NoFall extends Check {
                 || cc == null || pData == null) {
             return;
         }
+        // Callers usually check bypass and exemption beforehand, but guard here
+        // to avoid processing if invoked directly without those checks.
+        if (pData.hasBypass(type, player) || pData.isExempted(type)) {
+            return;
+        }
 
         final boolean debug = pData.isDebugActive(type);
         final PlayerMoveData thisMove = data.playerMoves.getCurrentMove();


### PR DESCRIPTION
## Summary
- prevent running the NoFall check if the player bypasses or is exempted

## Testing
- `mvn -q -DskipITs verify` *(fails: TestGodModeHelpers NullPointerException)*
- `mvn -q -DskipTests checkstyle:check pmd:check spotbugs:check` *(errors from spotbugs but build continues)*

------
https://chatgpt.com/codex/tasks/task_b_685c578b4a248329a8b21587596b83dc

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a safeguard to the `NoFall` check to prevent processing if a player is exempted or has bypass permissions.

### Why are these changes being made?

The change ensures that even if the `NoFall` method is called directly, it will not process exempted players or those with bypass permissions. This additional validation acts as a fail-safe to maintain the integrity of checks by preventing unnecessary processing, enhancing both performance and security.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance by adding an early-exit check to prevent unnecessary processing for players with bypass permissions or exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->