### PR TITLE
Improve UnexemptCommand missing target feedback

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/UnexemptCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/UnexemptCommand.java
@@ -62,11 +62,16 @@ public class UnexemptCommand extends BaseCommand {
         }
 
         final UUID id = resolveTargetId(targetName, sender);
-        if (id != null) {
-            final Player player = DataManager.getPlayer(targetName);
-            final String name = player != null ? player.getName() : targetName;
-            unexemptPlayer(id, name, checkType, sender);
+        if (id == null) {
+            final boolean player = sender instanceof Player;
+            final String tag = player ? TAG : CTAG;
+            final String c3 = player ? ChatColor.RED.toString() : "";
+            sender.sendMessage(tag + "Not an online player nor a UUID: " + c3 + targetName);
+            return true;
         }
+        final Player player = DataManager.getPlayer(targetName);
+        final String name = player != null ? player.getName() : targetName;
+        unexemptPlayer(id, name, checkType, sender);
         return true;
     }
 


### PR DESCRIPTION
## Summary
- show a message when `/ncp unexempt` is called for an unknown player
- keep helper methods for parsing the check type and resolving player IDs

## Testing
- `mvn -q test`
- `mvn -Dcheckstyle.consoleOutput=true checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685c57685ee883298c6b329405c043b0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Improve the feedback message in `UnexemptCommand.java` for cases when the target is neither an online player nor a valid UUID, ensuring a more user-friendly experience by providing clear and concise error messages.

### Why are these changes being made?

The previous implementation did not properly handle or provide informative messages when the `UnexemptCommand` could not resolve the target ID, which could lead to confusion for users. By immediately checking for a null `id` and sending a contextual feedback message, this change enhances error communication, specifically when the command fails to find an online player or a valid UUID.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->