### PR TITLE
Improve bounds length validation message

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -55,7 +55,8 @@ public class BukkitStatic implements BukkitShapeModel {
      */
     public static BukkitStatic ofBounds(double... bounds) {
         if (bounds.length % 6 != 0) {
-            throw new IllegalArgumentException("The length must be a multiple of 6");
+            throw new IllegalArgumentException(
+                    "The length must be a multiple of 6, but was: " + bounds.length);
         }
         return new BukkitStatic(bounds);
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/LegacyBlocks.java
@@ -97,7 +97,8 @@ public class LegacyBlocks {
             }
 
             if (bounds.length % 6 != 0) {
-                throw new IllegalArgumentException("The length must be a multiple of 6");
+                throw new IllegalArgumentException(
+                        "The length must be a multiple of 6, but was: " + bounds.length);
             }
             this.bounds = bounds;
         }


### PR DESCRIPTION
## Summary
- improve diagnostic message for invalid bounds length in BlockStatic
- improve diagnostic message for BukkitStatic bounds helper

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2352040c8329a88657327fec3f23