### PR TITLE
Fix vehicle teleportation logic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -320,9 +320,8 @@ public class PassengerUtil {
         }
         if (redoPassengers) {
             vehicle.eject();
-            return Folia.teleportEntity(vehicle, LocUtil.clone(location), BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION);
         }
-        return false;
+        return Folia.teleportEntity(vehicle, LocUtil.clone(location), BridgeMisc.TELEPORT_CAUSE_CORRECTION_OF_POSITION);
     }
 
     private TeleportResult teleportPassengers(final Entity vehicle, final Player player, final Location location,


### PR DESCRIPTION
## Summary
- ensure vehicles teleport even when `redoPassengers` is false

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f7097cc8329a2d3493803481b37

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the vehicle teleportation logic to conditionally execute `Folia.teleportEntity()` when not redoing passengers, instead of directly returning false.

### Why are these changes being made?

The previous logic prematurely returned false if passengers were not being redone, even if teleportation could proceed, which inhibited proper vehicle teleportation under specific conditions. The change ensures vehicles can always be teleported when necessary, thereby enhancing the reliability of teleportation mechanics in the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->