### PR TITLE
Add cactus bounding box model

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -121,6 +121,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     private static final BukkitShapeModel MODEL_GROUND_HEAD = BukkitStatic.ofInsetAndHeight(0.25, 0.5);
     private static final BukkitShapeModel MODEL_SINGLE_CHEST = BukkitStatic.ofInsetAndHeight(0.0625, 0.875);
     private static final BukkitShapeModel MODEL_HONEY_BLOCK = BukkitStatic.ofInsetAndHeight(0.0625, 0.9375);
+    private static final BukkitShapeModel MODEL_CACTUS = BukkitStatic.ofBounds(0.0625, 0.0, 0.0625, 0.9375, 0.9375, 0.9375);
     private static final BukkitShapeModel MODEL_SCULK_SHRIEKER = BukkitStatic.ofInsetAndHeight(0.0, 0.5);
 
     // Static blocks with full height sorted by inset.
@@ -299,7 +300,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
         addModel(Material.LADDER, MODEL_LADDER);
         addModel(Material.BREWING_STAND, MODEL_BREWING_STAND);
         addModel(Material.DRAGON_EGG, MODEL_INSET16_1_HEIGHT100);
-        addModel(Material.CACTUS, MODEL_HONEY_BLOCK);
+        addModel(Material.CACTUS, MODEL_CACTUS);
     }
 
     private void registerMiscModelCollections() {


### PR DESCRIPTION
## Summary
- define `MODEL_CACTUS` in `MCAccessBukkitModern`
- register the new model for cactus blocks

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fb5d47083299fd006c776a912ee

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a specific bounding box model for cactus to the `MCAccessBukkitModern` class.

### Why are these changes being made?

The existing code incorrectly utilized the honey block model for cactus, which may not accurately represent its bounding properties in the game. By introducing a dedicated bounding box model for cactus, the behavior and interactions of cactus blocks in the game world are expected to be more realistic and aligned with their intended design.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->