### PR TITLE
Add safety check for CraftEntity cast

### DIFF
--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
@@ -32,6 +32,7 @@ import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.location.LocUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 import net.minecraft.server.v1_11_R1.AxisAlignedBB;
 import net.minecraft.server.v1_11_R1.Block;
 import net.minecraft.server.v1_11_R1.BlockPosition;
@@ -128,15 +129,26 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        // (entity.getHeight() returns the length field, but we access nms anyway.)
-        final net.minecraft.server.v1_11_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_11_R1.Entity mcEntity = getHandleIfCraft(entity);
+        if (mcEntity == null) {
+            return entity != null ? entity.getHeight() : 0.0;
+        }
         final AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
-        final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
+        final double entityHeight = Math.max(mcEntity.length,
+                Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
             return Math.max(((LivingEntity) entity).getEyeHeight(), entityHeight);
         } else {
             return entityHeight;
         }
+    }
+
+    private net.minecraft.server.v1_11_R1.Entity getHandleIfCraft(final Entity entity) {
+        if (entity instanceof CraftEntity) {
+            return ((CraftEntity) entity).getHandle();
+        }
+        StaticLog.logWarning("Expected CraftEntity but got " + entity);
+        return null;
     }
 
     private net.minecraft.server.v1_11_R1.Material getMaterial(int blockId) {
@@ -174,7 +186,11 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        final net.minecraft.server.v1_11_R1.Entity mcEntity = getHandleIfCraft(entity);
+        if (mcEntity == null) {
+            return 0.6;
+        }
+        return mcEntity.width;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid `ClassCastException` in `MCAccessSpigotCB1_11_R1`
- log a warning and fall back when the entity is not a `CraftEntity`
- return a default width when missing

## Testing
- `mvn -q test`
- `mvn -DskipTests -DskipITs checkstyle:check pmd:check spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685d2fc781688329a5ce1c1ed7457034

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a safety check method `getHandleIfCraft` to validate and log warning if `Entity` is not an instance of `CraftEntity` before casting, and update methods `getHeight` and `getWidth` to use this new validation.

### Why are these changes being made?

These changes enhance the code's robustness by preventing class cast exceptions when casting entities to `CraftEntity`. The additional logging helps in diagnosing potential issues when entities are not of the expected type. This approach ensures better error handling and maintains logical integrity without interrupting the application's flow.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->