### PR TITLE
Fix crossbow meta null check

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/NoSlow.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/NoSlow.java
@@ -278,10 +278,13 @@ public class NoSlow extends BaseAdapter {
         if (item.getType() != Material.CROSSBOW) {
             return false;
         }
-        final ItemMeta rawMeta = item.getItemMeta();
-        if (rawMeta instanceof CrossbowMeta) {
-            final CrossbowMeta meta = (CrossbowMeta) rawMeta;
-            if (!meta.hasChargedProjectiles() && hasArrow(player.getInventory(), true)) {
+        final ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+        if (meta instanceof CrossbowMeta) {
+            final CrossbowMeta crossbowMeta = (CrossbowMeta) meta;
+            if (!crossbowMeta.hasChargedProjectiles() && hasArrow(player.getInventory(), true)) {
                 markOffHandUse(event, data, false);
                 return true;
             }


### PR DESCRIPTION
## Summary
- prevent NPE when checking crossbow use by verifying `ItemMeta`

## Testing
- `mvn -q -DskipTests=false verify`
- `mvn -DskipTests=true verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f8610ec832996c268141cc7f758