### PR TITLE
Improve enchantment check logging

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -72,6 +72,8 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.stats.Counters;
 import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+import fr.neatmonster.nocheatplus.logging.LogManager;
+import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.utilities.map.MaterialUtil;
 
@@ -245,7 +247,7 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
         final ItemStack cursor = event.getCursor();
         final ItemStack clicked = event.getCurrentItem();
 
-        boolean cancel = checkIllegalEnchantments(player, cursor, clicked, pData);
+        boolean cancel = checkIllegalEnchantments(player, cursor, clicked, pData, slot);
         cancel |= checkFastClick(event, player, pData, now, slot, cursor, clicked, action, data);
         cancel |= checkInventoryMove(event, player, pData, data);
 
@@ -264,26 +266,33 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
     }
 
     private boolean checkIllegalEnchantments(final Player player, final ItemStack cursor,
-            final ItemStack clicked, final IPlayerData pData) {
+            final ItemStack clicked, final IPlayerData pData, final int slot) {
         try {
             if (Items.checkIllegalEnchantments(player, clicked, pData)) {
                 counters.addPrimaryThread(idIllegalItem, 1);
                 return true;
             }
-        } catch (final ArrayIndexOutOfBoundsException ignore) {
-            // Safe to ignore - CraftBukkit issue where slot can sometimes be out of range
-            // See: https://hub.spigotmc.org/jira/browse/SPIGOT-123
+        } catch (final ArrayIndexOutOfBoundsException ex) {
+            logSlotWarning(player, slot, ex);
         }
         try {
             if (Items.checkIllegalEnchantments(player, cursor, pData)) {
                 counters.addPrimaryThread(idIllegalItem, 1);
                 return true;
             }
-        } catch (final ArrayIndexOutOfBoundsException ignore) {
-            // Safe to ignore - CraftBukkit issue where slot can sometimes be out of range
-            // See: https://hub.spigotmc.org/jira/browse/SPIGOT-123
+        } catch (final ArrayIndexOutOfBoundsException ex) {
+            logSlotWarning(player, slot, ex);
         }
         return false;
+    }
+
+    private void logSlotWarning(final Player player, final int slot,
+            final ArrayIndexOutOfBoundsException ex) {
+        final String playerName = player != null ? player.getName() : "null";
+        final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+        logManager.warning(Streams.PLUGIN_LOGGER,
+                "Slot out of range while checking illegal enchantments: player="
+                        + playerName + " slot=" + slot + " (" + ex.getMessage() + ")");
     }
 
     private boolean checkFastClick(final InventoryClickEvent event, final Player player, final IPlayerData pData,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -267,6 +267,7 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
 
     private boolean checkIllegalEnchantments(final Player player, final ItemStack cursor,
             final ItemStack clicked, final IPlayerData pData, final int slot) {
+        boolean logged = false;
         try {
             if (Items.checkIllegalEnchantments(player, clicked, pData)) {
                 counters.addPrimaryThread(idIllegalItem, 1);
@@ -274,6 +275,7 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
             }
         } catch (final ArrayIndexOutOfBoundsException ex) {
             logSlotWarning(player, slot, ex);
+            logged = true;
         }
         try {
             if (Items.checkIllegalEnchantments(player, cursor, pData)) {
@@ -281,7 +283,9 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
                 return true;
             }
         } catch (final ArrayIndexOutOfBoundsException ex) {
-            logSlotWarning(player, slot, ex);
+            if (!logged) {
+                logSlotWarning(player, slot, ex);
+            }
         }
         return false;
     }
@@ -290,9 +294,13 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
             final ArrayIndexOutOfBoundsException ex) {
         final String playerName = player != null ? player.getName() : "null";
         final LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+        final String invType = player != null && player.getOpenInventory() != null
+                ? player.getOpenInventory().getType().name()
+                : "unknown";
         logManager.warning(Streams.PLUGIN_LOGGER,
                 "Slot out of range while checking illegal enchantments: player="
-                        + playerName + " slot=" + slot + " (" + ex.getMessage() + ")");
+                        + playerName + " inventory=" + invType + " slot=" + slot
+                        + " (" + ex.getMessage() + ")");
     }
 
     private boolean checkFastClick(final InventoryClickEvent event, final Player player, final IPlayerData pData,


### PR DESCRIPTION
## Summary
- log inventory slot details when illegal enchantment check fails
- include player name with new warning

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fcf07b0832991578659e36de902

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the logging mechanism for illegal enchantment checks by introducing detailed logging for slot-related exceptions and updating the method signatures to include the slot parameter.

### Why are these changes being made?

The changes address the need for improved diagnostics in illegal enchantment detection by recording specific slot-related information when an `ArrayIndexOutOfBoundsException` occurs, thereby facilitating easier debugging and traceability of inventory issues related to slot indexing discrepancies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->