### PR TITLE
Rename survival fly fall damage options

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -135,13 +135,13 @@ public class MovingConfig extends ACheckConfig {
     public boolean    survivalFlyVLFreezeInAir;
     // Set back policy.
     public boolean    sfSetBackPolicyVoid;
-    public boolean    sfSetBackPolicyFallDamage;
+    public boolean    sfSetBackPolicyApplyFallDamage;
     public ActionList survivalFlyActions;
 
     public boolean 	sfHoverCheck; // Placeholder for potential sub check
     public int 		sfHoverTicks;
     public int		sfHoverLoginTicks;
-    public boolean    sfHoverFallDamage;
+    public boolean    sfHoverTakeFallDamage;
     public double		sfHoverViolation;
 
     // Special tolerance values:
@@ -363,7 +363,7 @@ public class MovingConfig extends ACheckConfig {
         survivalFlyAccountingV = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_VACC);
         survivalFlyAccountingStep = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_STEP);
         survivalFlyResetItem = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_EXTENDED_RESETITEM);
-        sfSetBackPolicyFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE);
+        sfSetBackPolicyApplyFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE);
         sfSetBackPolicyVoid = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID);
         final double sfStepHeight = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_STEPHEIGHT, Double.MAX_VALUE);
         if (sfStepHeight == Double.MAX_VALUE) {
@@ -386,7 +386,7 @@ public class MovingConfig extends ACheckConfig {
         sfHoverCheck = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK);
         sfHoverTicks = config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS);
         sfHoverLoginTicks = Math.max(0, config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS));
-        sfHoverFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_FALLDAMAGE);
+        sfHoverTakeFallDamage = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_TAKEFALLDAMAGE);
         sfHoverViolation = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_HOVER_SFVIOLATION);
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -329,7 +329,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 newTo = LocUtil.clone(loc);
             }
 
