### PR TITLE
Implement boat passenger re-add retries

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -337,39 +337,69 @@ public class PassengerUtil {
         }
 
         for (final Entity passenger : originalPassengers) {
-            if (passenger == null) {
-                continue;
+            processPassenger(passenger, vehicle, player, location, debug, vWorldMatchesPWorld,
+                    vehicleTeleported, result);
+        }
+
+        return result;
+    }
+
+    private void processPassenger(final Entity passenger, final Entity vehicle, final Player player,
+                                  final Location location, final boolean debug,
+                                  final boolean vWorldMatchesPWorld, final boolean vehicleTeleported,
+                                  final TeleportResult result) {
+        if (!isValidPassenger(passenger, vWorldMatchesPWorld, player, debug)) {
+            return;
+        }
+        if (passenger instanceof Player) {
+            handlePlayerPassenger((Player) passenger, vehicle, location, vehicleTeleported, player, result, debug);
+        } else {
+            teleportEntityPassenger(passenger, vehicle, location, vehicleTeleported);
+        }
+    }
+
+    private boolean isValidPassenger(final Entity passenger, final boolean vWorldMatchesPWorld,
+                                     final Player player, final boolean debug) {
+        if (passenger == null) {
+            return false;
+        }
+        if (!passenger.isValid() || passenger.isDead() || !vWorldMatchesPWorld) {
+            if (debug) {
+                CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                        (!vWorldMatchesPWorld)
+                                ? "**** Prevent adding passengers to root vehicle on world change (potential exploit)"
+                                : "Can't add passenger to vehicle: passenger is dead.");
             }
-            if (!passenger.isValid() || passenger.isDead() || !vWorldMatchesPWorld) {
-                if (debug) {
-                    CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
-                            (!vWorldMatchesPWorld) ? "**** Prevent adding passengers to root vehicle on world change (potential exploit)"
-                                    : "Can't add passenger to vehicle: passenger is dead.");
-                }
-                continue;
-            }
-            if (passenger instanceof Player) {
-                if (teleportPlayerPassenger((Player) passenger, vehicle, location, vehicleTeleported,
-                        DataManager.getGenericInstance((Player) passenger, MovingData.class), debug)) {
-                    if (player.equals(passenger)) {
-                        result.playerTeleported = true;
-                    } else {
-                        result.otherPlayersTeleported++;
-                    }
-                }
+            return false;
+        }
+        return true;
+    }
+
+    private void handlePlayerPassenger(final Player passenger, final Entity vehicle, final Location location,
+                                       final boolean vehicleTeleported, final Player mainPlayer,
+                                       final TeleportResult result, final boolean debug) {
+        final boolean teleported = teleportPlayerPassenger(passenger, vehicle, location, vehicleTeleported,
+                DataManager.getGenericInstance(passenger, MovingData.class), debug);
+        if (teleported) {
+            if (mainPlayer.equals(passenger)) {
+                result.playerTeleported = true;
             } else {
-                if (Folia.teleportEntity(passenger, location, BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION)
-                        && vehicleTeleported
-                        && TrigUtil.distance(passenger.getLocation(useLoc2), vehicle.getLocation(useLoc)) < 1.5) {
-                    if (vehicle.getType() == EntityType.BOAT) {
-                        addPassengerWithRetry(passenger, vehicle, 2);
-                    } else {
-                        handleVehicle.getHandle().addPassenger(passenger, vehicle);
-                    }
-                }
+                result.otherPlayersTeleported++;
             }
         }
-        return result;
+    }
+
+    private void teleportEntityPassenger(final Entity passenger, final Entity vehicle, final Location location,
+                                         final boolean vehicleTeleported) {
+        if (Folia.teleportEntity(passenger, location, BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION)
+                && vehicleTeleported
+                && TrigUtil.distance(passenger.getLocation(useLoc2), vehicle.getLocation(useLoc)) < 1.5) {
+            if (vehicle.getType() == EntityType.BOAT) {
+                addPassengerWithRetry(passenger, vehicle, 2);
+            } else {
+                handleVehicle.getHandle().addPassenger(passenger, vehicle);
+            }
+        }
     }
 
     private boolean addPassengerWithRetry(final Entity passenger, final Entity vehicle, final int retries) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -361,11 +361,25 @@ public class PassengerUtil {
                 if (Folia.teleportEntity(passenger, location, BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION)
                         && vehicleTeleported
                         && TrigUtil.distance(passenger.getLocation(useLoc2), vehicle.getLocation(useLoc)) < 1.5) {
-                    handleVehicle.getHandle().addPassenger(passenger, vehicle);
+                    if (vehicle.getType() == EntityType.BOAT) {
+                        addPassengerWithRetry(passenger, vehicle, 2);
+                    } else {
+                        handleVehicle.getHandle().addPassenger(passenger, vehicle);
+                    }
                 }
             }
         }
         return result;
