### PR TITLE
Add addPassenger reflection check

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
@@ -33,8 +33,12 @@ public class EntityAccessVehicleMultiPassenger implements IEntityAccessVehicle {
      * @return Instance or {@code null} if not supported.
      */
     public static EntityAccessVehicleMultiPassenger createIfSupported() {
-        // Ensure the method signature matches List<Entity> for getPassengers.
-        if (ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class) == null) {
+        // Ensure both getPassengers and addPassenger methods exist.
+        boolean hasGetPassengers =
+                ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class) != null;
+        boolean hasAddPassenger =
+                ReflectionUtil.getMethodNoArgs(Entity.class, "addPassenger", Entity.class) != null;
+        if (!hasGetPassengers || !hasAddPassenger) {
             return null;
         }
         return new EntityAccessVehicleMultiPassenger();

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
@@ -1,0 +1,60 @@
+package fr.neatmonster.nocheatplus.compat.bukkit;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.bukkit.entity.Entity;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+
+public class TestEntityAccessVehicleMultiPassenger {
+
+    private static List<Entity> dummyPassengers() { return null; }
+    private static boolean dummyAddPassenger() { return true; }
+
+    @Test
+    public void testMissingGetPassengers() throws Exception {
+        Method dummyAdd = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyAddPassenger");
+        try (MockedStatic<ReflectionUtil> util = mockStatic(ReflectionUtil.class)) {
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class))
+                    .thenReturn(null);
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "addPassenger", Entity.class))
+                    .thenReturn(dummyAdd);
+            EntityAccessVehicleMultiPassenger access = EntityAccessVehicleMultiPassenger.createIfSupported();
+            assertNull(access);
+        }
+    }
+
+    @Test
+    public void testMissingAddPassenger() throws Exception {
+        Method dummyGet = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyPassengers");
+        try (MockedStatic<ReflectionUtil> util = mockStatic(ReflectionUtil.class)) {
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class))
+                    .thenReturn(dummyGet);
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "addPassenger", Entity.class))
+                    .thenReturn(null);
+            EntityAccessVehicleMultiPassenger access = EntityAccessVehicleMultiPassenger.createIfSupported();
+            assertNull(access);
+        }
+    }
+
+    @Test
+    public void testBothMethodsPresent() throws Exception {
+        Method dummyGet = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyPassengers");
+        Method dummyAdd = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyAddPassenger");
+        try (MockedStatic<ReflectionUtil> util = mockStatic(ReflectionUtil.class)) {
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class))
+                    .thenReturn(dummyGet);
+            util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "addPassenger", Entity.class))
+                    .thenReturn(dummyAdd);
+            EntityAccessVehicleMultiPassenger access = EntityAccessVehicleMultiPassenger.createIfSupported();
+            assertNotNull(access);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `EntityAccessVehicleMultiPassenger.createIfSupported` checks `addPassenger`
- return `null` when either method is absent
- test `createIfSupported` when one or both methods are present

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check com.github.spotbugs:spotbugs-maven-plugin:4.9.3.0:check` *(fails: Medium spotbugs issues)*

------
https://chatgpt.com/codex/tasks/task_b_685d2f4ff7d88329bedf395a2d88bd5d