### PR TITLE
Refactor improbable feed logic with tests

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
@@ -592,9 +592,8 @@ public class BlockPlaceListener extends CheckListener {
             return true;
         }
         if (cc.speedImprobableWeight > 0.0f) {
-            if (cc.speedImprobableFeedOnly) {
-                Improbable.feed(player, cc.speedImprobableWeight, now);
-            } else if (Improbable.check(player, cc.speedImprobableWeight, now, "blockplace.speed", pData)) {
+            Improbable.feed(player, cc.speedImprobableWeight, now);
+            if (!cc.speedImprobableFeedOnly && Improbable.checkOnly(player, now, "blockplace.speed", pData)) {
                 return true;
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/Improbable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/Improbable.java
@@ -43,9 +43,34 @@ public class Improbable extends Check implements IDisableListener{
      * @param now
      * @return
      */
-    public static final boolean check(final Player player, final float weight, final long now, 
+    /**
+     * Feed weight and run the improbable check.
+     *
+     * @param player
+     * @param weight
+     * @param now
+     * @param tags
+     * @param pData
+     * @return true if actions request to cancel
+     */
+    public static final boolean check(final Player player, final float weight, final long now,
             final String tags, final IPlayerData pData){
-        return instance.checkImprobable(player, weight, now, tags, pData);
+        feed(player, weight, now, pData);
+        return instance.checkImprobableOnly(player, now, tags, pData);
+    }
+
+    /**
+     * Only run the improbable check without adding new input.
+     *
+     * @param player
+     * @param now
+     * @param tags
+     * @param pData
+     * @return true if actions request to cancel
+     */
+    public static final boolean checkOnly(final Player player, final long now, final String tags,
+            final IPlayerData pData) {
+        return instance.checkImprobableOnly(player, now, tags, pData);
     }
 
     /**
@@ -79,14 +104,13 @@ public class Improbable extends Check implements IDisableListener{
         instance = this;
     }
 
-    private boolean checkImprobable(final Player player, final float weight, final long now, 
+    private boolean checkImprobableOnly(final Player player, final long now,
             final String tags, final IPlayerData pData) {
         if (!pData.isCheckActive(type, player)) {
             return false;
         }
         final CombinedData data = pData.getGenericInstance(CombinedData.class);
         final CombinedConfig cc = pData.getGenericInstance(CombinedConfig.class);
-        data.improbableCount.add(now, weight);
         final float shortTerm = data.improbableCount.bucketScore(0);
         double violation = 0;
         boolean violated = false;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
@@ -85,6 +85,11 @@ public class FightConfig extends ACheckConfig {
 
     public final int        speedShortTermLimit;
     public final int        speedShortTermTicks;
+    /**
+     * If set, only feed the Improbable system with speed related events and do
+     * not evaluate violations here. Useful when another plugin handles speed
+     * checks.
+     */
     public final boolean    speedImprobableFeedOnly;
     public final float      speedImprobableWeight;
     public final ActionList speedActions;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -554,18 +554,17 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         if (player == null || pData == null || !speed.isEnabled(player, pData)) {
             return false;
         }
+        if (cc.speedImprobableWeight > 0.0f) {
+            Improbable.feed(player, cc.speedImprobableWeight, now);
+        }
         if (speed.check(player, now, data, cc, pData)) {
-            if (data.speedVL > 50) {
-                if (cc.speedImprobableWeight > 0.0f && !cc.speedImprobableFeedOnly) {
-                    Improbable.check(player, cc.speedImprobableWeight, now, "fight.speed", pData);
-                }
-            } else if (cc.speedImprobableWeight > 0.0f) {
-                Improbable.feed(player, cc.speedImprobableWeight, now);
+            if (data.speedVL > 50 && cc.speedImprobableWeight > 0.0f && !cc.speedImprobableFeedOnly) {
+                Improbable.checkOnly(player, now, "fight.speed", pData);
             }
             return true;
         }
         if (normalizedMove > 2.0 && cc.speedImprobableWeight > 0.0f && !cc.speedImprobableFeedOnly
-                && Improbable.check(player, cc.speedImprobableWeight, now, "fight.speed", pData)) {
+                && Improbable.checkOnly(player, now, "fight.speed", pData)) {
             return true;
         }
         return false;

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestImprobable.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestImprobable.java
@@ -1,0 +1,138 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.actions.ActionList;
+import fr.neatmonster.nocheatplus.checks.combined.CombinedConfig;
+import fr.neatmonster.nocheatplus.checks.combined.CombinedData;
+import fr.neatmonster.nocheatplus.checks.combined.Improbable;
+import fr.neatmonster.nocheatplus.permissions.RegisteredPermission;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.worlds.IWorldData;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.players.DataManager;
+import fr.neatmonster.nocheatplus.players.PlayerDataManager;
+import org.bukkit.Server;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.Bukkit;
+
+public class TestImprobable {
+
+    private static sun.misc.Unsafe getUnsafe() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (sun.misc.Unsafe) f.get(null);
+    }
+
+    private CombinedConfig createConfig(float level) throws Exception {
+        sun.misc.Unsafe u = getUnsafe();
+        CombinedConfig cc = (CombinedConfig) u.allocateInstance(CombinedConfig.class);
+        Field wf = CombinedConfig.class.getSuperclass().getDeclaredField("worldData");
+        wf.setAccessible(true);
+        wf.set(cc, mock(IWorldData.class));
+        Field lf = CombinedConfig.class.getDeclaredField("improbableLevel");
+        lf.setAccessible(true);
+        lf.setFloat(cc, level);
+        Field af = CombinedConfig.class.getDeclaredField("improbableActions");
+        af.setAccessible(true);
+        af.set(cc, new ActionList(new RegisteredPermission(1, "dummy")));
+        return cc;
+    }
+
+    private IPlayerData pData;
+    private CombinedData data;
+    private CombinedConfig config;
+    private Player player;
+    private IWorldData worldData;
+    private Server server;
+    private Server previousServer;
+
+    @Before
+    public void setup() throws Exception {
+        java.lang.reflect.Field f = NCPAPIProvider.class.getDeclaredField("noCheatPlusAPI");
+        f.setAccessible(true);
+        f.set(null, new TestGodModeHelpers.DummyAPI());
+        sun.misc.Unsafe un = getUnsafe();
+        Object pdm = un.allocateInstance(PlayerDataManager.class);
+        java.lang.reflect.Field eh = PlayerDataManager.class.getDeclaredField("executionHistories");
+        eh.setAccessible(true);
+        eh.set(pdm, new java.util.HashMap<>());
+        java.lang.reflect.Field dm = DataManager.class.getDeclaredField("instance");
+        dm.setAccessible(true);
+        dm.set(null, pdm);
+        PluginManager pluginManager = mock(PluginManager.class);
+        ConsoleCommandSender console = mock(ConsoleCommandSender.class);
+        server = (Server) java.lang.reflect.Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{Server.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getPluginManager": return pluginManager;
+                        case "getConsoleSender": return console;
+                        case "getLogger": return java.util.logging.Logger.getLogger("TestServer");
+                        case "isPrimaryThread": return true;
+                        default: return null;
+                    }
+                });
+        previousServer = Bukkit.getServer();
+        if (previousServer == null) {
+            Bukkit.setServer(server);
+        } else {
+            server = previousServer;
+        }
+        player = mock(Player.class);
+        worldData = mock(IWorldData.class);
+        when(worldData.shouldAdjustToLag(any())).thenReturn(false);
+        data = new CombinedData();
+        config = createConfig(1f);
+        pData = mock(IPlayerData.class);
+        when(pData.isCheckActive(any(), any())).thenReturn(true);
+        when(pData.getGenericInstance(CombinedData.class)).thenReturn(data);
+        when(pData.getGenericInstance(CombinedConfig.class)).thenReturn(config);
+        when(pData.getCurrentWorldData()).thenReturn(worldData);
+        new Improbable();
+    }
+
+    @org.junit.After
+    public void teardown() {
+        if (previousServer != null && Bukkit.getServer() != previousServer) {
+            Bukkit.setServer(previousServer);
+        }
+    }
+
+    @Test
+    public void testFeedAndCheckOnly() {
+        long now = System.currentTimeMillis();
+        Improbable.feed(player, 1f, now, pData);
+        Improbable.checkOnly(player, now, "test", pData);
+        assertTrue(data.improbableVL > 0d);
+    }
+
+    @Test
+    public void testCheckFeedsAndEvaluates() {
+        long now = System.currentTimeMillis();
+        Improbable.check(player, 1f, now, "test", pData);
+        assertTrue(data.improbableCount.bucketScore(0) > 0f);
+        assertTrue(data.improbableVL > 0d);
+    }
+}


### PR DESCRIPTION
## Summary
- separate feed-only logic from improbable checks
- clarify speedImprobableFeedOnly in FightConfig
- use feed+checkOnly in fight and blockplace listeners
- add unit tests for improbable feed/check behavior

## Testing
- `mvn -q test`
- `mvn -B checkstyle:check pmd:check spotbugs:check -DskipTests`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7c92908329b8e60d3ad4120507

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor and optimize the logic for handling improbable speed detection in the BlockPlaceListener and FightListener classes, and add corresponding unit tests in the new TestImprobable class. 

### Why are these changes being made?

These changes introduce a separation of logic to improve how speed-related inputs are processed by the Improbable class, distinguishing between merely feeding data and actively performing checks. This allows for more flexibility in handling speed events, especially when configured to defer evaluation to other plugins. Additionally, it enhances the maintainability and testing capabilities of the codebase by adding comprehensive tests to validate the new logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->