### PR TITLE
Introduce vehicle behavior strategy enum

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleBehavior.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleBehavior.java
@@ -1,0 +1,108 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.checks.moving.vehicle;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Minecart;
+import org.bukkit.entity.Pig;
+
+import fr.neatmonster.nocheatplus.utilities.map.MaterialUtil;
+import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveData;
+import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveInfo;
+
+/**
+ * Per-vehicle behavior strategy used by {@link VehicleEnvelope}.
+ */
+enum VehicleBehavior {
+
+    BOAT {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyBoatSettings();
+        }
+    },
+    MINECART {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyMinecartSettings(info, data);
+        }
+    },
+    HORSE {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyHorseSettings();
+        }
+    },
+    STRIDER {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyStriderSettings(data);
+        }
+    },
+    CAMEL {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyCamelSettings();
+        }
+    },
+    PIG {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.applyPigSettings();
+        }
+    },
+    GENERIC {
+        @Override
+        void apply(final VehicleEnvelope env, final Entity vehicle,
+                    final VehicleMoveInfo info, final VehicleMoveData data) {
+            env.useGenericSettings(data.vehicleType);
+        }
+    };
+
+    abstract void apply(VehicleEnvelope env, Entity vehicle,
+                        VehicleMoveInfo info, VehicleMoveData data);
+
+    static VehicleBehavior fromEntity(final Entity vehicle,
+                                      final VehicleEnvelope env) {
+        if (vehicle == null) {
+            return GENERIC;
+        }
+        if (MaterialUtil.isBoat(vehicle.getType())) {
+            return BOAT;
+        }
+        if (vehicle instanceof Minecart) {
+            return MINECART;
+        }
+        if (env.isCamel(vehicle)) {
+            return CAMEL;
+        }
+        if (env.isStrider(vehicle)) {
+            return STRIDER;
+        }
+        if (env.isHorse(vehicle)) {
+            return HORSE;
+        }
+        if (vehicle instanceof Pig) {
+            return PIG;
+        }
+        return GENERIC;
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
@@ -18,12 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.bukkit.Material;
-import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Minecart;
-import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
 
@@ -558,25 +555,8 @@ public class VehicleEnvelope extends Check {
         checkDetails.reset();
         setBasicMediumState(thisMove);
 
-        if (vehicle != null) {
-            if (MaterialUtil.isBoat(vehicle.getType())) {
-                applyBoatSettings();
-            } else if (vehicle instanceof Minecart) {
-                applyMinecartSettings(moveInfo, thisMove);
-            } else if (isHorse(vehicle)) {
-                applyHorseSettings();
-            } else if (isStrider(vehicle)) {
-                applyStriderSettings(thisMove);
-            } else if (isCamel(vehicle)) {
-                applyCamelSettings();
-            } else if (vehicle instanceof Pig) {
-                applyPigSettings();
-            } else {
-                checkDetails.simplifiedType = thisMove.vehicleType;
-            }
-        } else {
-            checkDetails.simplifiedType = thisMove.vehicleType;
-        }
+        VehicleBehavior.fromEntity(vehicle, this)
+                .apply(this, vehicle, moveInfo, thisMove);
 
         applyJumpSettings();
         applyClimbSettings(thisMove);
@@ -588,12 +568,12 @@ public class VehicleEnvelope extends Check {
         checkDetails.inAir = !checkDetails.fromIsSafeMedium && !checkDetails.toIsSafeMedium;
     }
 
-    private void applyBoatSettings() {
+    void applyBoatSettings() {
         checkDetails.simplifiedType = EntityType.BOAT;
         checkDetails.maxAscend = MagicVehicle.maxAscend;
     }
 
-    private void applyMinecartSettings(final VehicleMoveInfo moveInfo, final VehicleMoveData thisMove) {
+    void applyMinecartSettings(final VehicleMoveInfo moveInfo, final VehicleMoveData thisMove) {
         checkDetails.simplifiedType = EntityType.MINECART;
         checkDetails.canRails = true;
         thisMove.setExtraMinecartProperties(moveInfo); // Cheating.
@@ -608,13 +588,13 @@ public class VehicleEnvelope extends Check {
         checkDetails.gravityTargetSpeed = 0.79;
     }
 
-    private void applyHorseSettings() {
+    void applyHorseSettings() {
         checkDetails.simplifiedType = EntityType.HORSE; // Consider using AbstractHorse from 1.11 onward.
         checkDetails.canJump = true;
         checkDetails.canStepUpBlock = true;
     }
 
-    private void applyStriderSettings(final VehicleMoveData thisMove) {
+    void applyStriderSettings(final VehicleMoveData thisMove) {
         checkDetails.canJump = false;
         checkDetails.canStepUpBlock = true;
         checkDetails.canClimb = true;
@@ -627,18 +607,22 @@ public class VehicleEnvelope extends Check {
         }
     }
 
-    private void applyCamelSettings() {
+    void applyCamelSettings() {
         checkDetails.simplifiedType = EntityType.CAMEL;
         checkDetails.canStepUpBlock = true;
         checkDetails.canClimb = false;
         checkDetails.canJump = false;
     }
 
-    private void applyPigSettings() {
+    void applyPigSettings() {
         checkDetails.simplifiedType = EntityType.PIG;
         checkDetails.canJump = false;
         checkDetails.canStepUpBlock = true;
         checkDetails.canClimb = true;
+    }
+
+    void useGenericSettings(final EntityType type) {
+        checkDetails.simplifiedType = type;
     }
 
     private void applyJumpSettings() {
@@ -660,15 +644,15 @@ public class VehicleEnvelope extends Check {
         }
     }
 
-    private boolean isHorse(final Entity vehicle) {
+    boolean isHorse(final Entity vehicle) {
         return bestHorse != null && bestHorse.isAssignableFrom(vehicle.getClass());
     }
 
-    private boolean isStrider(final Entity vehicle) {
+    boolean isStrider(final Entity vehicle) {
         return strider != null && strider.isAssignableFrom(vehicle.getClass());
     }
 
-    private boolean isCamel(final Entity vehicle) {
+    boolean isCamel(final Entity vehicle) {
         return camel != null && camel.isAssignableFrom(vehicle.getClass());
     }
 

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleBehaviorTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleBehaviorTest.java
@@ -1,0 +1,152 @@
+package fr.neatmonster.nocheatplus.checks.moving.vehicle;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+
+import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Camel;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Minecart;
+import org.bukkit.entity.Pig;
+import org.bukkit.entity.Strider;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
+import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
+
+import fr.neatmonster.nocheatplus.checks.moving.magic.MagicVehicle;
+import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveData;
+import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveInfo;
+
+public class VehicleBehaviorTest {
+
+    private static class DummyVehicleMoveData extends VehicleMoveData {
+        @Override
+        public void setExtraMinecartProperties(final VehicleMoveInfo moveInfo) {
+            // Do nothing for tests.
+        }
+    }
+
+    static class SimpleHandle<T> implements IGenericInstanceHandle<T> {
+        private final T handle;
+        SimpleHandle(T h) { this.handle = h; }
+        @Override public T getHandle() { return handle; }
+        @Override public void disableHandle() { }
+    }
+
+    @Before
+    public void setupAPI() throws Exception {
+        Object api = java.lang.reflect.Proxy.newProxyInstance(
+                NCPAPIProvider.class.getClassLoader(),
+                new Class<?>[]{NoCheatPlusAPI.class},
+                (proxy, method, args) -> {
+                    if ("getGenericInstanceHandle".equals(method.getName())) {
+                        return new SimpleHandle<>(null);
+                    }
+                    Class<?> r = method.getReturnType();
+                    if (r == boolean.class) return false;
+                    if (r.isPrimitive()) return 0;
+                    return null;
+                });
+        Field f = NCPAPIProvider.class.getDeclaredField("noCheatPlusAPI");
+        f.setAccessible(true);
+        f.set(null, api);
+        Field dm = fr.neatmonster.nocheatplus.players.DataManager.class.getDeclaredField("instance");
+        dm.setAccessible(true);
+        dm.set(null, mock(fr.neatmonster.nocheatplus.players.PlayerDataManager.class));
+    }
+
+    private VehicleEnvelope.CheckDetails getDetails(VehicleEnvelope env) throws Exception {
+        Field f = VehicleEnvelope.class.getDeclaredField("checkDetails");
+        f.setAccessible(true);
+        return (VehicleEnvelope.CheckDetails) f.get(env);
+    }
+
+    @Test
+    public void testBoatBehavior() throws Exception {
+        Entity boat = mock(Entity.class);
+        when(boat.getType()).thenReturn(EntityType.BOAT);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(boat, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.BOAT, details.simplifiedType);
+        assertEquals(MagicVehicle.maxAscend, details.maxAscend, 0.0);
+    }
+
+    @Test
+    public void testMinecartBehavior() throws Exception {
+        Minecart minecart = mock(Minecart.class);
+        when(minecart.getType()).thenReturn(EntityType.MINECART);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(minecart, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.MINECART, details.simplifiedType);
+        assertTrue(details.canRails);
+    }
+
+    @Test
+    public void testHorseBehavior() throws Exception {
+        AbstractHorse horse = mock(AbstractHorse.class);
+        when(horse.getType()).thenReturn(EntityType.HORSE);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(horse, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.HORSE, details.simplifiedType);
+        assertTrue(details.canJump);
+    }
+
+    @Test
+    public void testStriderBehavior() throws Exception {
+        Strider strider = mock(Strider.class);
+        when(strider.getType()).thenReturn(EntityType.STRIDER);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(strider, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertTrue(details.canClimb);
+    }
+
+    @Test
+    public void testCamelBehavior() throws Exception {
+        Camel camel = mock(Camel.class);
+        when(camel.getType()).thenReturn(EntityType.CAMEL);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(camel, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.CAMEL, details.simplifiedType);
+        assertTrue(details.canStepUpBlock);
+    }
+
+    @Test
+    public void testPigBehavior() throws Exception {
+        Pig pig = mock(Pig.class);
+        when(pig.getType()).thenReturn(EntityType.PIG);
+        VehicleEnvelope env = new VehicleEnvelope();
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        env.prepareCheckDetails(pig, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.PIG, details.simplifiedType);
+        assertTrue(details.canClimb);
+    }
+
+    @Test
+    public void testGenericBehavior() throws Exception {
+        Entity e = mock(Entity.class);
+        when(e.getType()).thenReturn(EntityType.SHEEP);
+        DummyVehicleMoveData data = new DummyVehicleMoveData();
+        data.vehicleType = EntityType.SHEEP;
+        VehicleEnvelope env = new VehicleEnvelope();
+        env.prepareCheckDetails(e, null, data);
+        VehicleEnvelope.CheckDetails details = getDetails(env);
+        assertEquals(EntityType.SHEEP, details.simplifiedType);
+    }
+}


### PR DESCRIPTION
## Summary
- factor vehicle-specific logic into `VehicleBehavior` enum
- use strategy lookup in `VehicleEnvelope.prepareCheckDetails`
- test settings for all supported vehicles

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q verify -DskipTests=true` *(fails: SpotBugs warnings but build proceeds)*

------
https://chatgpt.com/codex/tasks/task_b_685d2f88f05c8329bbb5d415c1234933