### PR TITLE
Refactor TestWorldDataManager setup

### DIFF
--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestWorldDataManager.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/test/TestWorldDataManager.java
@@ -92,6 +92,12 @@ public class TestWorldDataManager {
         return rawWorldConfigs;
     }
 
+    private WorldDataManager initWithConfig(Map<String, ConfigFile> rawConfig) {
+        WorldDataManager worldMan = newManager();
+        worldMan.applyConfiguration(rawConfig);
+        return worldMan;
+    }
+
     private Map<String, ConfigFile> createDummyConfig() {
         Map<String, ConfigFile> rawWorldConfigs = new LinkedHashMap<>();
         set(rawWorldConfigs, null, "dummy", "dummy");
@@ -100,9 +106,8 @@ public class TestWorldDataManager {
 
     @Test
     public void testApplyConfiguration() {
-        WorldDataManager worldMan = newManager();
         Map<String, ConfigFile> rawWorldConfigs = createBaseConfig();
-        worldMan.applyConfiguration(rawWorldConfigs);
+        WorldDataManager worldMan = initWithConfig(rawWorldConfigs);
 
         for (String worldName : Arrays.asList("Exist1", "Exist2")) {
             if (rawWorldConfigs.get(worldName) != worldMan.getWorldData(worldName).getRawConfiguration()) {
@@ -129,9 +134,8 @@ public class TestWorldDataManager {
 
     @Test
     public void testOverrideBehaviour() {
-        WorldDataManager worldMan = newManager();
         Map<String, ConfigFile> rawWorldConfigs = createBaseConfig();
-        worldMan.applyConfiguration(rawWorldConfigs);
+        WorldDataManager worldMan = initWithConfig(rawWorldConfigs);
 
         set(rawWorldConfigs, "Exist2", ConfPaths.COMBINED_MUNCHHAUSEN_CHECK, true);
         worldMan.applyConfiguration(rawWorldConfigs);
@@ -151,9 +155,8 @@ public class TestWorldDataManager {
 
     @Test
     public void testReloadHandling() {
-        WorldDataManager worldMan = newManager();
         Map<String, ConfigFile> rawWorldConfigs = createBaseConfig();
-        worldMan.applyConfiguration(rawWorldConfigs);
+        WorldDataManager worldMan = initWithConfig(rawWorldConfigs);
 
         set(rawWorldConfigs, "Exist2", ConfPaths.COMBINED_MUNCHHAUSEN_CHECK, true);
         worldMan.applyConfiguration(rawWorldConfigs);
@@ -180,9 +183,8 @@ public class TestWorldDataManager {
 
     @Test
     public void testResetAndGlobalOverride() {
-        WorldDataManager worldMan = newManager();
         Map<String, ConfigFile> rawWorldConfigs = createDummyConfig();
-        worldMan.applyConfiguration(rawWorldConfigs);
+        WorldDataManager worldMan = initWithConfig(rawWorldConfigs);
 
         IWorldData defaultWorldData = worldMan.getDefaultWorldData();
         defaultWorldData.overrideCheckActivation(CheckType.ALL, AlmostBoolean.NO, OverrideType.VOLATILE, true);


### PR DESCRIPTION
## Summary
- add `initWithConfig` helper in TestWorldDataManager
- use helper to reduce duplication in tests

## Testing
- `mvn -q -DskipTests=false verify` *(fails: Cannot invoke "java.util.Map.put(Object, Object)" because "this.executionHistories" is null)*
- `mvn -q checkstyle:check pmd:check com.github.spotbugs:spotbugs-maven-plugin:check`

------
https://chatgpt.com/codex/tasks/task_b_685c5774794c8329af51115b37cf30c1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the setup process of `WorldDataManager` tests by introducing a utility method `initWithConfig` to consolidate configuration initialization.

### Why are these changes being made?

This change simplifies test code by reducing repetition and using a single method for initializing `WorldDataManager` with a given configuration, thus improving code readability and maintainability. The new method encapsulates the manager creation and configuration application steps, which were previously repeated in multiple test methods.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->