### PR TITLE
Refactor burn window counting for morePackets

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -36,6 +36,36 @@ import fr.neatmonster.nocheatplus.worlds.WorldFactoryArgument;
  */
 public class NetStatic {
 
+    static class BurnInfo {
+        final int burnStart;
+        final int empty;
+        BurnInfo(int burnStart, int empty) {
+            this.burnStart = burnStart;
+            this.empty = empty;
+        }
+    }
+
+    static BurnInfo computeBurnInfo(final ActionFrequency packetFreq) {
+        final int winNum = packetFreq.numberOfBuckets();
+        int burnStart = winNum;
+        int empty = 0;
+        boolean firstUsed = false;
+        boolean counting = false;
+        for (int i = 1; i < winNum; i++) {
+            if (packetFreq.bucketScore(i) > 0f) {
+                if (!firstUsed) {
+                    firstUsed = true;
+                } else if (!counting) {
+                    burnStart = i;
+                    counting = true;
+                }
+            } else if (counting) {
+                empty++;
+            }
+        }
+        return new BurnInfo(burnStart, empty);
+    }
+
     /**
      * Packet-cheating check, for catching clients that send more packets than
      * allowed. Intention is to have a more accurate check than just preventing
@@ -101,25 +131,9 @@ public class NetStatic {
 
         // Fill up all "used" time windows (minimum we can do without other events).
         final float burnScore = (float) idealPackets * (float) winDur / 1000f;
-        // Find index.
-        int burnStart;
-        int empty = 0;
-        boolean used = false;
-        for (burnStart = 1; burnStart < winNum; burnStart ++) {
-            if (packetFreq.bucketScore(burnStart) > 0f) {
-                // Evaluate whether burnStart should increment for partially filled windows.
-                if (used) {
-                    for (int j = burnStart; j < winNum; j ++) {
-                        if (packetFreq.bucketScore(j) == 0f) {
-                            empty += 1;
-                        }
-                    }
-                    break;
-                } else {
-                    used = true;
-                }
-            }
-        }
+        final BurnInfo burnInfo = computeBurnInfo(packetFreq);
+        final int burnStart = burnInfo.burnStart;
+        int empty = burnInfo.empty;
 
         // Future: burn time windows based on other activity counting, such as matching ActinFrequency with keep-alive packets.
 

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
@@ -1,0 +1,44 @@
+package fr.neatmonster.nocheatplus.checks.net;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.utilities.ds.count.ActionFrequency;
+
+public class TestMorePacketsCheck {
+
+    @Test
+    public void testNoViolationWithEmptyBuckets() {
+        ActionFrequency freq = new ActionFrequency(5, 1000);
+        ActionFrequency burst = new ActionFrequency(12, 5000);
+        List<String> tags = new ArrayList<String>();
+        double v = NetStatic.morePacketsCheck(freq, 0L, 0f, 2f, 2f, burst, 10f, 100.0, 1000.0, tags);
+        assertEquals(0.0, v, 0.0001);
+    }
+
+    @Test
+    public void testViolationForHighPacketFrequency() {
+        ActionFrequency freq = new ActionFrequency(5, 1000);
+        for (int i = 0; i < 5; i++) {
+            freq.setBucket(i, 5f);
+        }
+        ActionFrequency burst = new ActionFrequency(12, 5000);
+        List<String> tags = new ArrayList<String>();
+        double v = NetStatic.morePacketsCheck(freq, 0L, 0f, 2f, 2f, burst, 10f, 100.0, 1000.0, tags);
+        assertTrue(v > 0.0);
+    }
+
+    @Test
+    public void testBurnInfoSeparatedBuckets() {
+        ActionFrequency freq = new ActionFrequency(5, 1000);
+        freq.setBucket(1, 2f);
+        freq.setBucket(3, 1f);
+        NetStatic.BurnInfo info = NetStatic.computeBurnInfo(freq);
+        assertEquals(3, info.burnStart);
+        assertEquals(1, info.empty);
+    }
+}


### PR DESCRIPTION
## Summary
- compute burnStart and empty with a single pass helper
- add a unit test for various bucket distributions
- run `mvn -P checks clean verify`

## Testing
- `mvn -P checks clean verify -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7589648329a2acc3120b363e92

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the burn window counting logic in the `morePacketsCheck` method by encapsulating it in a new `computeBurnInfo` method within the `NetStatic` class and add related unit tests.

### Why are these changes being made?

The changes simplify the `morePacketsCheck` method by removing duplicate code and enhancing readability. By introducing a separate `computeBurnInfo` method, the logic for determining burn start and empty buckets is decoupled, allowing for easier maintenance and potential reuse. The addition of unit tests ensures that this functionality behaves as expected and increases overall code reliability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->