### PR TITLE
Improve scheduling failure logging

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/Folia.java
@@ -76,10 +76,7 @@ public class Folia {
                 return Bukkit.getScheduler().runTaskAsynchronously(plugin,
                         () -> run.accept(null));
             } catch (Exception ex) {
-                LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
-                logManager.warning(Streams.STATUS,
-                        "Failed to schedule async task: " + ex.getClass().getSimpleName());
-                logManager.warning(Streams.STATUS, ex);
+                logScheduleFailure("Failed to schedule async task", plugin, null, null, ex);
             }
             return null;
         //}
@@ -112,7 +109,7 @@ public class Folia {
             Object taskInfo = executeMethod.invoke(syncScheduler, plugin, run, delay, period);
             return taskInfo;
         } catch (Exception e) {
-            e.printStackTrace();
+            logScheduleFailure("Failed to schedule repeating task", plugin, delay, period, e);
         }
         return null;
     }
@@ -145,7 +142,7 @@ public class Folia {
             Object taskInfo = executeMethod.invoke(syncScheduler, plugin, run);
             return taskInfo;
         } catch (Exception e) {
-            e.printStackTrace();
+            logScheduleFailure("Failed to schedule task", plugin, null, null, e);
         }
         return null;
     }
@@ -176,9 +173,7 @@ public class Folia {
             Object taskInfo = executeMethod.invoke(syncScheduler, plugin, run, delay);
             return taskInfo;
         } catch (Exception e) {
-            LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
-            logManager.warning(Streams.STATUS, "Failed to schedule delayed task: " + e.getClass().getSimpleName());
-            logManager.warning(Streams.STATUS, e);
+            logScheduleFailure("Failed to schedule delayed task", plugin, delay, null, e);
         }
         return null;
     }
@@ -223,9 +218,7 @@ public class Folia {
             Object taskInfo = executeMethod.invoke(syncEntityScheduler, plugin, run, retired, delay);
             return taskInfo;
         } catch (Exception e) {
-            LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
-            logManager.warning(Streams.STATUS, "Failed to schedule entity task: " + e.getClass().getSimpleName());
-            logManager.warning(Streams.STATUS, e);
+            logScheduleFailure("Failed to schedule entity task", plugin, delay, null, e);
         }
         return null;
     }
@@ -272,6 +265,21 @@ public class Folia {
                 e.printStackTrace();
             }
         }
+    }
+
+    private static void logScheduleFailure(String message, Plugin plugin, Long delay, Long period, Exception e) {
+        LogManager logManager = NCPAPIProvider.getNoCheatPlusAPI().getLogManager();
+        StringBuilder sb = new StringBuilder(message).append(" plugin=")
+                .append(plugin != null ? plugin.getName() : "null");
+        if (delay != null) {
+            sb.append(" delay=").append(delay);
+        }
+        if (period != null) {
+            sb.append(" period=").append(period);
+        }
+        sb.append(": ").append(e.getClass().getSimpleName());
+        logManager.warning(Streams.STATUS, sb.toString());
+        logManager.warning(Streams.STATUS, e);
     }
 
     public static boolean teleportEntity(Entity entity, Location loc, TeleportCause cause) {


### PR DESCRIPTION
## Summary
- extend scheduling failure logs with plugin name, delay and period
- add helper method for logging scheduling failures

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7780a08329a85119d0300027cb

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor logging for scheduling failures by introducing a new `logScheduleFailure` method for consistent and detailed error logging.

### Why are these changes being made?

The changes aim to improve error logging by consolidating repetitive logging code into a single method, which enhances code maintainability and ensures consistent logging format across different scheduling tasks. This allows clearer insight into scheduling failures and aids in debugging by including additional context such as plugin name and optional delay/period information in the log messages.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->