### PR TITLE
Introduce JAR URL separator constant

### DIFF
--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -25,6 +25,12 @@ import java.util.Map;
 
 public class ResourceUtil {
 
+    /**
+     * Separator used in jar URLs to delimit the archive from the internal
+     * resource path (e.g. {@code "jar:file:/plugin.jar!/path"}).
+     */
+    private static final String JAR_URL_SEPARATOR = "!";
+
     private ResourceUtil() {
     }
 
@@ -45,15 +51,16 @@ public class ResourceUtil {
         if (codeSource == null) {
             return null;
         }
-        final String csPath = codeSource.getLocation().getPath();
-        final String csLower = csPath.toLowerCase();
-        if (!csLower.endsWith(".jar") && !csLower.contains(".jar!")) {
+        final String codeSourcePath = codeSource.getLocation().getPath();
+        final String codeSourcePathLower = codeSourcePath.toLowerCase();
+        if (!codeSourcePathLower.endsWith(".jar") && !codeSourcePathLower.contains(".jar" + JAR_URL_SEPARATOR)) {
             return null;
         }
         if (!classPath.startsWith("jar")) {
             return null;
         }
-        final String absPath = classPath.substring(0, classPath.lastIndexOf('!') + 1)
+        // JAR URLs place the resource path after "!" following the archive path.
+        final String absPath = classPath.substring(0, classPath.lastIndexOf(JAR_URL_SEPARATOR) + JAR_URL_SEPARATOR.length())
                 + "/" + path;
         try {
             final URL url = new URL(absPath);


### PR DESCRIPTION
## Summary
- add `JAR_URL_SEPARATOR` constant in `ResourceUtil`
- use the constant instead of literal `!`
- rename `csPath`/`csLower` variables for clarity
- document JAR URL delimiter usage

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f70b0308329b699e3f43747048b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a constant `JAR_URL_SEPARATOR` to represent the "!" separator in JAR URLs used to delimit the archive path from the internal resource path.

### Why are these changes being made?

Using a constant for the JAR URL separator improves code readability and maintainability by avoiding magic strings in the code and allowing easy adjustments if the separator were to ever change. This change helps clarify the functionality concerning JAR URL handling within the `ResourceUtil` class.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->