### PR TITLE
Document negative infinity sentinel

### DIFF
--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
@@ -14,6 +14,16 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_10_R1;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.10 (1_10_R1).
+ * <p>
+ * Methods that return potion effect amplifiers will yield
+ * {@link Double#NEGATIVE_INFINITY} when the effect is not active. Calling code
+ * checks using {@code Double.isInfinite(value)} and thus the sentinel must stay
+ * intact.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
@@ -14,6 +14,16 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_11_R1;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.11 (1_11_R1).
+ * <p>
+ * When potion effects are missing, amplifier methods return
+ * {@link Double#NEGATIVE_INFINITY}. Calling code checks this via
+ * {@code Double.isInfinite(value)} – altering the sentinel will break that
+ * logic.
+ * </p>
+ */
+
 import java.lang.reflect.Method;
 
 import org.bukkit.Bukkit;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/MCAccessSpigotCB1_8_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/MCAccessSpigotCB1_8_R1.java
@@ -14,6 +14,15 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_8_R1;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.8.1 (1_8_R1).
+ * <p>
+ * Potion amplifier methods return {@link Double#NEGATIVE_INFINITY} when the
+ * respective potion effect is absent. Consumers test with
+ * {@code Double.isInfinite(value)} – do not replace this sentinel.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/MCAccessSpigotCB1_8_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/MCAccessSpigotCB1_8_R2.java
@@ -14,6 +14,15 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_8_R2;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.8.3 (1_8_R2).
+ * <p>
+ * Potion amplifier methods return {@link Double#NEGATIVE_INFINITY} when the
+ * effect does not exist. Call sites rely on {@code Double.isInfinite(value)} to
+ * detect this, so keep the sentinel unchanged.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/MCAccessSpigotCB1_8_R3.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/MCAccessSpigotCB1_8_R3.java
@@ -14,6 +14,15 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_8_R3;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.8.8 (1_8_R3).
+ * <p>
+ * When no potion effect is present the amplifier methods return
+ * {@link Double#NEGATIVE_INFINITY}. Callers check with
+ * {@code Double.isInfinite(value)} and depend on this sentinel remaining.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/MCAccessSpigotCB1_9_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/MCAccessSpigotCB1_9_R1.java
@@ -14,6 +14,15 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_9_R1;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.9.2 (1_9_R1).
+ * <p>
+ * Amplifier methods use {@link Double#NEGATIVE_INFINITY} to signal missing
+ * potion effect data. Consumers must test with {@code Double.isInfinite(value)}
+ * and rely on this sentinel remaining unchanged.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
@@ -14,6 +14,17 @@
  */
 package fr.neatmonster.nocheatplus.compat.spigotcb1_9_R2;
 
+/**
+ * Spigot compatibility implementation for Minecraft 1.9.4 (1_9_R2).
+ * <p>
+ * Methods returning {@code double} for potion amplifiers use
+ * {@link Double#NEGATIVE_INFINITY} as a sentinel indicating that the player
+ * has no matching potion effect. Code using these values typically checks with
+ * {@code Double.isInfinite(value)} and must retain this sentinel for
+ * correctness.
+ * </p>
+ */
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -3241,6 +3241,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void appendPotionEffectDetails(final Player player, final MCAccess mcAccess,
             final StringBuilder builder) {
         final double speed = mcAccess.getFasterMovementAmplifier(player);
+        // See MCAccessSpigotCB class JavaDocs for the meaning of NEGATIVE_INFINITY.
         if (!Double.isInfinite(speed)) {
             builder.append("(e_speed=" + (speed + 1) + ")");
         }
@@ -3249,6 +3250,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             builder.append("(e_slow=" + (slow + 1) + ")");
         }
         final double jump = mcAccess.getJumpAmplifier(player);
+        // Sentinel NEGATIVE_INFINITY indicates no jump potion effect.
         if (!Double.isInfinite(jump)) {
             builder.append("(e_jump=" + (jump + 1) + ")");
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LiquidWorkarounds.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LiquidWorkarounds.java
@@ -82,6 +82,7 @@ public class LiquidWorkarounds {
         }
 
         // Ascend by water level
+        // Dolphin's Grace amplifier is NEGATIVE_INFINITY when absent.
         if (!(data.liftOffEnvelope == LiftOffEnvelope.LIMIT_LIQUID && Double.isInfinite(Bridge1_13.getDolphinGraceAmplifier(from.getPlayer()))) &&
                 (yDistance <= data.liftOffEnvelope.getMaxJumpGain(data.jumpAmplifier) &&
                         !BlockProperties.isLiquid(from.getTypeIdAbove()) ||

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
@@ -86,6 +86,7 @@ public class MagicBunny {
         final double baseSpeed = thisMove.hAllowedDistanceBase;
         final boolean headObstructed = thisMove.headObstructed || lastMove.headObstructed && lastMove.toIsValid;
         /** Catch-all multiplier for all those cases where bunnyhop activation can happen at lower accelerations.*/
+        // speedAmplifier is NEGATIVE_INFINITY when the speed effect is absent.
         final boolean needLowerMultiplier = Magic.wasOnIceRecently(data) || Magic.wasOnBouncyBlockRecently(data) || headObstructed || !Double.isInfinite(speedAmplifier);
         final PlayerMoveData pastMove2 = data.playerMoves.getSecondPastMove();
         final PlayerMoveData pastMove3 = data.playerMoves.getThirdPastMove();

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -1130,6 +1130,7 @@ public class CreativeFly extends Check {
             final double attrMod = attributeAccess.getHandle().getSpeedAttributeMultiplier(player);
             if (attrMod == Double.MAX_VALUE) {
                 final double speedAmplifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+                // NEGATIVE_INFINITY from MCAccess means no speed potion effect.
                 if (!Double.isInfinite(speedAmplifier)) {
                     allowedH *= 1.0D + 0.2D * (speedAmplifier + 1);
                 }
@@ -1553,6 +1554,7 @@ public class CreativeFly extends Check {
         double fSpeed;
         if (model.getApplyModifiers()) {
             final double speedModifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+            // NEGATIVE_INFINITY signals that the speed effect is absent.
             if (Double.isInfinite(speedModifier)) fSpeed = 1.0;
             else fSpeed = 1.0 + 0.2 * (speedModifier + 1.0);
             if (flying) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -1581,6 +1581,7 @@ public class SurvivalFly extends Check {
             st.useSneakModifier = true;
             st.allowed = modStairs * move.walkSpeed * cc.survivalFlyWalkingSpeed / 100D;
             st.friction = 0.0;
+            // If the player has a speed effect (NEGATIVE_INFINITY means none).
             if (!Double.isInfinite(mcAccess.getHandle().getFasterMovementAmplifier(player))) {
                 st.allowed *= 0.88;
             }
@@ -1888,6 +1889,7 @@ public class SurvivalFly extends Check {
                     st.allowed += 0.051 * BridgeEnchant.getSwiftSneakLevel(player);
                     st.useBaseModifiers = true;
                     st.friction = 0.0;
+                    // Only reduce if a speed potion effect is present.
                     if (!Double.isInfinite(mcAccess.getHandle().getFasterMovementAmplifier(player))) {
                         st.allowed *= 0.88;
                         st.useBaseModifiersSprint = true;
@@ -1941,6 +1943,7 @@ public class SurvivalFly extends Check {
             final MovingData data, final MovingConfig cc, final Player player, final DistanceState st) {
         if (!move.to.onGround) {
             final double speedAmplifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+            // The amplifier is NEGATIVE_INFINITY when no speed effect is active.
             st.allowed = (lastMove.hDistance > 0.23 ? 0.4 : 0.23 + (ServerIsAtLeast1_13 ? 0.155 : 0.0))
                     + 0.02 * (Double.isInfinite(speedAmplifier) ? 0 : speedAmplifier + 1.0);
             st.allowed *= cc.survivalFlyBlockingSpeed / 100D;
@@ -2035,6 +2038,7 @@ public class SurvivalFly extends Check {
         final double attrMod = attributeAccess.getHandle().getSpeedAttributeMultiplier(player);
         if (attrMod == Double.MAX_VALUE) {
             final double speedAmplifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+            // speedAmplifier is NEGATIVE_INFINITY if the effect is not present.
             if (!Double.isInfinite(speedAmplifier) && useBaseModifiersSprint) {
                 hAllowedDistance *= 1.0D + 0.2D * speedAmplifier;
             }
@@ -2048,6 +2052,7 @@ public class SurvivalFly extends Check {
             }
             if (!useBaseModifiersSprint) {
                 final double speedAmplifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+                // NEGATIVE_INFINITY indicates no speed potion effect.
                 if (!Double.isInfinite(speedAmplifier)) {
                     hAllowedDistance /= attrMod;
                     hAllowedDistance *= attrMod - 0.15D * speedAmplifier;
@@ -2544,6 +2549,7 @@ public class SurvivalFly extends Check {
                                        final boolean skipPermChecks) {
 
         final double speedAmplifier = mcAccess.getHandle().getFasterMovementAmplifier(player);
+        // Speed amplifier may be NEGATIVE_INFINITY when no potion is active.
 
         // 1: Attempt to reset item on NoSlow Violation, if set so in the configuration.
         final double[] reset = attemptItemReset(player, from, to, hAllowedDistance, hDistanceAboveLimit,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/MovingUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/MovingUtil.java
@@ -452,6 +452,8 @@ public class MovingUtil {
 
     public static double getJumpAmplifier(final Player player, final MCAccess mcAccess) {
         final double amplifier = mcAccess.getJumpAmplifier(player);
+        // Missing potion effects are indicated by Double.NEGATIVE_INFINITY in
+        // MCAccess implementations (see their class JavaDocs).
         if (Double.isInfinite(amplifier)) {
             return 0.0;
         }


### PR DESCRIPTION
## Summary
- note `Double.NEGATIVE_INFINITY` as missing potion effect data in each MCAccessSpigotCB class
- reference this sentinel where potion amplifier values are checked

## Testing
- No tests run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_b_685d2fb30ee08329bf579f95ccaeb5a7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add documentation to various classes indicating that the method return value `Double.NEGATIVE_INFINITY` is used as a sentinel to indicate the absence of potion effects, and adjust the logic accordingly across multiple Spigot compatibility implementations and moving check classes.

### Why are these changes being made?
This change clarifies and enforces the use of `Double.NEGATIVE_INFINITY` as a sentinel to denote missing potion effects in the Minecraft Spigot implementations, ensuring that logic dependent on detecting these missing effects remains correct. This documentation and consistency prevent misunderstanding and potential bugs in future code related to potion effect handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->