### PR TITLE
Handle null display names in AllViolationsHook

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
@@ -134,8 +134,14 @@ public class AllViolationsHook implements NCPHook, ILast, IStats {
         builder.append("[VL] [" + checkType.toString() + "] ");
         builder.append("[" + ChatColor.YELLOW + playerName);
         builder.append(ChatColor.WHITE + "] ");
-        final String displayName = Objects.requireNonNull(ChatColor.stripColor(player.getDisplayName()), "displayName").trim();
-        if (!playerName.equals(displayName)) {
+        String displayName = player.getDisplayName();
+        if (displayName != null) {
+            displayName = ChatColor.stripColor(displayName);
+            if (displayName != null) {
+                displayName = displayName.trim();
+            }
+        }
+        if (displayName != null && !playerName.equals(displayName)) {
             builder.append("[->" + ChatColor.YELLOW + displayName + ChatColor.WHITE + "] ");
         }
         builder.append("VL=" + StringUtil.fdec1.format(info.getTotalVl()));

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestAllViolationsHook.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestAllViolationsHook.java
@@ -1,0 +1,67 @@
+package fr.neatmonster.nocheatplus;
+
+import fr.neatmonster.nocheatplus.hooks.allviolations.AllViolationsHook;
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.access.IViolationInfo;
+import fr.neatmonster.nocheatplus.logging.LogManager;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * Tests for {@link AllViolationsHook}.
+ */
+public class TestAllViolationsHook {
+
+    private static Player createPlayer(String name, String displayName) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "getName":
+                    return name;
+                case "getDisplayName":
+                    return displayName;
+                default:
+                    Class<?> r = method.getReturnType();
+                    if (r == boolean.class) return false;
+                    if (r.isPrimitive()) return 0;
+                    return null;
+            }
+        };
+        return (Player) Proxy.newProxyInstance(Player.class.getClassLoader(), new Class[]{Player.class}, h);
+    }
+
+    private static class DummyAPI extends PluginTests.UnitTestNoCheatPlusAPI {
+        final LogManager logManager = (LogManager) Proxy.newProxyInstance(
+                LogManager.class.getClassLoader(), new Class[]{LogManager.class}, (p, m, a) -> null);
+
+        @Override
+        public LogManager getLogManager() {
+            return logManager;
+        }
+    }
+
+    @Test
+    public void testNullDisplayNameLogging() throws Exception {
+        NCPAPIProvider.setNoCheatPlusAPI(new DummyAPI());
+        AllViolationsHook hook = new AllViolationsHook();
+        Method log = AllViolationsHook.class.getDeclaredMethod("log", CheckType.class, Player.class, IViolationInfo.class, boolean.class, boolean.class);
+        log.setAccessible(true);
+        IViolationInfo info = (IViolationInfo) Proxy.newProxyInstance(
+                IViolationInfo.class.getClassLoader(), new Class[]{IViolationInfo.class},
+                (p, m, a) -> {
+                    switch (m.getName()) {
+                        case "getTotalVl":
+                        case "getAddedVl":
+                            return 0.0;
+                        default:
+                            return null;
+                    }
+                });
+        Player player = createPlayer("Dummy", null);
+        // Should not throw.
+        log.invoke(hook, CheckType.ALL, player, info, false, false);
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null player display names before stripping color codes
- add regression test for AllViolationsHook when display names are null

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2ed854308329b05884e5bfc30921

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Handle null player display names in the `AllViolationsHook` class by adding null checks and update related unit tests to validate this behavior.

### Why are these changes being made?

In some cases, a player's display name can be null, which previously could lead to a `NullPointerException`. This change ensures that display names are safely handled, preventing potential errors. Unit tests have also been added to verify that the logging function correctly processes players with null display names without throwing exceptions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->