### PR TITLE
Add Javadoc for BukkitStatic bounds

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -20,6 +20,11 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 
 public class BukkitStatic implements BukkitShapeModel {
 
+    /**
+     * Bounding box coordinates. Every six consecutive values describe one box
+     * in the order {@code {minX, minY, minZ, maxX, maxY, maxZ}}. If multiple
+     * boxes are used, they are stored sequentially in this array.
+     */
     private final double[] bounds;
 
     private BukkitStatic(double... bounds) {


### PR DESCRIPTION
## Summary
- clarify how `BukkitStatic` stores bounding boxes

## Testing
- `No tests run (JavaDoc-only change)`

------
https://chatgpt.com/codex/tasks/task_b_685d2fadcec8832998e151514d458156