### PR TITLE
Fix Counters to respect added count values

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Counters.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/stats/Counters.java
@@ -141,7 +141,7 @@ public class Counters {
      */
     public void add(int id, int count, boolean isPrimaryThread) {
         if (isPrimaryThread) {
-            ptCounts[id].increment();
+            ptCounts[id].add(count);
         } else {
             addSynchronized(id, count);
         }
@@ -155,7 +155,7 @@ public class Counters {
      *            Count to add.
      */
     public void addPrimaryThread(int id, int count) {
-        ptCounts[id].increment();
+        ptCounts[id].add(count);
     }
 
     /**

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCounters.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestCounters.java
@@ -1,0 +1,29 @@
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.stats.Counters;
+
+public class TestCounters {
+
+    @Test
+    public void testAddMultipleCounts() {
+        Counters counters = new Counters();
+        int id = counters.registerKey("foo");
+        counters.addPrimaryThread(id, 5);
+        counters.add(id, 3, true);
+        counters.add(id, 2, false);
+
+        Map<String, Integer> pt = counters.getPrimaryThreadCounts();
+        Map<String, Integer> sy = counters.getSynchronizedCounts();
+        Map<String, Integer> merged = counters.getMergedCounts();
+
+        assertEquals(Integer.valueOf(8), pt.get("foo"));
+        assertEquals(Integer.valueOf(2), sy.get("foo"));
+        assertEquals(Integer.valueOf(10), merged.get("foo"));
+    }
+}


### PR DESCRIPTION
## Summary
- update Counters to add whole count on primary thread
- add unit test ensuring non-unit counts accumulate

## Testing
- `mvn -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2ed8029c8329ab262349b3788cd7