### PR TITLE
Add Elytra boost logging

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -91,6 +91,7 @@ import fr.neatmonster.nocheatplus.checks.moving.util.bounce.BounceUtil;
 import fr.neatmonster.nocheatplus.checks.moving.helper.MoveCheckContext;
 import fr.neatmonster.nocheatplus.checks.moving.helper.ExtremeMoveHandler;
 import fr.neatmonster.nocheatplus.checks.moving.helper.VelocityAdjustment;
+import fr.neatmonster.nocheatplus.checks.moving.helper.ElytraBoostHandler;
 import fr.neatmonster.nocheatplus.checks.moving.vehicle.VehicleChecks;
 import fr.neatmonster.nocheatplus.checks.moving.velocity.AccountEntry;
 import fr.neatmonster.nocheatplus.checks.moving.velocity.SimpleEntry;
@@ -1181,18 +1182,19 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             return;
         }
 
-        handleFireworkBoost(lastMove, thisMove, tick, data, cc);
+        handleFireworkBoost(player, lastMove, thisMove, tick, data, cc);
         updateLiquidTick(pFrom, data);
         updateRiptideState(player, data);
         updateBubbleStreamState(pFrom, pTo, thisMove, lastMove, data);
         handleVehicleExit(from, thisMove, data);
     }
 
-    private void handleFireworkBoost(final PlayerMoveData lastMove, final PlayerMoveData thisMove,
-            final int tick, final MovingData data, final MovingConfig cc) {
+    private void handleFireworkBoost(final Player player, final PlayerMoveData lastMove,
+            final PlayerMoveData thisMove, final int tick, final MovingData data, final MovingConfig cc) {
         if (data.fireworksBoostDuration <= 0) {
             return;
         }
+        final int remaining = data.fireworksBoostDuration;
         final boolean invalidBoost = !lastMove.valid
                 || (cc != null && cc.resetFwOnground
                         && (lastMove.flyCheck != CheckType.MOVING_CREATIVEFLY
@@ -1200,8 +1202,12 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 || data.fireworksBoostTickExpire < tick;
         if (invalidBoost) {
             data.fireworksBoostDuration = 0;
+            ElytraBoostHandler.logBoostEvent(player, "reset", tick, remaining);
         } else {
             data.fireworksBoostDuration--;
+            if (data.fireworksBoostDuration == 0) {
+                ElytraBoostHandler.logBoostEvent(player, "ended", tick, remaining);
+            }
         }
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
@@ -1,8 +1,13 @@
 package fr.neatmonster.nocheatplus.checks.moving.helper;
 
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.config.ConfigManager;
+import fr.neatmonster.nocheatplus.config.ConfPaths;
+import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 
@@ -12,6 +17,17 @@ import fr.neatmonster.nocheatplus.utilities.TickTask;
 public final class ElytraBoostHandler {
 
     private ElytraBoostHandler() {
+    }
+
+    public static void logBoostEvent(Player player, String event, int tick, int duration) {
+        if (player == null) {
+            return;
+        }
+        if (ConfigManager.getConfigFile().getBoolean(ConfPaths.LOGGING_EXTENDED_ELYTRABOOST)) {
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().info(Streams.STATUS,
+                    "Elytra boost " + event + " for " + player.getName()
+                            + " at tick " + tick + " duration " + duration);
+        }
     }
 
     /**
@@ -35,6 +51,7 @@ public final class ElytraBoostHandler {
         mData.fireworksBoostDuration = ticks;
         mData.fireworksBoostTickNeedCheck = ticks - 1;
         mData.fireworksBoostTickExpire = tick + ticks;
+        logBoostEvent(context.player(), "started", tick, ticks);
         return true;
     }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -106,6 +106,7 @@ public abstract class ConfPaths {
     public static final String  LOGGING_EXTENDED_ALLVIOLATIONS_DEBUGONLY = LOGGING_EXTENDED_ALLVIOLATIONS + "debugonly";
     private static final String LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND   = LOGGING_EXTENDED_ALLVIOLATIONS + "backend.";
     public static final String  LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE     = LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND + "trace";
+    public static final String  LOGGING_EXTENDED_ELYTRABOOST = LOGGING_EXTENDED + "elytraboost";
     public static final String  LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_NOTIFY    = LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND + "notify";
 
     @GlobalConfig

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -61,6 +61,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_DEBUGONLY, false, 785);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_TRACE, false, 785);
         set(ConfPaths.LOGGING_EXTENDED_ALLVIOLATIONS_BACKEND_NOTIFY, false, 785);
+        set(ConfPaths.LOGGING_EXTENDED_ELYTRABOOST, false, 785);
         set(ConfPaths.LOGGING_BACKEND_CONSOLE_ACTIVE, true, 785);
         set(ConfPaths.LOGGING_BACKEND_CONSOLE_ASYNCHRONOUS, true, 785);
         set(ConfPaths.LOGGING_BACKEND_FILE_ACTIVE, true, 785);


### PR DESCRIPTION
## Summary
- add a configuration flag for Elytra boost logging
- default to disabled in the config
- log boost start, end, and reset events with player and tick data

## Testing
- `mvn -q -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fc521308329a674ebfea6774427

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logging for Elytra boost events in the `MovingListener`, including tracking event start, reset, and end moments with the new `ElytraBoostHandler` for improved monitoring.

### Why are these changes being made?

The changes aim to enhance the tracking and debugging of Elytra boost-related activities, providing better visibility into player actions and potentially aiding in cheat detection. This logging can be enabled through an added configuration setting, ensuring flexibility without affecting current function unless desired.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->