### PR TITLE
Clean registration code

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/permissions/PermissionUtil.java
@@ -63,10 +63,8 @@ public class PermissionUtil {
             this.permissionMessage = permissionMessage;
         }
 
+        // Restore stored command parameters.
         public void restore() {
-            // (Don't skip resetting, as there could be fall-back aliases.)
-            //			Command registered = CommandUtil.getCommand(label);
-            //			if (registered == null || registered != command) return;
             if (!label.equalsIgnoreCase(command.getLabel().trim().toLowerCase())) {
                 command.setLabel(label);
             }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -197,9 +197,6 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     /** Configuration problems (send to log files). */
     private String configProblemsFile = null;
 
-    //    /** Is a new update available? */
-    //    private boolean              updateAvailable = false;
-
     // Permission registry is currently global; per-world entries might be introduced later.
     private final PermissionRegistry permissionRegistry = new PermissionRegistry(10000);
     /** Per world data. */
@@ -1110,23 +1107,11 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         allViolationsHook.setConfig(new AllViolationsConfig(config));
         vlFrequencyHook.setConfig(new ViolationFrequencyConfig(config));
 
-        //        if (config.getBoolean(ConfPaths.MISCELLANEOUS_CHECKFORUPDATES)) {
-        //            // Is a new update available?
-        //            final int timeout = config.getInt(ConfPaths.MISCELLANEOUS_UPDATETIMEOUT, 4) * 1000;
-        //            getServer().getScheduler().scheduleAsyncDelayedTask(this, new Runnable() {
-        //                @Override
-        //                public void run() {
-        //                    updateAvailable = Updates.checkForUpdates(getDescription().getVersion(), timeout);
-        //                }
-        //            });
-        //        }
-
         // Log other notes.
         logOtherNotes(config);
 
         // Is the version the configuration was created with consistent with the current one?
         if (configProblemsFile != null && config.getBoolean(ConfPaths.CONFIGVERSION_NOTIFY)) {
-            // Could use custom prefix from logging, however ncp should be mentioned then.
             logManager.warning(Streams.INIT, "" + configProblemsFile);
         }
 
@@ -1409,8 +1394,6 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         if (data.hasPermission(Permissions.NOTIFY, player)) { // Updates the cache.
             // Login notifications...
             //            // Update available.
-            //            if (updateAvailable) player.sendMessage(ChatColor.RED + "NCP: " + ChatColor.WHITE + "A new update of NoCheatPlus is available.\n" + "Download it at http://nocheatplus.org/update");
-
             // Inconsistent config version.
             if (configProblemsChat != null && ConfigManager.getConfigFile().getBoolean(ConfPaths.CONFIGVERSION_NOTIFY)) {
                 // Could use custom prefix from logging, however ncp should be mentioned then.

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
@@ -15,7 +15,6 @@
 package fr.neatmonster.nocheatplus.compat.registry;
 
 import fr.neatmonster.nocheatplus.compat.MCAccess;
-import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
 import fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleMultiPassenger;
 
@@ -41,8 +40,6 @@ public class EntityAccessFactory {
      * @param config
      */
     public void setupEntityAccess(final MCAccess mcAccess, final MCAccessConfig config) {
-
-        // Register implementation for IEntityAccessLastPositionAndLook if available.
 
         // IEntityAccessVehicle
         IEntityAccessVehicle vehicleAccess = EntityAccessVehicleMultiPassenger.createIfSupported();

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
@@ -42,15 +42,7 @@ public class EntityAccessFactory {
      */
     public void setupEntityAccess(final MCAccess mcAccess, final MCAccessConfig config) {
 
-        // IEntityAccessLastPositionAndLook
-        //RegistryHelper.setupGenericInstance(new String[] {
-        //        "fr.neatmonster.nocheatplus.compat.cbdev.EntityAccessLastPositionAndLook",
-        //        "fr.neatmonster.nocheatplus.compat.spigotcb1_10_R1.EntityAccessLastPositionAndLook",
-        //        "fr.neatmonster.nocheatplus.compat.spigotcb1_9_R2.EntityAccessLastPositionAndLook",
-        //        "fr.neatmonster.nocheatplus.compat.spigotcb1_9_R1.EntityAccessLastPositionAndLook",
-        //}, new String[] {
-        //        "fr.neatmonster.nocheatplus.compat.cbreflect.reflect.ReflectEntityLastPositionAndLook",
-        //}, IEntityAccessLastPositionAndLook.class, config, false);
+        // Register implementation for IEntityAccessLastPositionAndLook if available.
 
         // IEntityAccessVehicle
         IEntityAccessVehicle vehicleAccess = EntityAccessVehicleMultiPassenger.createIfSupported();

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/updates/Updates.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/updates/Updates.java
@@ -23,29 +23,7 @@ public class Updates {
      * @return
      */
     public static boolean checkForUpdates(String versionString, int updateTimeout) {
-        //		BufferedReader bufferedReader = null;
-        boolean updateAvailable = false;
-        //        try {
-        //            final String[] split = versionString.split("-b");
-        //            final int currentVersion = Integer.parseInt(split[split.length - 1]);
-        //            final URL url = new URL("http://nocheatplus.org:8080/job/NoCheatPlus/lastSuccessfulBuild/api/json");
-        //            final URLConnection connection = url.openConnection();
-        //            connection.setConnectTimeout(updateTimeout);
-        //            connection.setReadTimeout(2 * updateTimeout);
-        //            bufferedReader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        //            String line, content = "";
-        //            while ((line = bufferedReader.readLine()) != null) {
-        //                content += line;
-        //            }
-        //            final int jenkinsVersion = Integer.parseInt(content.split("\"number\":")[1].split(",")[0]);
-        //            updateAvailable = currentVersion < jenkinsVersion;
-        //        }
-        //        catch (final Exception e) {}
-        //        finally {
-        //            if (bufferedReader != null) {
-        //                 try{bufferedReader.close();}catch (IOException e) {};
-        //            }
-        //        }
-        return updateAvailable;
+        // Update checks have been removed. Always return false.
+        return false;
     }
 }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/updates/Updates.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/updates/Updates.java
@@ -17,13 +17,14 @@ package fr.neatmonster.nocheatplus.updates;
 public class Updates {
 
     /**
-     * To be called from an async task.
-     * @param versionString Current version string (getDescription().getVersion()).
-     * @param updateTimeout
-     * @return
+     * Checks for updates.
+     * <p>
+     * Update checks have been removed, so this always returns {@code false}.
+     * This method is kept for API compatibility.
+     *
+     * @return always {@code false}
      */
-    public static boolean checkForUpdates(String versionString, int updateTimeout) {
-        // Update checks have been removed. Always return false.
+    public static boolean checkForUpdates() {
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- delete dead update check code
- remove stale registration snippets
- clarify command restore comment

## Testing
- `mvn -q verify`
- `mvn -q checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2fe1cb9c8329bdf77b69b589671c





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed all code and references related to update checking and update notifications.
  * Cleaned up old commented-out code and internal comments for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove deprecated and commented-out code related to update checks and command registration from the NoCheatPlus plugin codebase.

### Why are these changes being made?

This change cleans up the codebase by removing unnecessary, dead code that was primarily related to update checks and command registration procedures that are no longer applicable or needed. Divesting from outdated code enhances maintainability and readability, reduces potential confusion for future development, and ensures the system only contains relevant functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->