### PR TITLE
Fix Timings range update

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Timings.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Timings.java
@@ -79,7 +79,8 @@ public final class Timings {
                 void updateRange(final long value) {
                         if (value < min) {
                                 min = value;
-                        } else if (value > max) {
+                        }
+                        if (value > max) {
                                 max = value;
                         }
                 }


### PR DESCRIPTION
## Summary
- fix updateRange logic so min and max update independently

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d230b489c8329b9cf571eb38dce4a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the logic in the `updateRange` method by separating the condition for updating the `max` value from the `else if` block to an independent `if` block.

### Why are these changes being made?

The previous logic incorrectly restricted updates to `max` value, which should be checked independently; separating the conditions ensures both `min` and `max` values can be updated correctly, improving the accuracy of the Timings range update.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->