### PR TITLE
Fix negative lag empty values

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -128,7 +128,7 @@ public class NetStatic {
             // Consider adding a configuration flag to skip lag adaption when running in strict mode.
             final float lag = TickTask.getLag(totalDur, true); // Full seconds range considered.
             // Also consider increasing the allowed maximum for extreme server-side lag conditions.
-            empty = Math.min(empty, (int) Math.round((lag - 1f) * winNum));
+            empty = Math.max(0, Math.min(empty, (int) Math.round((lag - 1f) * winNum)));
         }
 
         final double fullCount;


### PR DESCRIPTION
## Summary
- ensure empty value is never negative in lag adjustment

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: Medium Exception thrown, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_685d229c262083298a852363a7450a0e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the calculation for the `empty` value to ensure it does not become negative by using `Math.max` with zero as a boundary.

### Why are these changes being made?

Previously, the calculation for `empty` could result in a negative value, leading to incorrect behavior in handling lag conditions. Adding a `Math.max` call ensures that `empty` is always non-negative, which is critical for accurate packet frequency checks during server-side lag conditions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->