### PR TITLE
Fix null attribute defaults

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BukkitAttributeAccess.java
@@ -82,7 +82,7 @@ public class BukkitAttributeAccess implements IAttributeAccess {
     public double getSpeedAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
         if (attrInst == null) {
-            return Double.MAX_VALUE;
+            return 1.0;
         }
         final double val = attrInst.getValue() / attrInst.getBaseValue();
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.ID_SPRINT_BOOST);
@@ -93,7 +93,7 @@ public class BukkitAttributeAccess implements IAttributeAccess {
     public double getSprintAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
         if (attrInst == null) {
-            return Double.MAX_VALUE;
+            return 1.0;
         }
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.ID_SPRINT_BOOST);
         return mod == null ? 1.0 : getMultiplier(mod);

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/NSBukkitAttributeAccess.java
@@ -81,7 +81,7 @@ public class NSBukkitAttributeAccess implements IAttributeAccess {
     public double getSpeedAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
         if (attrInst == null) {
-            return Double.MAX_VALUE;
+            return 1.0;
         }
         final double val = attrInst.getValue() / attrInst.getBaseValue();
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.NSID_SPRINT_BOOST);
@@ -92,7 +92,7 @@ public class NSBukkitAttributeAccess implements IAttributeAccess {
     public double getSprintAttributeMultiplier(final Player player) {
         final AttributeInstance attrInst = player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
         if (attrInst == null) {
-            return Double.MAX_VALUE;
+            return 1.0;
         }
         final AttributeModifier mod = getModifier(attrInst, AttribUtil.NSID_SPRINT_BOOST);
         return mod == null ? 1.0 : getMultiplier(mod);

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
@@ -23,7 +23,7 @@ public class TestBukkitAttributeAccess {
         
         Player player = mock(Player.class);
         when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(Double.MAX_VALUE, access.getSpeedAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestBukkitAttributeAccess {
         
         Player player = mock(Player.class);
         when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(Double.MAX_VALUE, access.getSprintAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
     }
 
     @Test

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
@@ -23,7 +23,7 @@ public class TestNSBukkitAttributeAccess {
         
         Player player = mock(Player.class);
         when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(Double.MAX_VALUE, access.getSpeedAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class TestNSBukkitAttributeAccess {
         
         Player player = mock(Player.class);
         when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(Double.MAX_VALUE, access.getSprintAttributeMultiplier(player), 0.0);
+        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- avoid Double.MAX_VALUE when speed attributes are missing
- update attribute access tests

## Testing
- `mvn --no-transfer-progress --errors verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f5061188329a3c61a65facc6f69