### PR TITLE
Refactor DebugPlayerCommand color code handling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/debug/DebugPlayerCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/debug/DebugPlayerCommand.java
@@ -26,7 +26,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.ChatColor;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.command.BaseCommand;
@@ -100,7 +99,7 @@ public class DebugPlayerCommand extends BaseCommand {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String alias, String[] args) {
 
-        String[] colors = prepareColorCodes(sender);
+        String[] colors = getColorCodes(sender);
         String c1 = colors[0];
         String c3 = colors[2];
 
@@ -130,22 +129,9 @@ public class DebugPlayerCommand extends BaseCommand {
         return true;
     }
 
-    private String[] prepareColorCodes(CommandSender sender) {
-        if (sender instanceof Player) {
-            return new String[] {
-                    ChatColor.GRAY.toString(),
-                    ChatColor.BOLD.toString(),
-                    ChatColor.RED.toString(),
-                    ChatColor.ITALIC.toString(),
-                    ChatColor.GOLD.toString(),
-                    ChatColor.WHITE.toString(),
-                    ChatColor.YELLOW.toString() };
-        }
-        return new String[] {"", "", "", "", "", "", ""};
-    }
 
     private Player resolvePlayer(CommandSender sender, String input) {
-        String[] colors = prepareColorCodes(sender);
+        String[] colors = getColorCodes(sender);
         String c3 = colors[2];
         Player player = null;
         if (IdUtil.isValidMinecraftUserName(input)) {
@@ -165,7 +151,7 @@ public class DebugPlayerCommand extends BaseCommand {
     }
 
     private DebugEntry parseDebugEntry(CommandSender sender, String input) {
-        String[] colors = prepareColorCodes(sender);
+        String[] colors = getColorCodes(sender);
         String c3 = colors[2];
         DebugEntry entry = DebugEntry.parseEntry(input);
         if (entry == null) {


### PR DESCRIPTION
## Summary
- reuse `BaseCommand.getColorCodes` in `DebugPlayerCommand`
- remove duplicated helper and unused import

## Testing
- `mvn -q test`
- `mvn -q -DskipTests checkstyle:check pmd:check spotbugs:check` *(fails: SpotBugs errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685d22a63b1c832980242979d697fb83

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `DebugPlayerCommand` by renaming the method `prepareColorCodes` to `getColorCodes` and removing unused import `ChatColor`.

### Why are these changes being made?

The method name was changed to enhance readability and better reflect its functionality, which retrieves color codes for command styling. The unused import was removed to clean up the code and adhere to best practices by eliminating unnecessary dependencies.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->