-            if (sfCheck && cc.sfSetBackPolicyFallDamage && noFall.isEnabled(player, pData)) {
+            if (sfCheck && cc.sfSetBackPolicyApplyFallDamage && noFall.isEnabled(player, pData)) {
                 // Check if to deal damage.
                 double y = loc.getY();
                 if (data.hasSetBack()) y = Math.min(y, data.getSetBackY());
@@ -1348,7 +1348,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             final PlayerLocation pFrom, final PlayerLocation pTo, final boolean checkNf,
             final double previousSetBackY, final MovingData data, final MovingConfig cc,
             final IPlayerData pData) {
-        if (checkNf && cc.sfSetBackPolicyFallDamage) {
+        if (checkNf && cc.sfSetBackPolicyApplyFallDamage) {
             boolean skip = !noFall.willDealFallDamage(player, from.getY(), previousSetBackY, data);
             if (!skip && (!pFrom.isOnGround() && !pFrom.isResetCond())) {
                 skip = false;
@@ -3133,7 +3133,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                                       final MovingConfig cc, final MovingData data, final IPlayerData pData) {
 
         // Check nofall damage (!).
-        if (cc.sfHoverFallDamage && noFall.isEnabled(player, pData)) {
+        if (cc.sfHoverTakeFallDamage && noFall.isEnabled(player, pData)) {
             // Consider adding 3/3.5 to fall distance if fall distance > 0?
             noFall.checkDamage(player, loc.getY(), data, pData);
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -699,6 +699,8 @@ public abstract class ConfPaths {
     public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT     = MOVING_SURVIVALFLY_LENIENCY + "freezecount";
     public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR     = MOVING_SURVIVALFLY_LENIENCY + "freezeinair";
     private static final String MOVING_SURVIVALFLY_SETBACKPOLICY            = MOVING_SURVIVALFLY + "setbackpolicy.";
+    public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE = MOVING_SURVIVALFLY_SETBACKPOLICY + "applyfalldamage";
+    @Moved(newPath = MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE)
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE  = MOVING_SURVIVALFLY_SETBACKPOLICY + "falldamage";
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID  = MOVING_SURVIVALFLY_SETBACKPOLICY + "voidtovoid";
     public static final String MOVING_SURVIVALFLY_ACTIONS                   = MOVING_SURVIVALFLY + "actions";
@@ -716,6 +718,8 @@ public abstract class ConfPaths {
     public static final String  MOVING_SURVIVALFLY_HOVER_STEP               = MOVING_SURVIVALFLY_HOVER + "step";
     public static final String  MOVING_SURVIVALFLY_HOVER_TICKS              = MOVING_SURVIVALFLY_HOVER + "ticks";
     public static final String  MOVING_SURVIVALFLY_HOVER_LOGINTICKS         = MOVING_SURVIVALFLY_HOVER + "loginticks";
+    public static final String  MOVING_SURVIVALFLY_HOVER_TAKEFALLDAMAGE     = MOVING_SURVIVALFLY_HOVER + "takefalldamage";
+    @Moved(newPath = MOVING_SURVIVALFLY_HOVER_TAKEFALLDAMAGE)
     public static final String  MOVING_SURVIVALFLY_HOVER_FALLDAMAGE         = MOVING_SURVIVALFLY_HOVER + "falldamage";
     public static final String  MOVING_SURVIVALFLY_HOVER_SFVIOLATION        = MOVING_SURVIVALFLY_HOVER + "sfviolation";
 
@@ -894,7 +898,7 @@ public abstract class ConfPaths {
     public static final String  MOVING_CREATIVEFLY_VERTICALSPEED         = "checks.moving.creativefly.verticalspeed";
     @Moved(newPath = MOVING_CREATIVEFLY_MODEL + "creative." + SUB_MAXHEIGHT)
     public static final String  MOVING_CREATIVEFLY_MAXHEIGHT             = "checks.moving.creativefly.maxheight";
-    @Moved(newPath = MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE)
+    @Moved(newPath = MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE)
     public static final String MOVING_SURVIVALFLY_FALLDAMAGE             = "checks.moving.survivalfly.falldamage";
     @Moved(newPath=MOVING_VEHICLE_ENFORCELOCATION)
     public static final String  MOVING_VEHICLES_ENFORCELOCATION             = "checks.moving.vehicles.enforcelocation";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -555,7 +555,8 @@ public class DefaultConfig extends ConfigFile {
         // More leniency features
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT, 40, 1144);
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR, true, 1143);
-        set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE, true, 785);
+        // MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE -> MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE
+        set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID, false, 1154);
         set(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, "cancel log:flyfile:6:15:f" 
             + " vl>100 cancel log:survivalfly:10:11:i log:flyfile:6:15:f" 
@@ -566,7 +567,8 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS, 85, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_LOGINTICKS, 60, 785);
-        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_FALLDAMAGE, true, 785);
+        // MOVING_SURVIVALFLY_HOVER_FALLDAMAGE -> MOVING_SURVIVALFLY_HOVER_TAKEFALLDAMAGE
+        set(ConfPaths.MOVING_SURVIVALFLY_HOVER_TAKEFALLDAMAGE, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_SFVIOLATION, 200, 1154); 
         // Moving Trace - Lag compensator
         set(ConfPaths.MOVING_TRACE_MAXAGE, 30, 1154);

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Links
 * [Issues/Tickets](https://github.com/Updated-NoCheatPlus/NoCheatPlus/issues)
 * [Wiki](https://github.com/Updated-NoCheatPlus/Docs)
 * [Configuration](https://github.com/Updated-NoCheatPlus/Docs#configuration)
+* The paths `checks.moving.survivalfly.setbackpolicy.falldamage` and
+  `checks.moving.survivalfly.hover.falldamage` are now
+  `checks.moving.survivalfly.setbackpolicy.applyfalldamage` and
+  `checks.moving.survivalfly.hover.takefalldamage`.
 * [Permissions](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Permissions.md)
 * [Commands](https://github.com/Updated-NoCheatPlus/Docs/blob/master/Settings/Commands.md)
 


### PR DESCRIPTION
## Summary
- rename fall damage config paths to `applyfalldamage` and `takefalldamage`
- migrate old paths in `ConfPaths`
- update default config defaults and doc
- refactor variable names and usages

## Testing
- `mvn -q verify -DskipTests=true`


------
https://chatgpt.com/codex/tasks/task_b_685d2fc540e88329a54182da3c4b6d5c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Rename survival fly fall damage configuration options from `falldamage` to `applyFallDamage` and `takeFallDamage`.

### Why are these changes being made?

These changes improve code clarity and intent by making the configuration option names more descriptive, reflecting the action of applying or taking damage on a player's fall scenario, thereby enhancing maintainability and understanding of the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->