### PR TITLE
Fix else brace spacing

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
@@ -328,7 +328,7 @@ public class ReflectionUtil {
                             }
                         }
                     }
-                    else{
+                    else {
                         // Check if the return type is preferred over previously found ones.
                         for (int i = 0; i < returnTypeIndex; i++){
                             if (returnTypePreference[i] == returnType){

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/bktree/BKModTree.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/bktree/BKModTree.java
@@ -103,7 +103,7 @@ public abstract class BKModTree<V, N extends Node<V, N>, L extends LookupEntry<V
 					if (child != null) nodes.add(child);
 				}
 			}
-			else{
+			else {
                                for (final Integer key : children.keySet()){
                                        // Unclear if this approach is faster than using the EntrySet.
                                        if (Math.abs(distance - key.intValue()) <= range) nodes.add(children.get(key));

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/AbstractCoordHashMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/AbstractCoordHashMap.java
@@ -196,7 +196,7 @@ public abstract class AbstractCoordHashMap<V, E extends fr.neatmonster.nocheatpl
                     if (used < 0) {
                         newBucket = new LinkedList<E>();
                     }
-                    else{
+                    else {
                         newBucket = entries[used];
                         entries[used] = null;
                         used--;

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/CoordHashMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/CoordHashMap.java
@@ -109,7 +109,7 @@ public class CoordHashMap<V> extends AbstractCoordHashMap<V, fr.neatmonster.noch
                         }
                         return res;
                     }
-                    else{
+                    else {
                         // Inconsistent state; bucket might be empty.
                         slot++;
                         index = 0;

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/ManagedMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/ManagedMap.java
@@ -66,7 +66,7 @@ public class ManagedMap<K, V>{
             map.put(key, new ValueWrap(value));
             return null;
         }
-        else{
+        else {
             final V res = wrap.getValue();
             wrap.setValue(value);
             wrap.ts = System.currentTimeMillis();
@@ -77,7 +77,7 @@ public class ManagedMap<K, V>{
     public V get(final K key){
         final ValueWrap wrap = map.get(key);
         if (wrap == null) return null;
-        else{
+        else {
             wrap.ts = System.currentTimeMillis();
             return wrap.getValue();
         }

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/prefixtree/PrefixTree.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/prefixtree/PrefixTree.java
@@ -169,7 +169,7 @@ public class PrefixTree<K, N extends Node<K, N>, L extends LookupEntry<K, N>>{
 				} 
 				else break;
 			}
-			else{
+			else {
 				// A node already exists, set as insertion point.
 				insertion = current = child;
 				depth ++;

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/workaround/SimpleWorkaroundRegistry.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/workaround/SimpleWorkaroundRegistry.java
@@ -202,7 +202,7 @@ public class SimpleWorkaroundRegistry implements IWorkaroundRegistry {
             if (bluePrint == null) {
                 throw new IllegalArgumentException("No blueprint registered for: " + workaround.getId());
             }
-            else  {
+            else {
                 ids.add(bluePrint.getId());
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/ActionWithParameters.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/actions/types/ActionWithParameters.java
@@ -70,7 +70,7 @@ public abstract class ActionWithParameters<D extends ParameterHolder, L extends 
             if (part instanceof String)
                 log.append((String) part);
             else if (part == null) log.append("[???]");
-            else{
+            else {
             	try{
             		log.append(violationData.getParameter((ParameterName) part));
             	}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
@@ -58,13 +58,13 @@ public class Frequency extends Check {
                 // Within range, add.
                 data.frequencyShortTermCount ++;
             }
-            else{
+            else {
                 // Too much lag, reset.
                 data.frequencyShortTermTick = tick;
                 data.frequencyShortTermCount = 1;
             }
         }
-        else{
+        else {
             data.frequencyShortTermTick = tick;
             data.frequencyShortTermCount = 1;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Reach.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Reach.java
@@ -82,7 +82,7 @@ public class Reach extends Check {
             final ViolationData vd = new ViolationData(this, player, data.reachVL, distance, cc.reachActions);
             vd.setParameter(ParameterName.REACH_DISTANCE, String.valueOf(Math.round(data.reachDistance)));
             cancel = executeActions(vd).willCancel();
-        } else{
+        } else {
             // Player passed the check, reward them.
             data.reachVL *= 0.9D;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
@@ -54,7 +54,7 @@ public class Speed extends Check {
                 data.addPassedCheck(this.type); // Not sure.
             }
         }
-        else{
+        else {
             data.speedVL *= 0.99;
             data.addPassedCheck(this.type);
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
@@ -66,13 +66,13 @@ public class FastPlace extends Check {
                 // Within range, add.
                 data.fastPlaceShortTermCount ++;
             }
-            else{
+            else {
                 // Too much lag, reset.
                 data.fastPlaceShortTermTick = tick;
                 data.fastPlaceShortTermCount = 1;
             }
         }
-        else{
+        else {
             data.fastPlaceShortTermTick = tick;
             data.fastPlaceShortTermCount = 1;
         }
@@ -84,11 +84,11 @@ public class FastPlace extends Check {
             if (lag) {
                 fullViolation = fullScore / TickTask.getLag(data.fastPlaceBuckets.bucketDuration() * data.fastPlaceBuckets.numberOfBuckets(), true) - cc.fastPlaceLimit;
             }
-            else{
+            else {
                 fullViolation = fullScore - cc.fastPlaceLimit;
             }	
         }
-        else{
+        else {
             fullViolation = 0;
         }
         final float shortTermViolation = data.fastPlaceShortTermCount - cc.fastPlaceShortTermLimit; 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Reach.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Reach.java
@@ -83,7 +83,7 @@ public class Reach extends Check {
             final ViolationData vd = new ViolationData(this, player, data.reachVL, distance, cc.reachActions);
             vd.setParameter(ParameterName.REACH_DISTANCE, String.valueOf(data.reachDistance));
             cancel = executeActions(vd).willCancel();
-        } else{
+        } else {
             // Player passed the check, reward them.
             data.reachVL *= 0.9D;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
@@ -69,13 +69,13 @@ public class Commands extends Check {
                 // Add up.
                 data.commandsShortTermWeight += weight;
             }
-            else{
+            else {
                 // Reset, too much lag.
                 data.commandsShortTermTick = tick;
                 data.commandsShortTermWeight = 1.0;
             }
         }
-        else{
+        else {
             // Reset.
             data.commandsShortTermTick = tick;
             data.commandsShortTermWeight = 1.0;
@@ -99,7 +99,7 @@ public class Commands extends Check {
             player.sendMessage(ColorUtil.replaceColors(cc.chatWarningMessage));
             data.chatWarningTime = now;
         }
-        else{
+        else {
             data.commandsVL *= 0.99;
         }
         return false;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Relog.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Relog.java
@@ -55,7 +55,7 @@ public class Relog extends Check {
                 player.sendMessage(ColorUtil.replaceColors(cc.relogWarningMessage));
                 data.relogWarningTime = now;
                 data.relogWarnings++;
-            } else{
+            } else {
                 // Find out if we need to ban the player or not.
                 data.relogVL += 1D;
                 cancel = executeActions(player, (double) data.relogVL, 1D, cc.relogActions).willCancel();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/analysis/engine/processors/DigestedWords.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/analysis/engine/processors/DigestedWords.java
@@ -101,7 +101,7 @@ public abstract class DigestedWords extends AbstractWordProcessor{
 		other.clear();
 		Collection<Character> chars;
 		if (compress) chars = word.counts.keySet();
-		else{
+		else {
 			// Add all.
 			chars = new ArrayList<Character>(word.word.length());
 			for (int i = 0; i < word.word.length(); i++){

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Direction.java
@@ -80,7 +80,7 @@ public class Direction extends Check {
         /*if (cc.directionStrict){
             off = CollisionUtil.combinedDirectionCheck(loc, player.getEyeHeight(), direction, dLoc.getX(), dLoc.getY() + height / 2D, dLoc.getZ(), width, height, TrigUtil.DIRECTION_PRECISION, 80.0, isPlayer);
         }
-        else{
+        else {
             // Also take into account the angle.
             off = CollisionUtil.directionCheck(loc, player.getEyeHeight(), direction, dLoc.getX(), dLoc.getY() + height / 2D, dLoc.getZ(), width, height, TrigUtil.DIRECTION_PRECISION);
         } */

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FastHeal.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FastHeal.java
@@ -47,7 +47,7 @@ public class FastHeal extends Check {
             // Only add a predefined amount to the buffer.
             data.fastHealBuffer = Math.min(cc.fastHealBuffer, data.fastHealBuffer + 50L);
         }
-        else{
+        else {
             // Violation.
             final double correctedDiff = ((double) time - data.fastHealRefTime) * TickTask.getLag(cc.fastHealInterval, true);
             if (correctedDiff < cc.fastHealInterval){

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/GodMode.java
@@ -127,7 +127,7 @@ public class GodMode extends Check {
         if (dState.tick < data.godModeHealthDecreaseTick){
             data.godModeHealthDecreaseTick = 0;
         }
-        else{
+        else {
             final int dht = dState.tick - data.godModeHealthDecreaseTick;
             if (dht <= 20) {
                 return false;
@@ -156,7 +156,7 @@ public class GodMode extends Check {
                 cancel = false;
             }
         }
-        else{
+        else {
             cancel = false;
         }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Speed.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Speed.java
@@ -71,13 +71,13 @@ public class Speed extends Check {
                 // Within range, add.
                 data.speedShortTermCount ++;
             }
-            else{
+            else {
                 // Too much lag, reset.
                 data.speedShortTermTick = tick;
                 data.speedShortTermCount = 1;
             }
         }
-        else{
+        else {
             data.speedShortTermTick = tick;
             data.speedShortTermCount = 1;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
@@ -253,7 +253,7 @@ public class Passable extends Check {
             newTo.setPitch(to.getPitch());
             return newTo;
         }
-        else{
+        else {
             // No cancel action set.
             return null;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/NoCheatPlusCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/NoCheatPlusCommand.java
@@ -181,7 +181,7 @@ public class NoCheatPlusCommand extends BaseCommand {
             sender.sendMessage(ColorUtil.replaceColors(config.getString(ConfPaths.PROTECT_PLUGINS_HIDE_NOCOMMAND_MSG)));
             return true; 
         }
-        else{
+        else {
             return false;
         }
     }
@@ -223,7 +223,7 @@ public class NoCheatPlusCommand extends BaseCommand {
     //				// Also check aliases for matches.
     //				return getTabMatches(sender, commands.keySet(), subLabel);
     //			}
-    //			else{
+    //			else {
     //				final NCPCommand cmd = commands.get(subLabel);
     //				if (cmd.testPermission...){
     //					// Delegate the tab-completion.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/actions/delay/DelayableCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/actions/delay/DelayableCommand.java
@@ -148,7 +148,7 @@ public abstract class DelayableCommand extends BaseCommand {
             alteredArgs = args;
             return true;
         }
-        else{
+        else {
             boolean hasDef = args[delayIndex].startsWith("delay=") && delay != -1;
             alteredArgs = new String[args.length + (hasDef ? -1 : 0)];
             if (alteredArgs.length > 0){

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/LagCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/LagCommand.java
@@ -70,7 +70,7 @@ public class LagCommand extends BaseCommand {
                 else if (i < spikeDurations.length - 1){
                     builder.append(cG + "\n• " + cGO +""+ (spikes[i] - spikes[i + 1]) + cG + "spike(s) x " + cGO +""+ cGO +""+ spikeDurations[i] + cG + "ms -> " + cGO +""+ spikeDurations[i + 1] + cG + ". ");
                 }
-                else{
+                else {
                     builder.append(cG + "\n• " + cGO +""+ spikes[i] + cG + "spike(s) x " + cGO +""+ cGO +""+ spikeDurations[i] +"ms"+ cG + ".");
                 }
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/BridgeHealth.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/BridgeHealth.java
@@ -89,12 +89,12 @@ public class BridgeHealth {
         if (o1 instanceof Number) {
             return ((Number) o1).doubleValue();
         }
-        else{
+        else {
             String message = "Expect method " + methodName + " in " + obj.getClass() + " with return type double or int, returned instead: " + ((o1 == null ? "null" : o1.getClass().getName()));
             if (reason == null) {
                 throw new RuntimeException(message);
             }
-            else{
+            else {
                 throw new RuntimeException(message, reason);
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/RegistrationOrder.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/order/RegistrationOrder.java
@@ -260,7 +260,7 @@ public class RegistrationOrder {
                     output[i] = item;
                     return;
                 }
-                else  {
+                else {
                     output[i] = output[i + 1];
                 }
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/RawConfigFile.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/RawConfigFile.java
@@ -169,7 +169,7 @@ public class RawConfigFile  extends YamlConfiguration {
             if (mat == null){
                 StaticLog.logWarning("Bad material entry (" + path +"): " + entry);
             }
-            else{
+            else {
                 target.add(mat);
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MiniListenerNode.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MiniListenerNode.java
@@ -129,7 +129,7 @@ public class MiniListenerNode<E, P> {
         if (registeredListeners.isEmpty()) {
             clear();
         }
-        else  {
+        else {
             final Object[] sortedOdd = typedSort.getSortedArray(registeredListeners);
             @SuppressWarnings("unchecked")
             final ListenerEntry<E>[] sortedListeners = new ListenerEntry[sortedOdd.length];

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/hooks/NCPHookManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/hooks/NCPHookManager.java
@@ -427,7 +427,7 @@ public final class NCPHookManager {
                     return applyHooks(type, violationData.player, violationData, hooksCheck);
                 }
             }
-            else{
+            else {
                 return applyHooks(type, violationData.player, violationData, hooksCheck);
             }
         }   

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionUtil.java
@@ -145,7 +145,7 @@ public class PermissionUtil {
                 command.setPermission(cmdPermName);
                 cmdHadPerm = false;
             }
-            else{
+            else {
                 cmdHadPerm = true;
             }
             // Set permission default behavior.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerMap.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerMap.java
@@ -131,7 +131,7 @@ public final class PlayerMap {
             if (storePlayerInstances) {
                 info.player = getPlayerBukkit(info);
                 return info.player;
-            } else  {
+            } else {
                 return getPlayerBukkit(info);
             }
         } else {
@@ -148,7 +148,7 @@ public final class PlayerMap {
             if (storePlayerInstances) {
                 info.player = getPlayerBukkit(info);
                 return info.player;
-            } else  {
+            } else {
                 return getPlayerBukkit(info);
             }
         } else {
@@ -169,7 +169,7 @@ public final class PlayerMap {
             if (storePlayerInstances) {
                 info.player = getPlayerBukkit(info);
                 return info.player;
-            } else  {
+            } else {
                 return getPlayerBukkit(info);
             }
         } else {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/ColorUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/ColorUtil.java
@@ -61,7 +61,7 @@ public class ColorUtil {
 				// Skip this one;
 				srcIndex ++;
 			}
-			else{
+			else {
 				newChars[tgtIndex] = chars[srcIndex];
 				tgtIndex++;
 			}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableRayTracing.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/collision/PassableRayTracing.java
@@ -78,7 +78,7 @@ public class PassableRayTracing extends RayTracing implements ICollidePassable {
         if (BlockProperties.isPassableRay(blockCache, blockX, blockY, blockZ, oX, oY, oZ, dX, dY, dZ, dT)){
             return true;
         }
-        else{
+        else {
             collides = true;
             return false;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/LocUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/LocUtil.java
@@ -174,7 +174,7 @@ public class LocUtil {
         if (setBack == null){
             return clone(ref);
         }
-        else{
+        else {
             return clone(setBack, ref.getYaw(), ref.getPitch());
         }
     }
@@ -191,7 +191,7 @@ public class LocUtil {
         if (setBack == null) {
             return ref.getLocation();
         }
-        else{
+        else {
             return clone(setBack, ref.getYaw(), ref.getPitch());
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
@@ -349,7 +349,7 @@ public class TrigUtil {
         else if  (x < 0.0) {
             a = Math.atan(z / x) + Math.PI;
         }
-        else{
+        else {
             if (z < 0.0) {
                 a = 3.0 * Math.PI / 2.0;
             }


### PR DESCRIPTION
## Summary
- fix style: add spaces after `else` in multiple classes

## Testing
- `mvn verify` *(fails: TestGodModeHelpers errors)*
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685c5786b9dc83299d50d8095256469f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Fix inconsistent spacing around brace preceding `else` statements across the codebase.

### Why are these changes being made?
The changes enhance readability and maintain consistency in the code style by ensuring that there is a space between the closing brace of an `if` statement and the following `else`. Standardizing coding format can aid in more comprehensible code reviews and maintenance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->