### PR TITLE
Fix dispatcher null checks and tests

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/AbstractLogNodeDispatcher.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/AbstractLogNodeDispatcher.java
@@ -92,11 +92,20 @@ public abstract class AbstractLogNodeDispatcher implements LogNodeDispatcher { /
     protected ContentLogger<String> initLogger = null;
 
     public <C> void dispatch(LogNode<C> node, Level level, C content) {
-        // NOTE: Try/catch ?
+        if (node == null || node.logger == null) {
+            logFallback(level, content);
+            return;
+        }
         if (isWithinContext(node)) {
             node.logger.log(level, content);
         } else {
             scheduleLog(node, level, content);
+        }
+    }
+
+    private <C> void logFallback(Level level, C content) {
+        if (initLogger != null) {
+            initLogger.log(level, content != null ? content.toString() : "null");
         }
     }
 

--- a/NCPCommons/src/test/java/fr/neatmonster/nocheatplus/test/TestLogNodeDispatcher.java
+++ b/NCPCommons/src/test/java/fr/neatmonster/nocheatplus/test/TestLogNodeDispatcher.java
@@ -1,0 +1,55 @@
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.Assert.fail;
+
+import java.util.logging.Level;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.logging.LoggerID;
+import fr.neatmonster.nocheatplus.logging.details.AbstractLogNodeDispatcher;
+import fr.neatmonster.nocheatplus.logging.details.LogNode;
+import fr.neatmonster.nocheatplus.logging.details.LogOptions;
+import fr.neatmonster.nocheatplus.logging.details.ContentLogger;
+
+public class TestLogNodeDispatcher {
+
+    private static class DummyDispatcher extends AbstractLogNodeDispatcher {
+        @Override
+        protected boolean isPrimaryThread() {
+            return true;
+        }
+        @Override
+        protected void scheduleAsynchronous() {
+        }
+        @Override
+        protected void cancelTask(Object taskInfo) {
+        }
+        @Override
+        protected boolean isTaskScheduled(Object taskInfo) {
+            return false;
+        }
+    }
+
+    @Test
+    public void testDispatchNullLogger() {
+        DummyDispatcher dispatcher = new DummyDispatcher();
+        LogNode<String> node = new LogNode<>(new LoggerID("test"), null,
+                new LogOptions("test", LogOptions.CallContext.ANY_THREAD_DIRECT));
+        try {
+            dispatcher.dispatch(node, Level.INFO, "content");
+        } catch (Exception e) {
+            fail("Dispatch threw exception for null logger: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDispatchNullNode() {
+        DummyDispatcher dispatcher = new DummyDispatcher();
+        try {
+            dispatcher.dispatch(null, Level.INFO, "content");
+        } catch (Exception e) {
+            fail("Dispatch threw exception for null node: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NPE in `AbstractLogNodeDispatcher.dispatch`
- add unit test ensuring null logger/node doesn't throw

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q checkstyle:check`
- `mvn -q pmd:check`
- `mvn -q spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2fb49f688329a9c4399a9960a82e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add null checks to the `dispatch` method in `AbstractLogNodeDispatcher` and create corresponding tests to ensure proper handling of null `LogNode` and its null `logger`.

### Why are these changes being made?

These changes are being made to prevent potential `NullPointerExceptions` when dispatching log messages with null `LogNode` or null `logger`; this update allows for fallback logging if `initLogger` is provided. It introduces a more robust logging mechanism and ensures the system's stability by verifying these scenarios through unit tests.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->