### PR TITLE
Fix bunny hop margin and add helper method

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/MagicBunny.java
@@ -203,7 +203,7 @@ public class MagicBunny {
         // Consider fixing resetbunny instead of adding this section.
         // This workaround might be obsolete now.
         final double inc = ServerIsAtLeast1_13 ? 0.03 : 0;
-        final double hopMargin = Magic.wasOnIceRecently(data) ? 1.4 : (data.momentumTick > 0 ? (data.momentumTick > 2 ? 1.0 + inc : 1.11 + inc) : 1.22 + inc);
+        final double hopMargin = calculateHopMargin(data, inc);
 
         if (lastMove.toIsValid && data.getBunnyhopDelay() <= 0 && data.lastbunnyhopDelay > 0
             && lastMove.hDistance > hDistance && baseSpeed > 0.0 && hDistance / baseSpeed < hopMargin) {
@@ -383,7 +383,7 @@ public class MagicBunny {
      * @return the modifier
      */
     public static double modBunny(final boolean headObstructed, final MovingData data) {
-        return  
+        return
                 // Ice (friction takes care with head obstr, so no need to increase the factor.)
                 Magic.wasOnIceRecently(data) ? 1.5415 :
                 // Slimes / beds
@@ -391,5 +391,12 @@ public class MagicBunny {
                 // Ordinary
                 headObstructed ? 1.474 : (data.momentumTick > 0 ? 1.09 : 1.255)
             ;
+    }
+
+    private static double calculateHopMargin(final MovingData data, final double inc) {
+        return Magic.wasOnIceRecently(data) ? 1.4
+                : (data.momentumTick > 0
+                        ? (data.momentumTick > 2 ? 1.0 + inc : 1.11 + inc)
+                        : 1.22 + inc);
     }
 }


### PR DESCRIPTION
## Summary
- refactor margin math in `MagicBunny.bunnyHop`
- extract new helper `calculateHopMargin` for clarity

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685d23afceb08329be04833f989d9933

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the calculation of bunny hop margin by refactoring it into a new helper method `calculateHopMargin`, and clean up redundant trailing whitespace.

### Why are these changes being made?

These changes improve code readability and maintainability by encapsulating the bunny hop margin logic into a dedicated method, making it easier to understand and modify in the future. The removal of redundant whitespace enhances code cleanliness and consistency.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->