### PR TITLE
Remove redundant null check in BlockBreakListener

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -415,9 +415,6 @@ public class BlockBreakListener extends CheckListener {
         //        	return;
         //        }
 
-        if (block == null) {
-            return;
-        }
 
         final int tick = TickTask.getTick();
         // Skip if already set to the same block without breaking within one tick difference.


### PR DESCRIPTION
## Summary
- remove the null check for block in `checkBlockDamage`
- run the full build including tests and static analysis

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2ed7128c832997e432fa5bb32d5e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove redundant null check for `block` in the `BlockBreakListener` class.

### Why are these changes being made?

The removed null check for `block` was unnecessary as the calling context guarantees `block` is non-null, simplifying the method and improving code readability. This change helps maintain cleaner code by eliminating dead code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->