### PR TITLE
Refactor exemption commands with color helper

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/BaseCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/BaseCommand.java
@@ -15,6 +15,8 @@
 package fr.neatmonster.nocheatplus.command;
 
 import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import fr.neatmonster.nocheatplus.permissions.RegisteredPermission;
@@ -36,8 +38,29 @@ public abstract class BaseCommand extends AbstractCommand<JavaPlugin>{
 		this(plugin, label, permission, null);
 	}
 
-	public BaseCommand(JavaPlugin access, String label, RegisteredPermission permission, String[] aliases){
-		super(access, label, permission, aliases);
-	}
+        public BaseCommand(JavaPlugin access, String label, RegisteredPermission permission, String[] aliases){
+                super(access, label, permission, aliases);
+        }
+
+        /**
+         * Convenience method to retrieve the color codes used for player messages.
+         *
+         * @param sender the command sender
+         * @return an array containing seven color code strings
+         */
+        protected String[] getColorCodes(CommandSender sender) {
+                if (sender instanceof Player) {
+                        return new String[] {
+                                        ChatColor.GRAY.toString(),
+                                        ChatColor.BOLD.toString(),
+                                        ChatColor.RED.toString(),
+                                        ChatColor.ITALIC.toString(),
+                                        ChatColor.GOLD.toString(),
+                                        ChatColor.WHITE.toString(),
+                                        ChatColor.YELLOW.toString()
+                        };
+                }
+                return new String[] {"", "", "", "", "", "", ""};
+        }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/ExemptCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/ExemptCommand.java
@@ -21,7 +21,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.ChatColor;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.command.BaseCommand;
@@ -40,20 +39,14 @@ public class ExemptCommand extends BaseCommand {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
-        final String c1, c2, c3, c4, c5, c6, c7;
-        if (sender instanceof Player) {
-            c1 = ChatColor.GRAY.toString();
-            c2 = ChatColor.BOLD.toString();
-            c3 = ChatColor.RED.toString();
-            c4 = ChatColor.ITALIC.toString();
-            c5 = ChatColor.GOLD.toString();
-            c6 = ChatColor.WHITE.toString();
-            c7 = ChatColor.YELLOW.toString();
-        } else {
-            c1 = c2 = c3 = c4 = c5 = c6 = c7 = "";
-        }
-
-        // Consider introducing a super class to reduce copy and paste.
+        final String[] colors = getColorCodes(sender);
+        final String c1 = colors[0];
+        final String c2 = colors[1];
+        final String c3 = colors[2];
+        final String c4 = colors[3];
+        final String c5 = colors[4];
+        final String c6 = colors[5];
+        final String c7 = colors[6];
         if (args.length < 2) {
             sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Please specify a player to exempt.");
             return true;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/ExemptionsCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/ExemptionsCommand.java
@@ -22,7 +22,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.ChatColor;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.command.BaseCommand;
@@ -41,18 +40,14 @@ public class ExemptionsCommand extends BaseCommand {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
 
-        final String c1, c2, c3, c4, c5, c6, c7;
-        if (sender instanceof Player) {
-            c1 = ChatColor.GRAY.toString();
-            c2 = ChatColor.BOLD.toString();
-            c3 = ChatColor.RED.toString();
-            c4 = ChatColor.ITALIC.toString();
-            c5 = ChatColor.GOLD.toString();
-            c6 = ChatColor.WHITE.toString();
-            c7 = ChatColor.YELLOW.toString();
-        } else {
-            c1 = c2 = c3 = c4 = c5 = c6 = c7 = "";
-        }
+        final String[] colors = getColorCodes(sender);
+        final String c1 = colors[0];
+        final String c2 = colors[1];
+        final String c3 = colors[2];
+        final String c4 = colors[3];
+        final String c5 = colors[4];
+        final String c6 = colors[5];
+        final String c7 = colors[6];
 
         if (args.length != 2) {
             sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Please specify a player.");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/UnexemptCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/exemption/UnexemptCommand.java
@@ -22,7 +22,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.ChatColor;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.command.BaseCommand;
@@ -41,7 +40,6 @@ public class UnexemptCommand extends BaseCommand {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
-        // Consider introducing a super class to reduce copy and paste.
         if (args.length < 2) {
             sender.sendMessage((sender instanceof Player ? TAG : CTAG) + "Please specify a player to unexempt.");
             return true;
@@ -95,10 +93,10 @@ public class UnexemptCommand extends BaseCommand {
         try {
             return CheckType.valueOf(input.toUpperCase().replace('-', '_').replace('.', '_'));
         } catch (Exception e) {
-            final boolean player = sender instanceof Player;
-            final String tag = player ? TAG : CTAG;
-            final String c3 = player ? ChatColor.RED.toString() : "";
-            final String c6 = player ? ChatColor.WHITE.toString() : "";
+            final String tag = sender instanceof Player ? TAG : CTAG;
+            final String[] colors = getColorCodes(sender);
+            final String c3 = colors[2];
+            final String c6 = colors[5];
             sender.sendMessage(tag + "Could not interpret: " + c3 + input);
             sender.sendMessage(tag + "Check type should be one of: " + c3 + StringUtil.join(Arrays.asList(CheckType.values()), c6 + ", " + c3));
             return null;
@@ -115,18 +113,18 @@ public class UnexemptCommand extends BaseCommand {
 
     private void unexemptAll(CheckType type, CommandSender sender) {
         NCPExemptionManager.clear();
-        final boolean player = sender instanceof Player;
-        final String tag = player ? TAG : CTAG;
-        final String c3 = player ? ChatColor.RED.toString() : "";
+        final String tag = sender instanceof Player ? TAG : CTAG;
+        final String[] colors = getColorCodes(sender);
+        final String c3 = colors[2];
         sender.sendMessage(tag + "Removed exemptions for all players for checks: " + c3 + type);
     }
 
     private void unexemptPlayer(UUID id, String playerName, CheckType type, CommandSender sender) {
         NCPExemptionManager.unexempt(id, type);
-        final boolean player = sender instanceof Player;
-        final String tag = player ? TAG : CTAG;
-        final String c1 = player ? ChatColor.GRAY.toString() : "";
-        final String c3 = player ? ChatColor.RED.toString() : "";
+        final String tag = sender instanceof Player ? TAG : CTAG;
+        final String[] colors = getColorCodes(sender);
+        final String c1 = colors[0];
+        final String c3 = colors[2];
         sender.sendMessage(tag + "Removed exemptions for " + c3 + playerName + c1 + " for checks: " + c3 + type);
     }
 


### PR DESCRIPTION
## Summary
- add a getColorCodes helper to `BaseCommand`
- replace repeated color logic in ExemptCommand, UnexemptCommand and ExemptionsCommand
- remove redundant superclass comment

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685c5768e6c48329aefb57c0091edce7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor exemption commands by introducing a color helper method to streamline the retrieval of color codes for player messages, thereby eliminating repetitive code and improving maintainability.

### Why are these changes being made?

To reduce code duplication across multiple command classes by consolidating the logic for generating color codes into a single helper method `getColorCodes`, making the codebase cleaner and easier to manage. This approach simplifies future updates to color code management, as changes only need to be made in one place, thus enhancing the overall maintainability of the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->