### PR TITLE
Fix inventory update call in FastConsume

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
@@ -80,6 +80,9 @@ public class FastConsume extends Check implements Listener, INotifyReload {
             return;
         }
         final IPlayerData pData = DataManager.getPlayerData(player);
+        if (pData == null) {
+            return;
+        }
         if (!pData.isCheckActive(type, player)) {
             return;
         }
@@ -87,7 +90,9 @@ public class FastConsume extends Check implements Listener, INotifyReload {
         final long time = System.currentTimeMillis();
         if (check(player, event.getItem(), time, data, pData)){
             event.setCancelled(true);
-            DataManager.getPlayerData(player).requestUpdateInventory();
+            if (pData != null) {
+                pData.requestUpdateInventory();
+            }
         }
     }
 

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
@@ -73,26 +73,31 @@ public class FastConsume extends Check implements Listener, INotifyReload {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onItemConsume(final PlayerItemConsumeEvent event){
         final Player player = event.getPlayer();
-        if (player.isDead() && BridgeHealth.getHealth(player) <= 0.0) {
-            // Eat after death.
-            event.setCancelled(true);
-            counters.addPrimaryThread(idCancelDead, 1);
+        if (shouldCancelForDeath(event, player)) {
             return;
         }
         final IPlayerData pData = DataManager.getPlayerData(player);
-        if (pData == null) {
+        if (pData == null || !pData.isCheckActive(type, player)) {
             return;
         }
-        if (!pData.isCheckActive(type, player)) {
-            return;
+        handleFastConsume(event, player, pData);
+    }
+
+    private boolean shouldCancelForDeath(final PlayerItemConsumeEvent event, final Player player) {
+        if (player.isDead() && BridgeHealth.getHealth(player) <= 0.0) {
+            event.setCancelled(true);
+            counters.addPrimaryThread(idCancelDead, 1);
+            return true;
         }
+        return false;
+    }
+
+    private void handleFastConsume(final PlayerItemConsumeEvent event, final Player player, final IPlayerData pData) {
         final InventoryData data = pData.getGenericInstance(InventoryData.class);
         final long time = System.currentTimeMillis();
-        if (check(player, event.getItem(), time, data, pData)){
+        if (check(player, event.getItem(), time, data, pData)) {
             event.setCancelled(true);
-            if (pData != null) {
-                pData.requestUpdateInventory();
-            }
+            pData.requestUpdateInventory();
         }
     }
 


### PR DESCRIPTION
## Summary
- fix duplicate getPlayerData call when updating inventory after fast consume events
- null check pData before use

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: EI_EXPOSE_REP2, RV_NEGATING_RESULT_OF_COMPARETO, ...)*

------
https://chatgpt.com/codex/tasks/task_b_685c578838d483298558c06398906592

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Ensure the player data is not null before attempting to update inventory in the `FastConsume` class, enhancing stability of the `onItemConsume` method.

### Why are these changes being made?

The update guards against potential null pointer exceptions by checking for nullity of the player data before proceeding, which addresses issues with inventory update calls during player item consumption. This preventative measure ensures the code handles edge cases gracefully, preventing crashes and promoting robust gameplay functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal structure of inventory consumption checks for better clarity and maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->