### PR TITLE
Improve jar URL detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,5 @@ nb-configuration.xml
 dummy/
 
 !NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtilTest.java
-
-essa.patch
+!NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/URLUtil.java
+!NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/URLUtilTest.java

--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -23,6 +23,8 @@ import java.net.URL;
 import java.security.CodeSource;
 import java.util.Map;
 
+import fr.neatmonster.nocheatplus.utilities.build.URLUtil;
+
 public class ResourceUtil {
 
     private ResourceUtil() {
@@ -46,8 +48,7 @@ public class ResourceUtil {
             return null;
         }
         final String csPath = codeSource.getLocation().getPath();
-        final String csLower = csPath.toLowerCase();
-        if (!csLower.endsWith(".jar") && !csLower.contains(".jar!")) {
+        if (!URLUtil.isJarURL(csPath)) {
             return null;
         }
         if (!classPath.startsWith("jar")) {

--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/URLUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/URLUtil.java
@@ -1,0 +1,44 @@
+package fr.neatmonster.nocheatplus.utilities.build;
+
+import java.net.URL;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for working with URLs.
+ */
+public final class URLUtil {
+
+    private static final Pattern JAR_PATTERN = Pattern.compile("\\.jar(?=([!?#]|$))", Pattern.CASE_INSENSITIVE);
+
+    private URLUtil() {
+    }
+
+    /**
+     * Determine if the supplied path points to a JAR file. The check ignores
+     * any trailing {@code !}, query or fragment segments.
+     *
+     * @param path
+     *            the path to check
+     * @return {@code true} if the path contains ".jar" before any of the
+     *         optional segments
+     */
+    public static boolean isJarURL(String path) {
+        if (path == null) {
+            return false;
+        }
+        return JAR_PATTERN.matcher(path).find();
+    }
+
+    /**
+     * Determine if the supplied URL points to a JAR file. The check ignores any
+     * trailing {@code !}, query or fragment segments.
+     *
+     * @param url
+     *            the URL to check
+     * @return {@code true} if the URL refers to a JAR file
+     */
+    public static boolean isJarURL(URL url) {
+        return url != null && isJarURL(url.toString());
+    }
+}

--- a/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/URLUtilTest.java
+++ b/NCPBuildBase/src/test/java/fr/neatmonster/nocheatplus/utilities/build/URLUtilTest.java
@@ -1,0 +1,28 @@
+package fr.neatmonster.nocheatplus.utilities.build;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+public class URLUtilTest {
+
+    @Test
+    public void jarUrlWithQueryIsDetected() throws Exception {
+        String spec = "file:/path/plugin.jar?version=1.0!/resource.txt";
+        assertTrue(URLUtil.isJarURL(spec));
+    }
+
+    @Test
+    public void urlObjectDetection() throws Exception {
+        URL url = new URL("jar:file:/path/lib.jar!/res.txt");
+        assertTrue(URLUtil.isJarURL(url));
+    }
+
+    @Test
+    public void nonJarUrlIsRejected() {
+        assertFalse(URLUtil.isJarURL("file:/path/plugin.zip"));
+    }
+}


### PR DESCRIPTION
## Summary
- recognize query parameters in jar URLs with new `URLUtil.isJarURL`
- use `URLUtil` within `ResourceUtil`
- test URL detection logic
- update `.gitignore` for new utility files

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f8265c883298afc8847db631b0d