### PR TITLE
Fix typos in check constructors

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
@@ -41,7 +41,7 @@ public class Against extends Check {
 
 
    /**
-    * Instanties a new Against check.
+    * Instantiates a new Against check.
     *
     */
     public Against() {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Scaffold.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Scaffold.java
@@ -43,7 +43,7 @@ public class Scaffold extends Check {
     public List<String> tags = new LinkedList<>();
     
    /*
-    * Instanties a new Scaffold check
+    * Instantiates a new Scaffold check
     *
     */
     public Scaffold() {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryMove.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryMove.java
@@ -53,7 +53,7 @@ public class InventoryMove extends Check {
 
 
    /**
-    * Instanties a new InventoryMove check
+    * Instantiates a new InventoryMove check
     *
     */
     public InventoryMove() {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/MoreInventory.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/MoreInventory.java
@@ -30,7 +30,7 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 public class MoreInventory extends Check{
 
   /**
-    * Instanties a new MoreInventory check
+    * Instantiates a new MoreInventory check
     *
     */
     public MoreInventory() {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
@@ -114,7 +114,7 @@ public class VehicleEnvelope extends Check {
     
    /*
     *
-    * Instanties a new VehicleEnvelope check
+    * Instantiates a new VehicleEnvelope check
     *
     */
     public VehicleEnvelope() {


### PR DESCRIPTION
## Summary
- correct typo in `Against` check JavaDoc
- fix same typo in other check classes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685c57671b3c832985725e34d206315f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix typographical errors in the constructors' documentation comments by correcting "Instanties" to "Instantiates" across various check classes.

### Why are these changes being made?

These changes correct the misspelling in the documentation comments for constructors, improving code readability and maintaining professional quality in the documentation. It ensures accurate and precise comments, which is critical for code maintenance and understanding.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->