### PR TITLE
Refactor WrongBlock check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -214,7 +214,7 @@ public class BlockBreakListener extends CheckListener {
             final Block block, final BlockBreakConfig cc, final BlockBreakData data,
             final IPlayerData pData) {
         if (!result.cancelled && wrongBlock.isEnabled(player, pData)
-                && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
+                && wrongBlock.check(player, block, cc, data, pData)) {
             result.cancelled = true;
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -35,10 +35,11 @@ public class WrongBlock extends Check {
      * Check if the player destroys another block than interacted with last.<br>
      * This does occasionally trigger for players that destroy grass or snow, 
      * probably due to packet delaying issues for insta breaking.
-     * @param player
-     * @param block
-     * @param data 
-     * @param cc 
+     * @param player the acting player, may be {@code null}
+     * @param block the targeted block, may be {@code null}
+     * @param data runtime data for this check
+     * @param cc configuration settings for this check
+     * @param pData aggregated player data
      * @return {@code true} if the event should be cancelled
      */
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -43,64 +43,90 @@ public class WrongBlock extends Check {
      * @return
      */
     
-    public boolean check(final Player player, final Block block, 
-            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData,
-            final AlmostBoolean isInstaBreak) {
+    public boolean check(final Player player, final Block block,
+            final BlockBreakConfig cc, final BlockBreakData data,
+            final IPlayerData pData, final AlmostBoolean isInstaBreak) {
 
         boolean cancel = false;
 
-        final boolean wrongTime = data.fastBreakfirstDamage < data.fastBreakBreakTime;
-        final int dist = Math.min(4, data.clickedX == Integer.MAX_VALUE ? 100 : TrigUtil.manhattan(data.clickedX, data.clickedY, data.clickedZ, block));
-        final boolean wrongBlock;
+        if (player != null && block != null && cc != null && data != null && pData != null) {
+            cancel = handleCheck(player, block, cc, data, pData);
+        }
+
+        return cancel;
+    }
+
+    private boolean handleCheck(final Player player, final Block block,
+            final BlockBreakConfig cc, final BlockBreakData data,
+            final IPlayerData pData) {
+        boolean cancel = false;
         final long now = System.currentTimeMillis();
+        final boolean wrongTime = data.fastBreakfirstDamage < data.fastBreakBreakTime;
+        final int dist = computeDistance(data, block);
         final boolean debug = pData.isDebugActive(type);
-        // The isInstaBreak argument should either be removed or utilized.
+        final boolean wrongBlock = isWrongBlock(player, data, dist, now, wrongTime, debug);
+
+        if (wrongBlock) {
+            cancel = applyViolation(player, pData, cc, data, now, dist, debug);
+        }
+
+        return cancel;
+    }
+
+    private int computeDistance(final BlockBreakData data, final Block block) {
+        if (data.clickedX == Integer.MAX_VALUE) {
+            return 100;
+        }
+        return Math.min(4, TrigUtil.manhattan(data.clickedX, data.clickedY, data.clickedZ, block));
+    }
+
+    private boolean isWrongBlock(final Player player, final BlockBreakData data,
+            final int dist, final long now, final boolean wrongTime,
+            final boolean debug) {
+        boolean wrongBlock;
         if (dist == 0) {
             if (wrongTime) {
                 data.fastBreakBreakTime = now;
                 data.fastBreakfirstDamage = now;
-                // Could set to wrong block, but prefer to transform it into a quasi insta break.
             }
             wrongBlock = false;
-        }
-        else if (dist == 1) {
-            // One might to a concession in case of instant breaking.
-            // Reason for this concession is not documented.
+        } else if (dist == 1) {
             if (now - data.wasInstaBreak < 60) {
                 if (debug) {
                     debug(player, "Skip on Manhattan 1 and wasInstaBreak within 60 ms.");
                 }
                 wrongBlock = false;
-            }
-            else {
+            } else {
                 wrongBlock = true;
             }
-        }
-        else {
-            // Note that the maximally counted distance is set above.
+        } else {
             wrongBlock = true;
         }
+        return wrongBlock;
+    }
 
-        if (wrongBlock) {
-            if ((debug) && pData.hasPermission(Permissions.ADMINISTRATION_DEBUG, player)) {
-                player.sendMessage("WrongBlock failure with dist: " + dist);
+    private boolean applyViolation(final Player player, final IPlayerData pData,
+            final BlockBreakConfig cc, final BlockBreakData data, final long now,
+            final int dist, final boolean debug) {
+        boolean cancel = false;
+        if (debug && pData.hasPermission(Permissions.ADMINISTRATION_DEBUG, player)) {
+            player.sendMessage("WrongBlock failure with dist: " + dist);
+        }
+        data.wrongBlockVL.add(now, (float) (dist + 1) / 2f);
+        final float score = data.wrongBlockVL.score(0.9f);
+        if (score > cc.wrongBLockLevel) {
+            if (executeActions(player, score, 1D, cc.wrongBlockActions).willCancel()) {
+                cancel = true;
             }
-            data.wrongBlockVL.add(now, (float) (dist + 1) / 2f);
-            final float score = data.wrongBlockVL.score(0.9f);
-            if (score > cc.wrongBLockLevel) {
-                if (executeActions(player, score, 1D, cc.wrongBlockActions).willCancel()) {
+            if (cc.wrongBlockImprobableWeight > 0.0f) {
+                if (cc.wrongBlockImprobableFeedOnly) {
+                    Improbable.feed(player, cc.wrongBlockImprobableWeight, now);
+                } else if (Improbable.check(player, cc.wrongBlockImprobableWeight,
+                        now, "blockbreak.wrongblock", pData)) {
                     cancel = true;
-                }
-                if (cc.wrongBlockImprobableWeight > 0.0f) {
-                	if (cc.wrongBlockImprobableFeedOnly) {
-                		Improbable.feed(player, cc.wrongBlockImprobableWeight, now);
-                	} else if (Improbable.check(player, cc.wrongBlockImprobableWeight, now, "blockbreak.wrongblock", pData)) {
-                		cancel = true;
-                	}
                 }
             }
         }
-
         return cancel;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -39,31 +39,19 @@ public class WrongBlock extends Check {
      * @param block
      * @param data 
      * @param cc 
-     * @param isInstaBreak 
-     * @return
+     * @return {@code true} if the event should be cancelled
      */
-    
+
     public boolean check(final Player player, final Block block,
             final BlockBreakConfig cc, final BlockBreakData data,
-            final IPlayerData pData, final AlmostBoolean isInstaBreak) {
+            final IPlayerData pData) {
 
-        if (player == null) {
-            return false;
+        boolean cancel = false;
+        if (player != null && block != null && cc != null
+                && data != null && pData != null) {
+            cancel = handleCheck(player, block, cc, data, pData);
         }
-        if (block == null) {
-            return false;
-        }
-        if (cc == null) {
-            return false;
-        }
-        if (data == null) {
-            return false;
-        }
-        if (pData == null) {
-            return false;
-        }
-
-        return handleCheck(player, block, cc, data, pData);
+        return cancel;
     }
 
     private boolean handleCheck(final Player player, final Block block,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -47,13 +47,23 @@ public class WrongBlock extends Check {
             final BlockBreakConfig cc, final BlockBreakData data,
             final IPlayerData pData, final AlmostBoolean isInstaBreak) {
 
-        boolean cancel = false;
-
-        if (player != null && block != null && cc != null && data != null && pData != null) {
-            cancel = handleCheck(player, block, cc, data, pData);
+        if (player == null) {
+            return false;
+        }
+        if (block == null) {
+            return false;
+        }
+        if (cc == null) {
+            return false;
+        }
+        if (data == null) {
+            return false;
+        }
+        if (pData == null) {
+            return false;
         }
 
-        return cancel;
+        return handleCheck(player, block, cc, data, pData);
     }
 
     private boolean handleCheck(final Player player, final Block block,


### PR DESCRIPTION
## Summary
- keep null checks separate
- break WrongBlock#check into helper methods for readability

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: missing classes and SpotBugs warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685d23d5bbf48329af2d43a01eaaff97

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `WrongBlock` check by introducing helper methods to separate concerns and improve code readability.

### Why are these changes being made?

The changes enhance maintainability by breaking down the monolithic `check` method into smaller, more manageable and descriptive helper methods (`handleCheck`, `computeDistance`, `isWrongBlock`, and `applyViolation`). This makes the code easier to understand and modify while adhering to the single responsibility principle.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->