### PR TITLE
Fix oddLiquid check order

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/AirWorkarounds.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/AirWorkarounds.java
@@ -178,9 +178,10 @@ public class AirWorkarounds {
 
 
     /**
-     * Jump after leaving the liquid near ground / jumping through liquid or simply leaving liquid in general
+     * Jump after leaving the liquid near ground or jumping through liquid
      * (rather friction envelope, problematic). Needs last move data.
-     * 
+     * Jump phase checks are handled in the invoked helper methods.
+     *
      * @return If the exemption condition applies.
      */
 private static boolean oddLiquid(final double yDistance, final double yDistDiffEx, final double maxJumpGain,
@@ -191,9 +192,6 @@ private static boolean oddLiquid(final double yDistance, final double yDistDiffE
                 || data.liftOffEnvelope == LiftOffEnvelope.LIMIT_NEAR_GROUND
                 || data.liftOffEnvelope == LiftOffEnvelope.LIMIT_SURFACE;
         final int blockData = from.getData(from.getBlockX(), from.getBlockY(), from.getBlockZ());
-        if (data.sfJumpPhase != 1 && data.sfJumpPhase != 2) {
-            return false;
-        }
         return isFallingTooFast(yDistance, yDistDiffEx, thisMove, lastMove, data, liquidEnvelope)
                 || isLimitLiquidVdistInversion(yDistance, yDistDiffEx, resetTo, lastMove, data, resetFrom)
                 || isLiquidEnvelopeBehavior(yDistance, yDistDiffEx, maxJumpGain, liquidEnvelope,


### PR DESCRIPTION
## Summary
- evaluate oddLiquid conditions even when jump phase doesn't match

## Testing
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_b_685d22f69b748329802f9a611cb1cce4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Reorder the `oddLiquid` method's check sequence by removing the jump phase condition and addressing it in invoked helper methods.

### Why are these changes being made?

This change optimizes the logic sequence within the `oddLiquid` method by moving the jump phase checks into appropriate helper methods, making the code cleaner and ensuring accurate exemption conditions. The redundant check removed streamlines the flow, potentially fixing issues related to false negatives in liquid-related movement checks.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->