### PR TITLE
Add comments for abbreviated fields

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
@@ -81,6 +81,7 @@ import java.util.List;
  */
 public class BlockPlaceListener extends CheckListener {
 
+    /** Prime numbers used for coordinate hashing. */
     private static final int p1 = 73856093;
     private static final int p2 = 19349663;
     private static final int p3 = 83492791;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Critical.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Critical.java
@@ -44,6 +44,7 @@ import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
 public class Critical extends Check {
 
 
+    /** Utility helper providing movement-related methods. */
     private final AuxMoving auxMoving = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(AuxMoving.class);
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -252,7 +252,10 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public double sfHorizontalBuffer = 0.0;
     /** Event-counter to cover up for sprinting resetting server side only. Set in the FighListener. */
     public int lostSprintCount = 0;
-    /** Count how long the player has been in the air, resets when landing on ground. */
+    /**
+     * Number of ticks spent in the current jump phase for the
+     * survival fly check. Resets when touching ground.
+     */
     public int sfJumpPhase = 0;
     /** Count how many times in a row yDistance has been zero, only for in-air moves, updated on not cancelled moves (aimed at in-air workarounds) */
     public int sfZeroVdistRepeat = 0;
@@ -276,9 +279,11 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public final ActionAccumulator vDistAcc = new ActionAccumulator(3, 3); // 3 buckets with max capacity of 3 events
     /** Horizontal accounting: tracker of actual speed / allowed base speed */
     public final ActionAccumulator hDistAcc = new ActionAccumulator(1, 100); // 1 bucket capable of holding a maximum of 100 events.
-    /** Workarounds (AirWorkarounds,LiquidWorkarounds). */
+    /**
+     * Per-player set of workaround counters used by the
+     * movement checks.
+     */
     public final WorkaroundSet ws;
-    /** Bed-flying flag */
     public boolean wasInBed = false;
 
     // *----------Data of the vehicles checks----------*
@@ -325,6 +330,7 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public final DefaultSetBackStorage vehicleSetBacks = new DefaultSetBackStorage();
 
 
+    /** Reference to the owning player's data. */
     private final IPlayerData pData;
     public MovingData(final MovingConfig config, final IPlayerData pData) {
         this.pData = pData;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/OnGroundReference.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/OnGroundReference.java
@@ -40,7 +40,9 @@ public class OnGroundReference {
      */
     // Possibly detach this so it can be used from within BlockProperties.
 
+    /** Cache used for retrieving block states. */
     private BlockCache blockCache = null;
+    /** Reference for the block currently tracked beneath the player. */
     private BlockChangeReference ref = null;
     private long ignoreFlags = 0L;
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Timings.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Timings.java
@@ -31,9 +31,13 @@ import fr.neatmonster.nocheatplus.logging.StaticLog;
 public final class Timings {
 	
         public static final class Entry{
+                /** Total accumulated time. */
                 private long val = 0;
+                /** Number of recorded samples. */
                 private long n = 0;
+                /** Minimum observed value. */
                 private long min = Long.MAX_VALUE;
+                /** Maximum observed value. */
                 private long max = Long.MIN_VALUE;
 
                 long getVal() {


### PR DESCRIPTION
## Summary
- document the purpose of `sfJumpPhase`, `ws`, and `pData` in `MovingData`
- describe hash constants in BlockPlaceListener
- clarify helper field usage in Critical
- explain fields in Timings.Entry and OnGroundReference

## Testing
- No tests run due to comment-only changes

------
https://chatgpt.com/codex/tasks/task_b_685d2f8ed354832992f3ca6e58f37bc7