### PR TITLE
Validate tick for target move info

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -366,16 +366,23 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
 
     /**
      * Calculate relative movement of the damaged entity since last attack.
+     * <p>
+     * The {@code tick} parameter must represent the current server tick at the
+     * moment of the attack. It must be non-negative and monotonically
+     * increasing. If the tick is older than the last known attack tick or if the
+     * provided values are otherwise invalid, a default {@link TargetMoveInfo} is
+     * returned.
+     * </p>
      */
     private TargetMoveInfo computeTargetMoveInfo(final FightData data, final Location damagedLoc,
                                                  final int tick, final boolean worldChanged) {
 
-        if (data == null || damagedLoc == null) {
-            return new TargetMoveInfo(0, 0.0, 0, 0.0);
+        if (tick < 0) {
+            throw new IllegalArgumentException("tick must be >= 0");
         }
-        if (data.lastAttackedX == Double.MAX_VALUE || tick < data.lastAttackTick
-                || worldChanged || tick - data.lastAttackTick > 20) {
-            return new TargetMoveInfo(0, 0.0, 0, 0.0);
+
+        if (isInvalidMoveInfo(data, damagedLoc, tick, worldChanged)) {
+            return DEFAULT_TARGET_MOVE_INFO;
         }
         final int age = tick - data.lastAttackTick;
         final double move = TrigUtil.distance(data.lastAttackedX, data.lastAttackedZ,
@@ -383,6 +390,15 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         final long msAge = (long) (50f * TickTask.getLag(50L * age, true) * (float) age);
         final double normalized = msAge == 0 ? move : move * Math.min(20.0, 1000.0 / (double) msAge);
         return new TargetMoveInfo(age, move, msAge, normalized);
+    }
+
+    private static boolean isInvalidMoveInfo(final FightData data, final Location damagedLoc,
+                                             final int tick, final boolean worldChanged) {
+        return data == null || damagedLoc == null
+                || data.lastAttackedX == Double.MAX_VALUE
+                || tick < data.lastAttackTick
+                || worldChanged
+                || tick - data.lastAttackTick > 20;
     }
 
     /**
@@ -420,6 +436,8 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         }
         auxMoving.returnPlayerMoveInfo(moveInfo);
     }
+
+    private static final TargetMoveInfo DEFAULT_TARGET_MOVE_INFO = new TargetMoveInfo(0, 0.0, 0, 0.0);
 
     private static final class TargetMoveInfo {
         final int tickAge;


### PR DESCRIPTION
## Summary
- validate `tick` in FightListener and return default movement info when outdated
- document tick semantics

## Testing
- `mvn verify -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_b_685d2fc871a483299964a7d4dbfb8b5e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enforce tick validity check for computing `TargetMoveInfo` and refactor validation logic into a helper method `isInvalidMoveInfo`.

### Why are these changes being made?

The changes ensure robustness by requiring that the `tick` parameter is non-negative and always increasing, throwing an exception if invalid; this prevents erroneous movement calculations. Refactoring the validation logic into a separate method and introducing `DEFAULT_TARGET_MOVE_INFO` improves readability and maintainability of the code by reducing duplication and centralizing the logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->