### PR TITLE
Fix asynchronous check node exemption

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerCheckTypeTree.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerCheckTypeTree.java
@@ -416,7 +416,7 @@ public class PlayerCheckTypeTree extends CheckTypeTree<PlayerCheckTypeTreeNode>{
     private boolean isExemptedAsynchronous(final PlayerCheckTypeTreeNode node, final ExemptionContext context) {
         lock.lock();
         try {
-            return node.isExemptedPrimaryThread(context);
+            return node.isExemptedAsynchronous(context);
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
## Summary
- correct the asynchronous exemption lookup in `PlayerCheckTypeTree`

## Testing
- `mvn verify -DskipITs=true`

------
https://chatgpt.com/codex/tasks/task_b_685d2302e78c8329b5590dbb46ec7cf5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the method call to `node.isExemptedAsynchronous(context)` instead of `node.isExemptedPrimaryThread(context)` in the `isExemptedAsynchronous` method of `PlayerCheckTypeTree.java`.

### Why are these changes being made?

This change resolves a logic error where the asynchronous exemption check inadvertently used the synchronous method, `isExemptedPrimaryThread`, likely resulting in incorrect exemption behavior. Switching to `isExemptedAsynchronous` ensures the correct method is called and the asynchronous exemptions are properly evaluated, improving program functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->