### PR TITLE
Improve exception logging for last position lookups

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectEntityLastPositionAndLook.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectEntityLastPositionAndLook.java
@@ -22,6 +22,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -62,7 +63,11 @@ public class ReflectEntityLastPositionAndLook extends ReflectGetHandleBase<Entit
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, "Could not retrieve last position and look for Entity: " + entity.getClass().getName());
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
+                    "Could not retrieve last position and look for Entity: "
+                            + entity.getClass().getName() + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -81,7 +86,11 @@ public class ReflectEntityLastPositionAndLook extends ReflectGetHandleBase<Entit
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, "Could not set last position and look for Entity: " + entity.getClass().getName());
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
+                    "Could not set last position and look for Entity: "
+                            + entity.getClass().getName() + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/EntityAccessLastPositionAndLook.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -42,9 +43,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -67,9 +71,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/EntityAccessLastPositionAndLook.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -42,9 +43,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -67,9 +71,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/EntityAccessLastPositionAndLook.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -42,9 +43,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -67,9 +71,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/EntityAccessLastPositionAndLook.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -42,9 +43,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -67,9 +71,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/EntityAccessLastPositionAndLook.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.location.IGetPositionWithLook;
 import fr.neatmonster.nocheatplus.components.location.ISetPositionWithLook;
+import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.Validate;
@@ -42,9 +43,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 
@@ -67,9 +71,12 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+            final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+            logManager.warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + " | Error: " + t.getMessage());
+            logManager.warning(Streams.STATUS, t);
         }
     }
 


### PR DESCRIPTION
## Summary
- log throwable details when entity last position lookups fail

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d236452d483299c116bd88b81dfe8