### PR TITLE
Add bubbleweb drag calculation with tests

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -3073,6 +3073,9 @@ public class SurvivalFly extends Check {
                                      final MovingData data) {
 
         final double yDistance = thisMove.yDistance;
+        if (thisMove.from.draggedByBubbleStream) {
+            return vDistBubbleWebDrag(yDistance, lastMove.yDistance);
+        }
         final double vAllowedDistance;
 
         // Lenient on first move(s) in web.
@@ -3088,6 +3091,21 @@ public class SurvivalFly extends Check {
 
         if (vDistanceAboveLimit > 0.0) {
             tags.add("vwebdesc");
+        }
+        return new double[]{vAllowedDistance, vDistanceAboveLimit};
+    }
+
+    private double[] vDistBubbleWebDrag(final double yDistance, final double lastYDistance) {
+        double vAllowedDistance = lastYDistance * Magic.FRICTION_MEDIUM_WATER;
+        final double limit = -Magic.bubbleStreamDescend * Magic.FRICTION_MEDIUM_WATER;
+        if (vAllowedDistance > limit) {
+            vAllowedDistance = limit;
+        }
+        final double vDistanceAboveLimit = yDistance < vAllowedDistance
+                ? Math.abs(yDistance - vAllowedDistance) : 0.0;
+        tags.add("bubbleweb_drag");
+        if (vDistanceAboveLimit > 0.0) {
+            tags.add("vwebdrag");
         }
         return new double[]{vAllowedDistance, vDistanceAboveLimit};
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestBubbleWebDrag.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestBubbleWebDrag.java
@@ -1,0 +1,70 @@
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.checks.moving.player.SurvivalFly;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestBubbleWebDrag {
+
+    static class SimpleHandle<T> implements IGenericInstanceHandle<T> {
+        private final T handle;
+        SimpleHandle(T h){ this.handle = h; }
+        @Override public T getHandle(){ return handle; }
+        @Override public void disableHandle(){}
+    }
+
+    private static void setupAPI() throws Exception {
+        Object api = Proxy.newProxyInstance(NCPAPIProvider.class.getClassLoader(),
+                new Class<?>[]{fr.neatmonster.nocheatplus.components.NoCheatPlusAPI.class},
+                (p,m,a) -> {
+                    if ("getBlockChangeTracker".equals(m.getName())) return new BlockChangeTracker();
+                    if ("getGenericInstanceHandle".equals(m.getName())) return new SimpleHandle<>(null);
+                    Class<?> r = m.getReturnType();
+                    if (r == boolean.class) return false;
+                    if (r.isPrimitive()) return 0;
+                    return null;
+                });
+        Field f = NCPAPIProvider.class.getDeclaredField("noCheatPlusAPI");
+        f.setAccessible(true);
+        f.set(null, api);
+    }
+
+    @Before
+    public void init() throws Exception {
+        setupAPI();
+    }
+
+    @Test
+    public void testDragViolation() throws Exception {
+        SurvivalFly sf = new SurvivalFly();
+        Method m = SurvivalFly.class.getDeclaredMethod("vDistBubbleWebDrag", double.class, double.class);
+        m.setAccessible(true);
+        double[] res = (double[]) m.invoke(sf, -0.5, -0.3);
+        double limit = -fr.neatmonster.nocheatplus.checks.moving.magic.Magic.bubbleStreamDescend
+                * fr.neatmonster.nocheatplus.checks.moving.magic.Magic.FRICTION_MEDIUM_WATER;
+        assertEquals(limit, res[0], 1e-6);
+        assertEquals(Math.abs(-0.5 - limit), res[1], 1e-6);
+    }
+
+    @Test
+    public void testDragNoViolation() throws Exception {
+        SurvivalFly sf = new SurvivalFly();
+        Method m = SurvivalFly.class.getDeclaredMethod("vDistBubbleWebDrag", double.class, double.class);
+        m.setAccessible(true);
+        double[] res = (double[]) m.invoke(sf, -0.47, -0.3);
+        double limit = -fr.neatmonster.nocheatplus.checks.moving.magic.Magic.bubbleStreamDescend
+                * fr.neatmonster.nocheatplus.checks.moving.magic.Magic.FRICTION_MEDIUM_WATER;
+        assertEquals(limit, res[0], 1e-6);
+        assertEquals(0.0, res[1], 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- handle cobweb slowdown when bubble columns drag downward
- add vDistBubbleWebDrag helper
- test vertical limits for bubble column + cobweb

## Testing
- `mvn -q test`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check` *(fails: spotbugs found medium severity issues)*

------
https://chatgpt.com/codex/tasks/task_b_685d2fe245dc8329820994cd082de92d