### PR TITLE
Cache Material enumeration in InventoryUtil

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkit.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkit.java
@@ -20,6 +20,8 @@ import java.util.Set;
 
 import org.bukkit.Material;
 
+import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
+
 import fr.neatmonster.nocheatplus.compat.blocks.BlockPropertiesSetup;
 import fr.neatmonster.nocheatplus.config.WorldConfigProvider;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
@@ -29,6 +31,9 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 
 public class MCAccessBukkit extends MCAccessBukkitBase implements BlockPropertiesSetup {
 
+    /** Cached Material values from InventoryUtil. */
+    private static final Material[] ALL_MATERIALS = InventoryUtil.ALL_MATERIALS;
+
     public MCAccessBukkit() {
         super();
     }
@@ -36,7 +41,7 @@ public class MCAccessBukkit extends MCAccessBukkitBase implements BlockPropertie
     @Override
     public void setupBlockProperties(final WorldConfigProvider<?> worldConfigProvider) {
         final Set<Material> itchyBlocks = new LinkedHashSet<Material>();
-        for (final Material mat : Material.values()) {
+        for (final Material mat : ALL_MATERIALS) {
             if (!mat.isBlock()) {
                 continue;
             }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Arrays;
 
+import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
+
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
@@ -47,6 +49,9 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     protected ReflectDamageSources reflectDamageSources = null;
     protected ReflectLivingEntity reflectLivingEntity = null;
     protected final Map<Material, BukkitShapeModel> shapeModels = new HashMap<Material, BukkitShapeModel>();
+
+    /** Cached Material values from InventoryUtil. */
+    private static final Material[] ALL_MATERIALS = InventoryUtil.ALL_MATERIALS;
 
     // Blocks that can be fetched automatically from from the Bukkit API
     private static final BukkitShapeModel MODEL_AUTO_FETCH = new BukkitFetchableBounds();
@@ -374,7 +379,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     }
 
     private void registerFlagBasedModels() {
-        for (final Material mat : Material.values()) {
+        for (final Material mat : ALL_MATERIALS) {
             final long flags = BlockFlags.getBlockFlags(mat);
             if (BlockFlags.hasAnyFlag(flags, BlockFlags.F_STAIRS)) {
                 addModel(mat, MODEL_STAIRS);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/InventoryUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/InventoryUtil.java
@@ -59,6 +59,9 @@ public class InventoryUtil {
             getAll("chest", "ender_chest", "dispenser", "dropper", "hopper", "barrel", "shulker_box", "chiseled_bookshelf")
             );
 
+    /** Cached array of all Material values to avoid repeated allocation. */
+    public static final Material[] ALL_MATERIALS = Material.values();
+
     public static Set<InventoryType> getAll(String... names) {
         final LinkedHashSet<InventoryType> res = new LinkedHashSet<InventoryType>();
         for (final String name : names) {
@@ -78,7 +81,7 @@ public class InventoryUtil {
     public static List<Material> collectItemsBySuffix(String suffix) {
         suffix = suffix.toLowerCase();
         final List<Material> res = new LinkedList<Material>();
-        for (final Material mat : Material.values()) {
+        for (final Material mat : ALL_MATERIALS) {
             if (!mat.isBlock() && mat.name().toLowerCase().endsWith(suffix)) {
                 res.add(mat);
             }
@@ -94,7 +97,7 @@ public class InventoryUtil {
     public static List<Material> collectItemsByPrefix(String prefix) {
         prefix = prefix.toLowerCase();
         final List<Material> res = new LinkedList<Material>();
-        for (final Material mat : Material.values()) {
+        for (final Material mat : ALL_MATERIALS) {
             if (!mat.isBlock() && mat.name().toLowerCase().startsWith(prefix)) {
                 res.add(mat);
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -36,6 +36,8 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.BubbleColumn;
+
+import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -83,6 +85,9 @@ public class BlockProperties {
 
     /** Tolerance for floating point comparisons. */
     private static final double EPSILON = 1.0E-6;
+
+    /** Cached Material values from InventoryUtil. */
+    private static final Material[] ALL_MATERIALS = InventoryUtil.ALL_MATERIALS;
 
     /**
      * The Enum ToolType.
@@ -1105,7 +1110,7 @@ public class BlockProperties {
         // Initialize block flags                           //
         //////////////////////////////////////////////////////
         // Generic initialization.
-        for (Material mat : Material.values()) {
+        for (Material mat : ALL_MATERIALS) {
             BlockFlags.blockFlags.put(mat, 0L);
             if (mcAccess.isBlockLiquid(mat).decide()) {
                 // NOTE: do not set BlockFlags.F_GROUND for liquids ?
@@ -1227,7 +1232,7 @@ public class BlockProperties {
             allBlocks.add("--- Present entries -------------------------------");
         }
         List<String> tags = new ArrayList<String>();
-        for (Material temp : Material.values()) {
+        for (Material temp : ALL_MATERIALS) {
             String mat;
             try {
                 if (!temp.isBlock()) {
@@ -4410,7 +4415,7 @@ public class BlockProperties {
         for (final Material mat : MaterialUtil.RAILS) {
             BlockFlags.setFlag(mat, BlockFlags.F_RAILS);
         }
-        for (Material material : Material.values()) {
+        for (Material material : ALL_MATERIALS) {
             if (material.isBlock()) {
                 final String name = material.name().toLowerCase();
                 if (name.endsWith("_door") || name.endsWith("_trapdoor") || name.endsWith("fence_gate")) {


### PR DESCRIPTION
## Summary
- cache all `Material` values in `InventoryUtil`
- use cached array in `collectItemsBySuffix` and `collectItemsByPrefix`
- reuse cached materials in `MCAccessBukkit`, `MCAccessBukkitModern` and `BlockProperties`

## Testing
- `mvn -DskipTests verify`
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fb597188329a46178e9499399bc