### PR TITLE
Improve resetPlayerPositions documentation

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -574,9 +574,10 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
 
 
     /**
-     * Invalidate all past player moves data and set last position if not null.
-     * 
-     * @param loc
+     * Invalidate the recorded player move history and reset temporary state.
+     * The given location will be stored as the last known move when not {@code null}.
+     *
+     * @param loc the new last position or {@code null}
      */
     public void resetPlayerPositions(final PlayerLocation loc) {
         resetPlayerPositions();
@@ -586,10 +587,21 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
             lastMove.setWithExtraProperties(loc);
         }
     }
-
-
     /**
-     * Invalidate all past moves data (player).
+     * Invalidate the recorded player move history and clear temporary movement state.
+     * <p>Resets:
+     * <ul>
+     * <li>{@link #sfZeroVdistRepeat}</li>
+     * <li>{@link #sfDirty}</li>
+     * <li>{@link #sfLowJump}</li>
+     * <li>{@link #liftOffEnvelope}</li>
+     * <li>{@link #insideMediumCount}</li>
+     * <li>{@link #lastFrictionHorizontal}</li>
+     * <li>{@link #lastFrictionVertical}</li>
+     * <li>{@link #verticalBounce}</li>
+     * <li>{@link #blockChangeRef}</li>
+     * </ul>
+     * Vehicle consistency is left unchanged.
      */
     private void resetPlayerPositions() {
         playerMoves.invalidate();


### PR DESCRIPTION
## Summary
- expand `resetPlayerPositions` JavaDocs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d2f6411d4832986f5023be6e7e006

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Revise the documentation of the `resetPlayerPositions` methods in `MovingData.java` to more clearly describe their functions and parameters.

### Why are these changes being made?

The previous documentation was unclear and lacked details regarding what these methods reset and the purpose of their parameters. The improved comments aim to clarify the method's function, specifying what parts of a player's movement state are reset, enhancing understanding for future developers working with or maintaining this code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->