### PR TITLE
Fix legacy vehicle access import

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/EntityAccessFactory.java
@@ -18,6 +18,7 @@ import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessLastPositionAndLook;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
 import fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleMultiPassenger;
+import fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleLegacy;
 
 /**
  * Set up more fine grained entity access providers, registered as generic
@@ -55,7 +56,7 @@ public class EntityAccessFactory {
         // IEntityAccessVehicle
         IEntityAccessVehicle vehicleAccess = EntityAccessVehicleMultiPassenger.createIfSupported();
         if (vehicleAccess == null) {
-            vehicleAccess = new fr.neatmonster.nocheatplus.compat.bukkit.EntityAccessVehicleLegacy();
+            vehicleAccess = new EntityAccessVehicleLegacy();
         }
         RegistryHelper.registerGenericInstance(IEntityAccessVehicle.class, vehicleAccess);
     }


### PR DESCRIPTION
## Summary
- add import for `EntityAccessVehicleLegacy`
- use simple class name for legacy vehicle access

## Testing
- `mvn -q test`
- `mvn -DskipTests checkstyle:check pmd:check spotbugs:check` *(failed: Codex couldn't run certain commands due to environment limitations)*


------
https://chatgpt.com/codex/tasks/task_b_685d2fb0a4c48329a96fa2f805ad5626

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the fully qualified package name for the EntityAccessVehicleLegacy class and include its import statement.

### Why are these changes being made?

This change simplifies the code by avoiding the use of a fully qualified name directly in the code and instead utilizing an import statement. This improves readability and adheres to standard Java practices, ensuring that the import mechanism is utilized for clarity and maintainability across the codebase.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->