### PR TITLE
Fix block break null handling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -188,7 +188,7 @@ public class BlockBreakListener extends CheckListener {
     private BreakCheckResult performBreakChecks(final Player player, final Block block,
             final IPlayerData pData) {
         final BreakCheckResult result = new BreakCheckResult();
-        if (player == null || block == null) {
+        if (player == null) {
             return result;
         }
 
@@ -197,7 +197,8 @@ public class BlockBreakListener extends CheckListener {
         result.data = data;
         final BlockInteractData bdata = pData.getGenericInstance(BlockInteractData.class);
         final int tick = TickTask.getTick();
-        final boolean isInteractBlock = !bdata.getLastIsCancelled() && bdata.matchesLastBlock(tick, block);
+        final boolean isInteractBlock = block != null && !bdata.getLastIsCancelled()
+                && bdata.matchesLastBlock(tick, block);
         final GameMode gameMode = player.getGameMode();
 
         applyWrongBlockCheck(result, player, block, cc, data, pData);
@@ -231,6 +232,9 @@ public class BlockBreakListener extends CheckListener {
     private void applyFastBreakCheck(final BreakCheckResult result, final Player player,
             final Block block, final GameMode gameMode, final BlockBreakConfig cc,
             final BlockBreakData data, final IPlayerData pData) {
+        if (block == null) {
+            return;
+        }
         if (!result.cancelled && gameMode != GameMode.CREATIVE
                 && fastBreak.isEnabled(player, pData)
                 && fastBreak.check(player, block, isInstaBreak, cc, data, pData)) {
@@ -249,6 +253,9 @@ public class BlockBreakListener extends CheckListener {
     private void applyReachDirectionChecks(final BreakCheckResult result, final Player player,
             final Block block, final boolean isInteractBlock, final BlockInteractData bdata,
             final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
+        if (block == null) {
+            return;
+        }
         final boolean reachEnabled = reach.isEnabled(player, pData);
         final boolean directionEnabled = direction.isEnabled(player, pData);
         if (!(reachEnabled || directionEnabled)) {
@@ -279,6 +286,9 @@ public class BlockBreakListener extends CheckListener {
 
     private void applyLiquidBreakCheck(final BreakCheckResult result, final Player player,
             final Block block, final IPlayerData pData) {
+        if (block == null) {
+            return;
+        }
         if (!result.cancelled && BlockProperties.isLiquid(block.getType())
                 && !BlockProperties.isWaterPlant(block.getType())
                 && !pData.hasPermission(Permissions.BLOCKBREAK_BREAK_LIQUID, player)


### PR DESCRIPTION
## Summary
- avoid returning early from `performBreakChecks` when `block` is null
- guard follow-up checks against null blocks

## Testing
- `mvn -q verify`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2f873b6c8329af0398371b6a94b9

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add null checks for the block parameter in `BlockBreakListener.java` to prevent null pointer exceptions during block break checks.

### Why are these changes being made?

The existing code did not handle instances where the `block` parameter could be null, leading to potential null pointer exceptions. By adding null checks before proceeding with operations on the `block`, the program stability is improved by ensuring that these operations are only performed when `block` is not null.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->