### PR TITLE
Refactor interact action handling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
@@ -211,25 +211,26 @@ public class BlockInteractListener extends CheckListener {
         }
 
         final BlockFace face = event.getBlockFace();
-        final ItemStack stack;
+        final ActionResult aResult;
         switch (action) {
         case RIGHT_CLICK_AIR:
+            aResult = handleRightClickAir(blockChecks);
+            break;
         case LEFT_CLICK_AIR:
+            aResult = handleLeftClickAir(blockChecks);
+            break;
         case LEFT_CLICK_BLOCK:
-            stack = null;
+            aResult = handleLeftClickBlock(blockChecks);
             break;
         case RIGHT_CLICK_BLOCK:
-            stack = Bridge1_9.getUsedItem(player, event);
-            if (stack != null && stack.getType() == Material.ENDER_PEARL) {
-                checkEnderPearlRightClickBlock(player, block, face, event, previousLastTick, data, pData);
-            }
-            if (stack != null && BlockProperties.isScaffolding(stack.getType())) {
-                blockChecks = false;
-            }
+            aResult = handleRightClickBlock(player, block, face, event, previousLastTick, data, pData,
+                    blockChecks);
             break;
         default:
             return null;
         }
+        final ItemStack stack = aResult.stack();
+        blockChecks = aResult.blockChecks();
 
         if (event.isCancelled() && event.useInteractedBlock() != Result.ALLOW) {
             if (event.useItemInHand() == Result.ALLOW) {
@@ -288,6 +289,33 @@ public class BlockInteractListener extends CheckListener {
             int previousLastTick, boolean blockChecks) {}
 
     private record CheckResult(boolean cancelled, boolean preventUseItem) {}
+
+    record ActionResult(ItemStack stack, boolean blockChecks) {}
+
+    private ActionResult handleRightClickAir(final boolean blockChecks) {
+        return new ActionResult(null, blockChecks);
+    }
+
+    private ActionResult handleLeftClickAir(final boolean blockChecks) {
+        return new ActionResult(null, blockChecks);
+    }
+
+    private ActionResult handleLeftClickBlock(final boolean blockChecks) {
+        return new ActionResult(null, blockChecks);
+    }
+
+    private ActionResult handleRightClickBlock(final Player player, final Block block, final BlockFace face,
+            final PlayerInteractEvent event, final int previousLastTick, final BlockInteractData data,
+            final IPlayerData pData, boolean blockChecks) {
+        final ItemStack stack = Bridge1_9.getUsedItem(player, event);
+        if (stack != null && stack.getType() == Material.ENDER_PEARL) {
+            checkEnderPearlRightClickBlock(player, block, face, event, previousLastTick, data, pData);
+        }
+        if (stack != null && BlockProperties.isScaffolding(stack.getType())) {
+            blockChecks = false;
+        }
+        return new ActionResult(stack, blockChecks);
+    }
 
     private void logUsedFlyingPacket(final Player player, final FlyingQueueHandle flyingHandle, 
             final int flyingIndex) {

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockinteract/TestInteractHandlers.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockinteract/TestInteractHandlers.java
@@ -1,0 +1,127 @@
+package fr.neatmonster.nocheatplus.checks.blockinteract;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event.Result;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.checks.combined.CombinedConfig;
+import fr.neatmonster.nocheatplus.checks.blockinteract.BlockInteractData;
+import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
+import fr.neatmonster.nocheatplus.compat.Bridge1_9;
+
+public class TestInteractHandlers {
+
+    private sun.misc.Unsafe unsafe;
+
+    @Before
+    public void setup() throws Exception {
+        java.lang.reflect.Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        unsafe = (sun.misc.Unsafe) f.get(null);
+    }
+
+    private BlockInteractListener createListener() throws Exception {
+        return (BlockInteractListener) unsafe.allocateInstance(BlockInteractListener.class);
+    }
+
+    private CombinedConfig createConfig() throws Exception {
+        CombinedConfig cfg = (CombinedConfig) unsafe.allocateInstance(CombinedConfig.class);
+        java.lang.reflect.Field f;
+        f = CombinedConfig.class.getDeclaredField("enderPearlCheck");
+        f.setAccessible(true);
+        f.setBoolean(cfg, true);
+        f = CombinedConfig.class.getDeclaredField("enderPearlPreventClickBlock");
+        f.setAccessible(true);
+        f.setBoolean(cfg, true);
+        return cfg;
+    }
+
+    private static Object invoke(Method m, Object instance, Object... args) throws Exception {
+        m.setAccessible(true);
+        return m.invoke(instance, args);
+    }
+
+    @Test
+    public void testHandleRightClickAir() throws Exception {
+        BlockInteractListener listener = createListener();
+        Method m = BlockInteractListener.class.getDeclaredMethod("handleRightClickAir", boolean.class);
+        BlockInteractListener.ActionResult ar = (BlockInteractListener.ActionResult) invoke(m, listener, true);
+        assertNull(ar.stack());
+        assertTrue(ar.blockChecks());
+    }
+
+    @Test
+    public void testHandleLeftClickAir() throws Exception {
+        BlockInteractListener listener = createListener();
+        Method m = BlockInteractListener.class.getDeclaredMethod("handleLeftClickAir", boolean.class);
+        BlockInteractListener.ActionResult ar = (BlockInteractListener.ActionResult) invoke(m, listener, false);
+        assertNull(ar.stack());
+        assertFalse(ar.blockChecks());
+    }
+
+    @Test
+    public void testHandleLeftClickBlock() throws Exception {
+        BlockInteractListener listener = createListener();
+        Method m = BlockInteractListener.class.getDeclaredMethod("handleLeftClickBlock", boolean.class);
+        BlockInteractListener.ActionResult ar = (BlockInteractListener.ActionResult) invoke(m, listener, true);
+        assertNull(ar.stack());
+        assertTrue(ar.blockChecks());
+    }
+
+    @Test
+    public void testHandleRightClickBlockScaffolding() throws Exception {
+        BlockInteractListener listener = createListener();
+        Method m = BlockInteractListener.class.getDeclaredMethod("handleRightClickBlock", Player.class,
+                org.bukkit.block.Block.class, BlockFace.class, PlayerInteractEvent.class, int.class,
+                BlockInteractData.class, IPlayerData.class, boolean.class);
+        Player player = mock(Player.class);
+        PlayerInteractEvent event = mock(PlayerInteractEvent.class);
+        BlockInteractData data = new BlockInteractData();
+        IPlayerData pData = mock(IPlayerData.class);
+        when(pData.getGenericInstance(CombinedConfig.class)).thenReturn(createConfig());
+        ItemStack stack = new ItemStack(Material.SCAFFOLDING);
+        try (MockedStatic<Bridge1_9> b = mockStatic(Bridge1_9.class); MockedStatic<BlockProperties> bp = mockStatic(BlockProperties.class)) {
+            b.when(() -> Bridge1_9.getUsedItem(player, event)).thenReturn(stack);
+            bp.when(() -> BlockProperties.isScaffolding(Material.SCAFFOLDING)).thenReturn(true);
+            BlockInteractListener.ActionResult ar = (BlockInteractListener.ActionResult) invoke(m, listener, player,
+                    null, BlockFace.UP, event, 0, data, pData, true);
+            assertEquals(stack, ar.stack());
+            assertFalse(ar.blockChecks());
+        }
+    }
+
+    @Test
+    public void testHandleRightClickBlockEnderPearl() throws Exception {
+        BlockInteractListener listener = createListener();
+        Method m = BlockInteractListener.class.getDeclaredMethod("handleRightClickBlock", Player.class,
+                org.bukkit.block.Block.class, BlockFace.class, PlayerInteractEvent.class, int.class,
+                BlockInteractData.class, IPlayerData.class, boolean.class);
+        Player player = mock(Player.class);
+        PlayerInteractEvent event = mock(PlayerInteractEvent.class);
+        when(event.useItemInHand()).thenReturn(Result.DENY);
+        BlockInteractData data = new BlockInteractData();
+        IPlayerData pData = mock(IPlayerData.class);
+        when(pData.getGenericInstance(CombinedConfig.class)).thenReturn(createConfig());
+        ItemStack stack = new ItemStack(Material.ENDER_PEARL);
+        try (MockedStatic<Bridge1_9> b = mockStatic(Bridge1_9.class)) {
+            b.when(() -> Bridge1_9.getUsedItem(player, event)).thenReturn(stack);
+            BlockInteractListener.ActionResult ar = (BlockInteractListener.ActionResult) invoke(m, listener, player,
+                    null, BlockFace.UP, event, 0, data, pData, true);
+            assertEquals(stack, ar.stack());
+            verify(event).setUseItemInHand(Result.DENY);
+            assertTrue(ar.blockChecks());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract action handling logic into dedicated methods
- add ActionResult record to pass action processing results
- add new unit tests for action handlers

## Testing
- `mvn -q -DskipTests=false verify`


------
https://chatgpt.com/codex/tasks/task_b_685d2f8852748329aeb7496649016fe9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the interaction handling in `BlockInteractListener` to use ActionResult records for better organization of code and introduce dedicated methods for handling different interaction actions with new corresponding tests.

### Why are these changes being made?

This refactoring improves code clarity and modularity by isolating action-specific logic into separate methods (`handleRightClickAir`, `handleLeftClickAir`, `handleLeftClickBlock`, `handleRightClickBlock`), which enhances maintainability and future scalability. This approach also enables more targeted testing, as demonstrated by the addition of a test suite to verify the correct functionality of each action handling method, addressing potential interaction inconsistencies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->