### PR TITLE
Refactor RemovePlayerCommand helpers

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
@@ -65,18 +65,9 @@ public class RemovePlayerCommand extends BaseCommand {
             return true;
         }
         String playerName = args[1];
-        final CheckType checkType;
-
-        if (args.length == 3){
-            checkType = parseCheckType(args[2]);
-            if (checkType == null){
-                sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Could not interpret: " + args[2]);
-                sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Check type should be one of: " + StringUtil.join(Arrays.asList(CheckType.values()), c6 + ", " + c3));
-                return true;
-            }
-        }
-        else {
-            checkType = CheckType.ALL;
+        final CheckType checkType = parseCheckType(args.length == 3 ? args[2] : null, sender);
+        if (checkType == null) {
+            return true;
         }
 
         if (playerName.equals("*")){
@@ -116,13 +107,24 @@ public class RemovePlayerCommand extends BaseCommand {
     /**
      * Parse the check type argument.
      *
-     * @param arg the argument to parse
+     * @param input the argument to parse, or {@code null} for {@link CheckType#ALL}
+     * @param sender the command sender
      * @return the matching {@link CheckType} or {@code null} if not found
      */
-    private CheckType parseCheckType(String arg) {
+    private CheckType parseCheckType(String input, CommandSender sender) {
+        if (input == null) {
+            return CheckType.ALL;
+        }
         try {
-            return CheckType.valueOf(arg.toUpperCase().replace('-', '_').replace('.', '_'));
+            return CheckType.valueOf(input.toUpperCase().replace('-', '_').replace('.', '_'));
         } catch (Exception e) {
+            final boolean player = sender instanceof Player;
+            final String tag = player ? TAG : CTAG;
+            final String c3 = player ? ChatColor.RED.toString() : "";
+            final String c6 = player ? ChatColor.WHITE.toString() : "";
+            sender.sendMessage(tag + "Could not interpret: " + c3 + input);
+            sender.sendMessage(tag + "Check type should be one of: " + c3
+                    + StringUtil.join(Arrays.asList(CheckType.values()), c6 + ", " + c3));
             return null;
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
@@ -68,48 +68,23 @@ public class RemovePlayerCommand extends BaseCommand {
         final CheckType checkType;
 
         if (args.length == 3){
-            try{
-                checkType = CheckType.valueOf(args[2].toUpperCase().replace('-', '_').replace('.', '_'));
-            } catch (Exception e){
+            checkType = parseCheckType(args[2]);
+            if (checkType == null){
                 sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Could not interpret: " + args[2]);
                 sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Check type should be one of: " + StringUtil.join(Arrays.asList(CheckType.values()), c6 + ", " + c3));
                 return true;
             }
         }
-        else checkType = CheckType.ALL;
+        else {
+            checkType = CheckType.ALL;
+        }
 
         if (playerName.equals("*")){
-            DataManager.clearData(checkType);
-            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Removed all data and history: " + c3 + checkType);
+            removeAllData(sender, checkType);
             return true;
         }
 
-        final Player player = DataManager.getPlayer(playerName);
-        if (player != null) playerName = player.getName();
-
-        ViolationHistory hist = ViolationHistory.getHistory(playerName, false);
-        boolean somethingFound = false;
-        if (hist != null){
-            somethingFound = hist.remove(checkType);
-            if (checkType == CheckType.ALL){
-                somethingFound = true;
-                ViolationHistory.removeHistory(playerName);
-            }
-        }
-
-        if (DataManager.removeExecutionHistory(checkType, playerName)) {
-            somethingFound = true;
-        }
-
-        if (DataManager.removeData(playerName, checkType)) {
-            somethingFound = true;
-        }
-
-        if (somethingFound){
-            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Issued history and data removal (" + c3 + checkType + c1 +"): " + c3 + playerName + c1);
-        }
-        else
-            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Nothing found (" + c3 + checkType + c1 +"): " + c3 + playerName + c1 + " (spelled correctly?)");
+        removePlayerData(sender, playerName, checkType);
         return true;
     }
 
@@ -133,9 +108,81 @@ public class RemovePlayerCommand extends BaseCommand {
      */
     @Override
     public boolean testPermission(CommandSender sender, Command command, String alias, String[] args) {
-        return super.testPermission(sender, command, alias, args) 
-                || args.length >= 2 && args[1].trim().equalsIgnoreCase(sender.getName()) 
+        return super.testPermission(sender, command, alias, args)
+                || args.length >= 2 && args[1].trim().equalsIgnoreCase(sender.getName())
                 && sender.hasPermission(Permissions.COMMAND_REMOVEPLAYER_SELF.getBukkitPermission());
+    }
+
+    /**
+     * Parse the check type argument.
+     *
+     * @param arg the argument to parse
+     * @return the matching {@link CheckType} or {@code null} if not found
+     */
+    private CheckType parseCheckType(String arg) {
+        try {
+            return CheckType.valueOf(arg.toUpperCase().replace('-', '_').replace('.', '_'));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Handle removing all data for all players.
+     *
+     * @param sender the command sender
+     * @param type the check type
+     */
+    private void removeAllData(CommandSender sender, CheckType type) {
+        DataManager.clearData(type);
+        final String c3 = sender instanceof Player ? ChatColor.RED.toString() : "";
+        sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Removed all data and history: " + c3 + type);
+    }
+
+    /**
+     * Remove data and history for a specific player.
+     *
+     * @param sender the command sender
+     * @param playerName the name of the player
+     * @param type the check type
+     */
+    private void removePlayerData(CommandSender sender, String playerName, CheckType type) {
+        final String c1, c3;
+        if (sender instanceof Player) {
+            c1 = ChatColor.GRAY.toString();
+            c3 = ChatColor.RED.toString();
+        } else {
+            c1 = c3 = "";
+        }
+
+        final Player player = DataManager.getPlayer(playerName);
+        if (player != null) {
+            playerName = player.getName();
+        }
+
+        ViolationHistory hist = ViolationHistory.getHistory(playerName, false);
+        boolean somethingFound = false;
+        if (hist != null) {
+            somethingFound = hist.remove(type);
+            if (type == CheckType.ALL) {
+                somethingFound = true;
+                ViolationHistory.removeHistory(playerName);
+            }
+        }
+
+        if (DataManager.removeExecutionHistory(type, playerName)) {
+            somethingFound = true;
+        }
+
+        if (DataManager.removeData(playerName, type)) {
+            somethingFound = true;
+        }
+
+        if (somethingFound) {
+            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Issued history and data removal (" + c3 + type + c1 + "): " + c3 + playerName + c1);
+        } else {
+            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Nothing found (" + c3 + type + c1 + "): " + c3 + playerName + c1 + " (spelled correctly?)");
+        }
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/RemovePlayerCommand.java
@@ -105,6 +105,26 @@ public class RemovePlayerCommand extends BaseCommand {
     }
 
     /**
+     * Format a message with a list of colors.
+     *
+     * @param message the message to color
+     * @param colors the colors to prepend, ignored if {@code null}
+     * @return the colored message
+     */
+    private String formatMessage(String message, ChatColor... colors) {
+        if (colors == null || colors.length == 0) {
+            return message;
+        }
+        final StringBuilder result = new StringBuilder();
+        for (ChatColor color : colors) {
+            if (color != null) {
+                result.append(color);
+            }
+        }
+        return result.append(message).toString();
+    }
+
+    /**
      * Parse the check type argument.
      *
      * @param input the argument to parse, or {@code null} for {@link CheckType#ALL}
@@ -120,11 +140,11 @@ public class RemovePlayerCommand extends BaseCommand {
         } catch (Exception e) {
             final boolean player = sender instanceof Player;
             final String tag = player ? TAG : CTAG;
-            final String c3 = player ? ChatColor.RED.toString() : "";
-            final String c6 = player ? ChatColor.WHITE.toString() : "";
-            sender.sendMessage(tag + "Could not interpret: " + c3 + input);
-            sender.sendMessage(tag + "Check type should be one of: " + c3
-                    + StringUtil.join(Arrays.asList(CheckType.values()), c6 + ", " + c3));
+            sender.sendMessage(tag + "Could not interpret: "
+                    + formatMessage(input, player ? ChatColor.RED : null));
+            final String list = StringUtil.join(Arrays.asList(CheckType.values()), ", ");
+            sender.sendMessage(tag + "Check type should be one of: "
+                    + formatMessage(list, player ? ChatColor.RED : null));
             return null;
         }
     }
@@ -137,8 +157,9 @@ public class RemovePlayerCommand extends BaseCommand {
      */
     private void removeAllData(CommandSender sender, CheckType type) {
         DataManager.clearData(type);
-        final String c3 = sender instanceof Player ? ChatColor.RED.toString() : "";
-        sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Removed all data and history: " + c3 + type);
+        final boolean player = sender instanceof Player;
+        sender.sendMessage((player ? TAG : CTAG) + "Removed all data and history: "
+                + formatMessage(type.toString(), player ? ChatColor.RED : null));
     }
 
     /**
@@ -149,17 +170,13 @@ public class RemovePlayerCommand extends BaseCommand {
      * @param type the check type
      */
     private void removePlayerData(CommandSender sender, String playerName, CheckType type) {
-        final String c1, c3;
-        if (sender instanceof Player) {
-            c1 = ChatColor.GRAY.toString();
-            c3 = ChatColor.RED.toString();
-        } else {
-            c1 = c3 = "";
-        }
+        final boolean isPlayer = sender instanceof Player;
+        final String c1 = isPlayer ? ChatColor.GRAY.toString() : "";
+        final ChatColor red = isPlayer ? ChatColor.RED : null;
 
-        final Player player = DataManager.getPlayer(playerName);
-        if (player != null) {
-            playerName = player.getName();
+        final Player exact = DataManager.getPlayer(playerName);
+        if (exact != null) {
+            playerName = exact.getName();
         }
 
         ViolationHistory hist = ViolationHistory.getHistory(playerName, false);
@@ -181,9 +198,13 @@ public class RemovePlayerCommand extends BaseCommand {
         }
 
         if (somethingFound) {
-            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Issued history and data removal (" + c3 + type + c1 + "): " + c3 + playerName + c1);
+            sender.sendMessage((isPlayer ? TAG : CTAG) + "Issued history and data removal ("
+                    + formatMessage(type.toString(), red) + c1 + "): "
+                    + formatMessage(playerName, red) + c1);
         } else {
-            sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Nothing found (" + c3 + type + c1 + "): " + c3 + playerName + c1 + " (spelled correctly?)");
+            sender.sendMessage((isPlayer ? TAG : CTAG) + "Nothing found ("
+                    + formatMessage(type.toString(), red) + c1 + "): "
+                    + formatMessage(playerName, red) + c1 + " (spelled correctly?)");
         }
     }
 


### PR DESCRIPTION
## Summary
- clean up remove player command with helper methods
- factor out logic for parsing check types and removing data

## Testing
- `mvn -q verify` *(fails: DataManager.instance is null)*
- `mvn -q -DskipTests checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685c5774c6108329b88349efa9c4a0c2

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `RemovePlayerCommand` by abstracting helper methods for parsing check types and managing data removal to improve readability and maintainability.

### Why are these changes being made?

The changes were made to simplify the `RemovePlayerCommand` class by extracting redundant code into dedicated helper methods. This enhances the organization, readability, and maintainability of the code by isolating distinct functionalities like parsing check types and removing player data or histories, allowing easier testing and future modifications.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->