+    }
+
+    private boolean addPassengerWithRetry(final Entity passenger, final Entity vehicle, final int retries) {
+        if (handleVehicle.getHandle().addPassenger(passenger, vehicle)) {
+            return true;
+        }
+        if (retries > 0 && plugin != null) {
+            Folia.runSyncDelayedTask(plugin, (arg) -> addPassengerWithRetry(passenger, vehicle, retries - 1), 1L);
+        }
+        return false;
     }
 
     private void logTeleportResult(final Player player, final Location location, final boolean debug,
@@ -383,9 +397,8 @@ public class PassengerUtil {
         boolean scheduleDelay = cc.schedulevehicleSetPassenger;
         if (data.vehicleSetPassengerTaskId == null) {
             if (vehicle.getType() == EntityType.BOAT) {
-                if (!handleVehicle.getHandle().addPassenger(player, vehicle)) {
+                if (!addPassengerWithRetry(player, vehicle, 2)) {
                     vehicle.eject();
-                    // Not schedule set passenger for boat due to location async
                 }
             } else if (scheduleDelay) {
                 data.vehicleSetPassengerTaskId = Folia.runSyncDelayedTaskForEntity(player, plugin,

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
@@ -4,12 +4,23 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.Server;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,21 +40,26 @@ public class PassengerUtilTest {
 
     private static class DummyVehicleAccess implements IEntityAccessVehicle {
         boolean called;
+        Map<Entity, Integer> attempts = new HashMap<>();
         @Override public java.util.List<Entity> getEntityPassengers(Entity e) { return Collections.emptyList(); }
         @Override
         public boolean addPassenger(Entity entity, Entity vehicle) {
             called = true;
-            return true;
+            int c = attempts.getOrDefault(entity, 0);
+            attempts.put(entity, c + 1);
+            return c > 0;
         }
     }
 
     private sun.misc.Unsafe unsafe;
+    private Server previousServer;
 
     @Before
     public void setup() throws Exception {
         Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
         f.setAccessible(true);
         unsafe = (sun.misc.Unsafe) f.get(null);
+        previousServer = org.bukkit.Bukkit.getServer();
     }
 
     private PassengerUtil newUtil(DummyVehicleAccess access) throws Exception {
@@ -64,6 +80,13 @@ public class PassengerUtilTest {
         f.setAccessible(true);
         f.setBoolean(cfg, false);
         return cfg;
+    }
+
+    @org.junit.After
+    public void teardown() {
+        if (previousServer != null && org.bukkit.Bukkit.getServer() != previousServer) {
+            org.bukkit.Bukkit.setServer(previousServer);
+        }
     }
 
     @Test
@@ -91,5 +114,74 @@ public class PassengerUtilTest {
         MovingData data = newData();
         sched.invoke(util, player, vehicle, cfg, data, false);
         assertTrue(access.called);
+    }
+
+    @Test
+    public void testAddPassengerWithRetryMultiple() throws Exception {
+        DummyVehicleAccess access = new DummyVehicleAccess();
+        PassengerUtil util = newUtil(access);
+        Method m = PassengerUtil.class.getDeclaredMethod("addPassengerWithRetry", Entity.class, Entity.class, int.class);
+        m.setAccessible(true);
+
+        org.junit.Assume.assumeTrue(org.bukkit.Bukkit.getScheduler() != null);
+
+        List<Runnable> tasks = new ArrayList<>();
+        Server server = createServer(tasks);
+        if (previousServer == null) {
+            org.bukkit.Bukkit.setServer(server);
+        } else {
+            server = previousServer;
+        }
+
+        Plugin plugin = mock(Plugin.class);
+        Field pf = PassengerUtil.class.getDeclaredField("plugin");
+        pf.setAccessible(true);
+        pf.set(util, plugin);
+
+        Entity boat = mock(Entity.class);
+        when(boat.getType()).thenReturn(EntityType.BOAT);
+        Entity p1 = mock(Entity.class);
+        Entity p2 = mock(Entity.class);
+
+        m.invoke(util, p1, boat, 1);
+        m.invoke(util, p2, boat, 1);
+
+        assertEquals(2, access.attempts.get(p1).intValue());
+        assertEquals(2, access.attempts.get(p2).intValue());
+    }
+
+    private static Server createServer(List<Runnable> tasks) {
+        PluginManager pm = (PluginManager) Proxy.newProxyInstance(PassengerUtilTest.class.getClassLoader(),
+                new Class[]{PluginManager.class}, (proxy, method, args) -> defaultValue(method.getReturnType()));
+        BukkitScheduler scheduler = (BukkitScheduler) Proxy.newProxyInstance(PassengerUtilTest.class.getClassLoader(),
+                new Class[]{BukkitScheduler.class}, (proxy, method, args) -> {
+                    if ("scheduleSyncDelayedTask".equals(method.getName())) {
+                        Runnable r = (Runnable) args[1];
+                        tasks.add(r);
+                        r.run();
+                        return 1;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+        InvocationHandler serverHandler = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "getPluginManager": return pm;
+                case "getScheduler": return scheduler;
+                case "getLogger": return Logger.getLogger("TestServer");
+                default: return defaultValue(method.getReturnType());
+            }
+        };
+        return (Server) Proxy.newProxyInstance(PassengerUtilTest.class.getClassLoader(), new Class[]{Server.class}, serverHandler);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == char.class) return '\0';
+        if (type == byte.class || type == short.class || type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0f;
+        if (type == double.class) return 0d;
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- retry adding boat passengers with `runSyncDelayedTask`
- integrate retry logic with player scheduling
- test passenger retries with multiple passengers

## Testing
- `mvn -q -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7fa6b8832998606d825aed643c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement retries for adding passengers to boats to handle cases where the initial attempt fails.

### Why are these changes being made?

This change addresses a problem where adding passengers to boats may occasionally fail due to timing or async location issues. The retry mechanism ensures that a passenger is successfully added upon subsequent attempts, improving the robustness of passenger management in the system. This approach provides a fallback for scenarios where async operations might lead to an inconsistent state, ensuring higher reliability without requiring a major redesign.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the structure and clarity of passenger teleportation logic, making it more modular and robust.
  * Enhanced validation and debug logging for passenger handling.
  * Introduced retry logic for adding passengers to vehicles, especially boats, to increase reliability.

* **Tests**
  * Added new tests to verify the retry mechanism for adding passengers and improved test setup and cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->