### PR TITLE
Switch block break timing to Monotonic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakData.java
@@ -24,6 +24,7 @@ import fr.neatmonster.nocheatplus.components.registry.IGetGenericInstance;
 import fr.neatmonster.nocheatplus.stats.Timings;
 import fr.neatmonster.nocheatplus.utilities.ds.count.ActionFrequency;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 
 /**
  * Player specific data for the block break checks.
@@ -53,9 +54,9 @@ public class BlockBreakData extends ACheckData implements IDataOnReload {
 
     // Data of the fast break check.
     public final ActionFrequency fastBreakPenalties;
-    public long    fastBreakBreakTime  = System.currentTimeMillis() - 1000L;
+    public long    fastBreakBreakTime  = Monotonic.millis() - 1000L;
     /** First time interaction with a block. */
-    public long    fastBreakfirstDamage = System.currentTimeMillis();
+    public long    fastBreakfirstDamage = Monotonic.millis();
 
     public final ActionFrequency frequencyBuckets;
     public int     frequencyShortTermCount;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -52,6 +52,7 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.players.PlayerFactoryArgument;
 import fr.neatmonster.nocheatplus.stats.Counters;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.worlds.WorldFactoryArgument;
 
@@ -148,7 +149,7 @@ public class BlockBreakListener extends CheckListener {
      */
     @EventHandler(ignoreCancelled = false, priority = EventPriority.LOWEST)
     public void onBlockBreak(final BlockBreakEvent event) {
-        final long now = System.currentTimeMillis();
+        final long now = Monotonic.millis();
         final Player player = event.getPlayer();
         final IPlayerData pData = player != null ? DataManager.getPlayerData(player) : null;
         final Block block = event.getBlock();
@@ -404,7 +405,7 @@ public class BlockBreakListener extends CheckListener {
     }
 
     private void checkBlockDamage(final Player player, final Block block, final Cancellable event){
-        final long now = System.currentTimeMillis();
+        final long now = Monotonic.millis();
         final IPlayerData pData = DataManager.getPlayerData(player);
         final BlockBreakData data = pData.getGenericInstance(BlockBreakData.class);
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -32,6 +32,7 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.PotionUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 
 /**
  * A check used to verify if the player isn't breaking blocks faster than possible.
@@ -60,7 +61,7 @@ public class FastBreak extends Check {
      */
     public boolean check(final Player player, final Block block, final AlmostBoolean isInstaBreak, 
             final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
-        final long now = System.currentTimeMillis();
+        final long now = Monotonic.millis();
         boolean cancel = false;
 
         // Determine expected breaking time by block type.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 
 /**
  * This checks just limits the number of blocks broken per time frame.
@@ -38,7 +39,7 @@ public class Frequency extends Check {
             final IPlayerData pData){
 
         final float interval = (float) ((player.getGameMode() == GameMode.CREATIVE)?(cc.frequencyIntervalCreative):(cc.frequencyIntervalSurvival));
-        data.frequencyBuckets.add(System.currentTimeMillis(), interval);
+        data.frequencyBuckets.add(Monotonic.millis(), interval);
 
         // Full period frequency.
         final float fullScore = data.frequencyBuckets.score(cc.frequencyBucketFactor);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -24,6 +24,7 @@ import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
 import fr.neatmonster.nocheatplus.permissions.Permissions;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.location.TrigUtil;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 
 public class WrongBlock extends Check {
 
@@ -50,7 +51,7 @@ public class WrongBlock extends Check {
         boolean cancel = false;
 
         if (player != null && block != null && cc != null && data != null && pData != null) {
-            final long now = System.currentTimeMillis();
+            final long now = Monotonic.millis();
             final boolean wrongTime = data.fastBreakfirstDamage < data.fastBreakBreakTime;
             final int dist = Math.min(4,
                     data.clickedX == Integer.MAX_VALUE ? 100

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestGodModeHelpers.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestGodModeHelpers.java
@@ -38,6 +38,7 @@ import fr.neatmonster.nocheatplus.components.registry.ComponentRegistry;
 import fr.neatmonster.nocheatplus.components.registry.setup.RegistrationContext;
 import fr.neatmonster.nocheatplus.actions.ActionFactoryFactory;
 import fr.neatmonster.nocheatplus.actions.ActionFactory;
+import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 import fr.neatmonster.nocheatplus.players.IPlayerDataManager;
 import fr.neatmonster.nocheatplus.config.ConfigFile;
 import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
@@ -195,11 +196,11 @@ public class TestGodModeHelpers {
         when(worldData.getRawConfiguration()).thenReturn(new DefaultConfig());
         FightConfig cfg = new FightConfig(worldData);
         FightData fData = new FightData(cfg);
-        fData.speedBuckets.clear(System.currentTimeMillis());
+        fData.speedBuckets.clear(Monotonic.synchMillis());
         BlockBreakConfig bbCfg = new BlockBreakConfig(worldData);
         BlockBreakData bbData = new BlockBreakData(bbCfg);
         bbData.fastBreakfirstDamage = 0;
-        bbData.frequencyBuckets.clear(System.currentTimeMillis());
+        bbData.frequencyBuckets.clear(Monotonic.synchMillis());
         CombinedData cData = new CombinedData();
         cData.lastMoveTime = 0;
         InventoryData iData = new InventoryData();
@@ -215,7 +216,7 @@ public class TestGodModeHelpers {
         when(pData.getGenericInstance(NetData.class)).thenReturn(netData);
 
         long diff = (cfg.godModeLagMinAge + cfg.godModeLagMaxAge) / 2;
-        netData.lastKeepAliveTime = System.currentTimeMillis() - diff;
+        netData.lastKeepAliveTime = Monotonic.synchMillis() - diff;
         Player player = mock(Player.class);
         GodMode gm = new GodMode();
 


### PR DESCRIPTION
## Summary
- use `Monotonic.millis()` in `FastBreak`, `Frequency`, `WrongBlock` and listener
- adjust `BlockBreakData` and tests to expect monotonic timestamps

## Testing
- `mvn --no-transfer-progress verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fcb1af48329bbe829ef03742e93