### PR TITLE
Refactor bounds method discovery

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
@@ -44,11 +44,15 @@ public class ReflectBlockSix implements IReflectBlock {
 
     /** Obfuscated nms names, allowing to find the order in the source code under certain circumstances. */
     private static final List<String> possibleNames = new ArrayList<String>();
+    private static final java.util.Map<String, Integer> possibleNameIndices = new java.util.HashMap<String, Integer>();
 
     static {
         // These might suffice for a while.
+        int index = 0;
         for (char c : "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray()) {
-            possibleNames.add("" + c);
+            String name = "" + c;
+            possibleNames.add(name);
+            possibleNameIndices.put(name, index++);
         }
     }
 
@@ -166,7 +170,7 @@ public class ReflectBlockSix implements IReflectBlock {
         if (names.size() < 6) {
             return null;
         }
-        names.sort(Comparator.comparingInt(possibleNames::indexOf));
+        names.sort(Comparator.comparingInt(possibleNameIndices::get));
         int startIndex = findConsecutiveStart(names);
         if (startIndex == -1) {
             return null;
@@ -198,7 +202,11 @@ public class ReflectBlockSix implements IReflectBlock {
         int lastIndex = -2;
         int currentStart = -1;
         for (int i = 0; i < names.size(); i++) {
-            int nameIndex = possibleNames.indexOf(names.get(i));
+            Integer nameIndexObj = possibleNameIndices.get(names.get(i));
+            if (nameIndexObj == null) {
+                continue;
+            }
+            int nameIndex = nameIndexObj.intValue();
             if (nameIndex - lastIndex == 1) {
                 if (currentStart == -1) {
                     currentStart = nameIndex - 1;

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSix.java
@@ -162,61 +162,63 @@ public class ReflectBlockSix implements IReflectBlock {
      *         resolved
      */
     private String[] guessBoundsMethodNames(Class<?> clazz) {
-        // Collect valid candidate names.
-        List<String> names = new ArrayList<String>();
-        for (Method method : clazz.getMethods()) {
-            if (method.getReturnType() == double.class && method.getParameterTypes().length == 0 && possibleNames.contains(method.getName())) {
-                names.add(method.getName());
-            }
-        }
+        List<String> names = collectCandidateNames(clazz);
         if (names.size() < 6) {
             return null;
         }
-        // Sort according to possibleNames order.
         names.sort(Comparator.comparingInt(possibleNames::indexOf));
-        // Check for six consecutive names.
-        int startIndex = 0;
-        if (names.size() > 6) {
-            // Attempt to locate the start index (future versions may have more).
-            startIndex = -1; // start index within candidate list
-            int lastIndex = -2; // index of last name within possibleNames
-            int currentStart = -1; // temporary start index
-            for (int i = 0; i < names.size(); i++) {
-                String name = names.get(i);
-                int nameIndex = possibleNames.indexOf(name);
-                if (nameIndex - lastIndex == 1) {
-                    if (currentStart == -1) {
-                        currentStart = nameIndex - 1;
-                    } else {
-                        int length = nameIndex - currentStart + 1;
-                        if (length > 6) {
-                            // ambiguous
-                            return null;
-                        }
-                        else if (length == 6) {
-                            if (startIndex != -1) {
-                                // ambiguous
-                                return null;
-                            } else {
-                                startIndex = i + 1 - length;
-                                // keep to detect long sequences
-                            }
-                        }
-                    }
-                } else {
-                    currentStart = -1;
-                }
-                lastIndex = nameIndex;
-            }
-            if (startIndex == -1) {
-                return null;
-            }
+        int startIndex = findConsecutiveStart(names);
+        if (startIndex == -1) {
+            return null;
         }
         String[] res = new String[6];
         for (int i = 0; i < 6; i++) {
             res[i] = names.get(startIndex + i);
         }
         return res;
+    }
+
+    private List<String> collectCandidateNames(Class<?> clazz) {
+        List<String> names = new ArrayList<String>();
+        for (Method method : clazz.getMethods()) {
+            boolean hasCorrectSignature = method.getReturnType() == double.class
+                    && method.getParameterTypes().length == 0;
+            if (hasCorrectSignature && possibleNames.contains(method.getName())) {
+                names.add(method.getName());
+            }
+        }
+        return names;
+    }
+
+    private int findConsecutiveStart(List<String> names) {
+        if (names.size() == 6) {
+            return 0;
+        }
+        int startIndex = -1;
+        int lastIndex = -2;
+        int currentStart = -1;
+        for (int i = 0; i < names.size(); i++) {
+            int nameIndex = possibleNames.indexOf(names.get(i));
+            if (nameIndex - lastIndex == 1) {
+                if (currentStart == -1) {
+                    currentStart = nameIndex - 1;
+                } else {
+                    int length = nameIndex - currentStart + 1;
+                    if (length > 6) {
+                        return -1;
+                    } else if (length == 6) {
+                        if (startIndex != -1) {
+                            return -1;
+                        }
+                        startIndex = i + 1 - length;
+                    }
+                }
+            } else {
+                currentStart = -1;
+            }
+            lastIndex = nameIndex;
+        }
+        return startIndex;
     }
 
     /**


### PR DESCRIPTION
## Summary
- extract helper methods to collect candidate names and to locate consecutive method sequences
- simplify `guessBoundsMethodNames` using the helpers

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d23c572848329a361bd09917541da

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `guessBoundsMethodNames` method to utilize helper methods for collecting candidate names and finding consecutive start indices, enhancing code clarity and maintainability.

### Why are these changes being made?

This change improves code readability and maintainability by breaking down a complex method into smaller, more understandable parts. This refactoring eliminates duplicated logic, makes the method more intuitive, and isolates the logic for candidate name retrieval and consecutive indexing into distinct methods.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->