### PR TITLE
Validate AxisAlignedBB bounds

### DIFF
--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
@@ -90,7 +90,8 @@ public class BlockCacheSpigotCB1_10_R1 extends BlockCache {
     private static boolean isBoundsValid(AxisAlignedBB bb) {
         return !(bb.a < -1.0D || bb.d > 2.0D
                 || bb.b < -1.0D || bb.e > 2.0D
-                || bb.c < -1.0D || bb.f > 2.0D);
+                || bb.c < -1.0D || bb.f > 2.0D
+                || bb.a > bb.d || bb.b > bb.e || bb.c > bb.f);
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
@@ -80,12 +80,17 @@ public class BlockCacheSpigotCB1_10_R1 extends BlockCache {
         // Deprecation warning below (reason / substitute?).
         @SuppressWarnings("deprecation")
         final AxisAlignedBB bb = block.a(world.getType(pos), world, pos);
-        if (bb == null) {
+        if (bb == null || !isBoundsValid(bb)) {
             return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0}; // Special case.
-            //return null;
         }
         // minX, minY, minZ, maxX, maxY, maxZ
-        return new double[]{bb.a, bb.b, bb.c, bb.d,  bb.e, bb.f};
+        return new double[] {bb.a, bb.b, bb.c, bb.d, bb.e, bb.f};
+    }
+
+    private static boolean isBoundsValid(AxisAlignedBB bb) {
+        return !(bb.a < -1.0D || bb.d > 2.0D
+                || bb.b < -1.0D || bb.e > 2.0D
+                || bb.c < -1.0D || bb.f > 2.0D);
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
@@ -88,7 +88,8 @@ public class BlockCacheSpigotCB1_9_R1 extends BlockCache {
     private static boolean isBoundsValid(AxisAlignedBB bb) {
         return !(bb.a < -1.0D || bb.d > 2.0D
                 || bb.b < -1.0D || bb.e > 2.0D
-                || bb.c < -1.0D || bb.f > 2.0D);
+                || bb.c < -1.0D || bb.f > 2.0D
+                || bb.a > bb.d || bb.b > bb.e || bb.c > bb.f);
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
@@ -78,12 +78,17 @@ public class BlockCacheSpigotCB1_9_R1 extends BlockCache {
         if (shape != null) return shape;
         final BlockPosition pos = new BlockPosition(x, y, z);
         final AxisAlignedBB bb = block.a(world.getType(pos), world, pos);
-        if (bb == null) {
+        if (bb == null || !isBoundsValid(bb)) {
             return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0}; // Special case.
-            //return null;
         }
         // minX, minY, minZ, maxX, maxY, maxZ
-        return new double[]{bb.a, bb.b, bb.c, bb.d,  bb.e, bb.f};
+        return new double[] {bb.a, bb.b, bb.c, bb.d, bb.e, bb.f};
+    }
+
+    private static boolean isBoundsValid(AxisAlignedBB bb) {
+        return !(bb.a < -1.0D || bb.d > 2.0D
+                || bb.b < -1.0D || bb.e > 2.0D
+                || bb.c < -1.0D || bb.f > 2.0D);
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
@@ -80,12 +80,17 @@ public class BlockCacheSpigotCB1_9_R2 extends BlockCache {
         // Suppress deprecation warning here until a supported alternative is available.
         @SuppressWarnings("deprecation")
         final AxisAlignedBB bb = block.a(world.getType(pos), world, pos);
-        if (bb == null) {
+        if (bb == null || !isBoundsValid(bb)) {
             return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0}; // Special case.
-            //return null;
         }
         // minX, minY, minZ, maxX, maxY, maxZ
-        return new double[]{bb.a, bb.b, bb.c, bb.d,  bb.e, bb.f};
+        return new double[] {bb.a, bb.b, bb.c, bb.d, bb.e, bb.f};
+    }
+
+    private static boolean isBoundsValid(AxisAlignedBB bb) {
+        return !(bb.a < -1.0D || bb.d > 2.0D
+                || bb.b < -1.0D || bb.e > 2.0D
+                || bb.c < -1.0D || bb.f > 2.0D);
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
@@ -90,7 +90,8 @@ public class BlockCacheSpigotCB1_9_R2 extends BlockCache {
     private static boolean isBoundsValid(AxisAlignedBB bb) {
         return !(bb.a < -1.0D || bb.d > 2.0D
                 || bb.b < -1.0D || bb.e > 2.0D
-                || bb.c < -1.0D || bb.f > 2.0D);
+                || bb.c < -1.0D || bb.f > 2.0D
+                || bb.a > bb.d || bb.b > bb.e || bb.c > bb.f);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- validate bounding box returned by deprecated block API for early Spigot versions

## Testing
- `mvn -q -Pnonfree_build -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d22ad70fc8329b05aa7a8e80a0221

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add validation for `AxisAlignedBB` bounds to ensure they lie within a specified range before returning their dimensions in `BlockCacheSpigotCB1_10_R1`, `BlockCacheSpigotCB1_9_R1`, and `BlockCacheSpigotCB1_9_R2` classes.

### Why are these changes being made?

These changes are introduced to address potential issues with invalid bounding box dimensions that could arise during block processing. The validation ensures that the bounds do not fall outside the permissible range, preventing potential errors or unexpected behavior in the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->