### PR TITLE
Improve logging of entity last position errors

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectEntityLastPositionAndLook.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectEntityLastPositionAndLook.java
@@ -62,7 +62,11 @@ public class ReflectEntityLastPositionAndLook extends ReflectGetHandleBase<Entit
             performGet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, "Could not retrieve last position and look for Entity: " + entity.getClass().getName());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+                    "Could not retrieve last position and look for Entity: "
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -81,7 +85,11 @@ public class ReflectEntityLastPositionAndLook extends ReflectGetHandleBase<Entit
             performSet(entity, location);
         }
         catch (Throwable t) {
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, "Could not set last position and look for Entity: " + entity.getClass().getName());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
+                    "Could not set last position and look for Entity: "
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/EntityAccessLastPositionAndLook.java
@@ -44,7 +44,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -69,7 +71,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/EntityAccessLastPositionAndLook.java
@@ -44,7 +44,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -69,7 +71,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/EntityAccessLastPositionAndLook.java
@@ -44,7 +44,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -69,7 +71,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/EntityAccessLastPositionAndLook.java
@@ -44,7 +44,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -69,7 +71,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/EntityAccessLastPositionAndLook.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/EntityAccessLastPositionAndLook.java
@@ -44,7 +44,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not retrieve last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 
@@ -69,7 +71,9 @@ public class EntityAccessLastPositionAndLook implements IEntityAccessLastPositio
         catch (Throwable t) {
             NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS,
                     "Could not set last position and look for Entity: "
-                    + (entity != null ? entity.getClass().getName() : "null"));
+                            + (entity != null ? entity.getClass().getName() : "null")
+                            + ". Error: " + t.getMessage());
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, t);
         }
     }
 


### PR DESCRIPTION
## Summary
- log the throwable when failing to get or set entity last position
- update compatibility modules accordingly

## Testing
- `mvn -q -P nonfree_build verify`

------
https://chatgpt.com/codex/tasks/task_b_685d235ba49883299d6115952a09cdef