### PR TITLE
Remove redundant check for BlockBreak event

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -134,10 +134,10 @@ public class BlockBreakListener extends CheckListener {
      * Validate the block for processing.
      *
      * @param block the block to validate
-     * @return {@code true} if the block is not null and not scaffolding
+     * @return {@code true} if the block is not scaffolding
      */
     private boolean isBlockValid(final Block block) {
-        return block != null && !BlockProperties.isScaffolding(block.getType());
+        return !BlockProperties.isScaffolding(block.getType());
     }
 
     /**


### PR DESCRIPTION
## Summary
- avoid null check when verifying blocks in `BlockBreakListener`

## Testing
- `mvn -q test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685d22d99a3883299a8685f13b98c4f5