### PR TITLE
Add timestamp and tick to inventory debug

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -74,6 +74,7 @@ import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.utilities.map.MaterialUtil;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
 
 /**
  * Central location to listen to events that are relevant for the inventory checks.
@@ -384,8 +385,10 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
 
     /**
      * Debug inventory classes. Contains information about classes, to indicate
-     * if cross-plugin compatibility issues can be dealt with easily.
-     * 
+     * if cross-plugin compatibility issues can be dealt with easily. The output
+     * includes the current time in milliseconds and, if available, the current
+     * server tick.
+     *
      * @param player
      * @param slot
      * @param event
@@ -397,7 +400,12 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
         // Consider logging only where different from expected (CraftXY, more/other viewer than player).
 
         final StringBuilder builder = new StringBuilder(512);
-        builder.append("Inventory click: slot: " + slot);
+        builder.append("Inventory click: slot: ").append(slot);
+        builder.append(" , Time: ").append(System.currentTimeMillis());
+        final int tick = TickTask.getTick();
+        if (tick > 0) {
+            builder.append(" , Tick: ").append(tick);
+        }
 
         // Viewers.
         builder.append(" , Viewers: ");


### PR DESCRIPTION
## Summary
- include current time and server tick in inventory debug output
- document the new fields in the debug description

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fc4e80c8329b44c56bc62876c3d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add current timestamp and server tick to the inventory debug output in the `InventoryListener` class.

### Why are these changes being made?

These changes enhance the debug information for inventory events by including the current time in milliseconds and the server tick, which can assist in diagnosing issues related to cross-plugin compatibility by providing precise timing context. This improvement aims to make troubleshooting and aligning inventory actions across plugins easier, acknowledging timing could play a crucial role in debugging operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->