### PR TITLE
Validate bounding box data

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
@@ -228,10 +228,11 @@ public class MCAccessCBReflect extends MCAccessBukkit {
     }
 
     /**
-     * Validate a bounds array.
+     * Validate a bounds array containing min/max coordinates
+     * {@code [xMin, yMin, zMin, xMax, yMax, zMax]}.
      *
      * @param bounds the bounds array to validate
-     * @return true if the array is usable
+     * @return true if the array has valid length and coordinates
      */
     static boolean isValidBounds(final double[] bounds) {
         if (bounds == null || bounds.length < 6) {

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflect.java
@@ -199,21 +199,21 @@ public class MCAccessCBReflect extends MCAccessBukkit {
 
     @Override
     public AlmostBoolean isIllegalBounds(final Player player) {
+        if (player == null) {
+            return AlmostBoolean.MAYBE;
+        }
         if (player.isDead()) {
             return AlmostBoolean.NO;
         }
         try {
             final double[] bounds = helper.getBoundsTemp(player);
-            if (bounds == null) {
+            if (!isValidBounds(bounds)) {
                 return AlmostBoolean.MAYBE;
-            }
-            if (LocUtil.isBadCoordinate(bounds)) {
-                return AlmostBoolean.YES;
             }
             if (!player.isSleeping()) {
                 final double dY = Math.abs(bounds[4] - bounds[1]);
                 if (dY > 1.8) {
-                    return AlmostBoolean.YES; // dY > 1.65D || 
+                    return AlmostBoolean.YES; // dY > 1.65D ||
                 }
                 // Should retrieve height/length from ReflectEntity.
                 if (dY < 0.1D && getHeight(player) >= 0.1) {
@@ -225,6 +225,22 @@ public class MCAccessCBReflect extends MCAccessBukkit {
             // Ignore.
         }
         return AlmostBoolean.MAYBE;
+    }
+
+    /**
+     * Validate a bounds array.
+     *
+     * @param bounds the bounds array to validate
+     * @return true if the array is usable
+     */
+    static boolean isValidBounds(final double[] bounds) {
+        if (bounds == null || bounds.length < 6) {
+            return false;
+        }
+        if (LocUtil.isBadCoordinate(bounds)) {
+            return false;
+        }
+        return bounds[0] <= bounds[3] && bounds[1] <= bounds[4] && bounds[2] <= bounds[5];
     }
 
     // ---- Missing (probably ok with Bukkit only) ----

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflectTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflectTest.java
@@ -1,0 +1,39 @@
+package fr.neatmonster.nocheatplus.compat.cbreflect;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class MCAccessCBReflectTest {
+
+    @Test
+    public void testValidBounds() {
+        double[] bounds = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+        assertTrue(MCAccessCBReflect.isValidBounds(bounds));
+    }
+
+    @Test
+    public void testInvalidLength() {
+        double[] bounds = {0.0, 0.0, 0.0};
+        assertFalse(MCAccessCBReflect.isValidBounds(bounds));
+    }
+
+    @Test
+    public void testBadCoordinate() {
+        double[] bounds = {0.0, Double.NaN, 0.0, 1.0, 1.0, 1.0};
+        assertFalse(MCAccessCBReflect.isValidBounds(bounds));
+    }
+
+    @Test
+    public void testExtremeCoordinate() {
+        double[] bounds = {0.0, 0.0, 0.0, 1.0e10, 1.0, 1.0};
+        assertFalse(MCAccessCBReflect.isValidBounds(bounds));
+    }
+
+    @Test
+    public void testReversedBounds() {
+        double[] bounds = {1.0, 0.0, 0.0, 0.0, 1.0, 1.0};
+        assertFalse(MCAccessCBReflect.isValidBounds(bounds));
+    }
+}


### PR DESCRIPTION
## Summary
- validate reflection-provided bounds before use
- test edge cases for bounds validity

## Testing
- `mvn -q -DskipTests=false test`
- `mvn checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7bc3388329b0bfbe1d475ef247

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add validation for bounding box data to `isIllegalBounds` method and introduce unit tests for this validation in `MCAccessCBReflectTest`.

### Why are these changes being made?

To ensure robust detection of invalid bounding box data for players, which prevents erroneous behavior during gameplay. The introduced validation checks if the bounding array is non-null, has the correct length, and the coordinates are in a valid order, enhancing the reliability of entity bounding evaluations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->