### PR TITLE
Fix timestamp drift in BlockPlace speed check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Speed.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Speed.java
@@ -44,12 +44,13 @@ public class Speed extends Check {
             final BlockPlaceConfig cc, final IPlayerData pData) {
         final BlockPlaceData data = pData.getGenericInstance(BlockPlaceData.class);
 
+        final long now = System.currentTimeMillis();
         boolean cancel = false;
 
         // Has the player thrown items too quickly?
-        if (data.speedLastTime != 0 && System.currentTimeMillis() - data.speedLastTime < cc.speedInterval) {
+        if (data.speedLastTime != 0 && now - data.speedLastTime < cc.speedInterval) {
             if (data.speedLastRefused) {
-                final double difference = cc.speedInterval - System.currentTimeMillis() + data.speedLastTime;
+                final double difference = cc.speedInterval - now + data.speedLastTime;
 
                 // They failed, increase this violation level.
                 data.speedVL += difference;
@@ -67,7 +68,7 @@ public class Speed extends Check {
             data.speedLastRefused = false;
         }
 
-        data.speedLastTime = System.currentTimeMillis();
+        data.speedLastTime = now;
 
         return cancel;
     }


### PR DESCRIPTION
## Summary
- capture `System.currentTimeMillis()` once at start of blockplace speed check
- reuse the timestamp for comparisons and assignments

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2fb2e20083299177c274d9fca08d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the BlockPlace speed check logic to use a consistent timestamp reference (`now`) for determining item placement speed violations.

### Why are these changes being made?

This change addresses issues of timestamp drift by using a single, consistent anchor time (`now`) during checks, thus improving reliability and clarity when evaluating if a player is placing blocks too quickly. This approach eliminates discrepancies arising from calling `System.currentTimeMillis()` multiple times, enhancing the accuracy of violation detection.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->