### PR TITLE
Fix lily pad and frogspawn check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
@@ -168,7 +168,7 @@ public class Against extends Check {
             return false;
         }
         if (BlockProperties.isLiquid(ncpAgainst)) {
-            final boolean lilyPadOrFrog = placedMat != BridgeMaterial.LILY_PAD || placedMat != BridgeMaterial.FROGSPAWN;
+            final boolean lilyPadOrFrog = placedMat != BridgeMaterial.LILY_PAD && placedMat != BridgeMaterial.FROGSPAWN;
             final boolean blockBelowLiquid = block != null && BlockProperties.isLiquid(block.getRelative(BlockFace.DOWN).getType());
             if ((lilyPadOrFrog || !blockBelowLiquid)
                     && !BlockProperties.isWaterPlant(ncpAgainst)


### PR DESCRIPTION
## Summary
- correct placement check logic for lily pads and frogspawn

## Testing
- `mvn -q test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685d2286bcf48329b195a61f4a178112

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the logic for checking if a placed material is either a lily pad or frogspawn by changing the condition from OR to AND.

### Why are these changes being made?

The previous condition incorrectly used the OR logic which always evaluated to true, causing placement checks for lily pads and frogspawn to fail. The correct logic should be AND to properly identify when the placed material is neither a lily pad nor frogspawn.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->