### PR TITLE
Fix lag adjustment logic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -128,7 +128,9 @@ public class NetStatic {
             // Consider adding a configuration flag to skip lag adaption when running in strict mode.
             final float lag = TickTask.getLag(totalDur, true); // Full seconds range considered.
             // Also consider increasing the allowed maximum for extreme server-side lag conditions.
-            empty = Math.max(0, Math.min(empty, (int) Math.round((lag - 1f) * winNum)));
+            int lagEmpty = (int) Math.round((lag - 1f) * winNum);
+            empty = lagEmpty > 0 ? Math.min(empty, lagEmpty) : empty;
+            empty = Math.max(0, empty);
         }
 
         final double fullCount;


### PR DESCRIPTION
## Summary
- adjust empty window reduction only when server lag exceeds one second

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2ed32cb483299155944dce66e4ca

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Adjust the lag compensation logic in `morePacketsCheck` by separately calculating the `lagEmpty` variable and ensuring `empty` is non-negative.

### Why are these changes being made?

These changes aim to improve the accuracy and reliability of lag adjustment by handling cases where calculated lag might unrealistically decrease allowed empty slots, ensuring `empty` is not reduced below zero. This prevents excessive restriction on packet handling during instances of server-side lag, improving gameplay experience in lag-heavy scenarios.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->