### PR TITLE
Fix multi-statement line in test

### DIFF
--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestPermissionUtil.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestPermissionUtil.java
@@ -34,7 +34,11 @@ public class TestPermissionUtil {
         @Override public boolean execute(CommandSender sender, String label, String[] args) { return false; }
         @Override public List<String> tabComplete(CommandSender sender, String alias, String[] args) { return null; }
         @Override public List<String> getAliases() { return aliases; }
-        @Override public Command setAliases(List<String> a) { this.aliases = a; return this; }
+        @Override
+        public Command setAliases(List<String> a) {
+            this.aliases = a;
+            return this;
+        }
         @Override public String getPermission() { return permission; }
         @Override public void setPermission(String perm) { this.permission = perm; }
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestPermissionUtil.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestPermissionUtil.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -36,7 +37,7 @@ public class TestPermissionUtil {
         @Override public List<String> getAliases() { return aliases; }
         @Override
         public Command setAliases(List<String> a) {
-            this.aliases = a;
+            this.aliases = (a != null) ? new ArrayList<>(a) : null;
             return this;
         }
         @Override public String getPermission() { return permission; }


### PR DESCRIPTION
## Summary
- fix a checkstyle violation by splitting statements in `DummyCommand#setAliases`

## Testing
- `mvn test` *(fails: TestPermissionUtilHelpers#testRegisterAndRecord)*
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn com.github.spotbugs:spotbugs-maven-plugin:check`


------
https://chatgpt.com/codex/tasks/task_b_685d17d9fc948329a31a6a915d791e6a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `setAliases` method in the `DummyCommand` class within `TestPermissionUtil.java` to split a multi-statement line into multiple lines for improved readability.

### Why are these changes being made?

The existing single-line format of the `setAliases` method was difficult to read and maintain; splitting it into multiple lines improves clarity and aligns with common coding standards. This change is crucial for ease of future modifications and understanding by other developers.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->