### PR TITLE
Optimize firework boost detection

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingData.java
@@ -221,6 +221,8 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
     public int fireworksBoostTickNeedCheck = 0;
     /** Expire at this tick. */
     public int fireworksBoostTickExpire = 0;
+    /** Quick access flag for an active firework boost. */
+    public boolean hasFireworkBoost = false;
 
     // *----------Data of the MorePackets check----------*
     /** Packet frequency count. */
@@ -942,8 +944,9 @@ public class MovingData extends ACheckData implements IDataOnRemoveSubCheckData,
         // Velocity
         removeAllVelocity();
         // Elytra boost best fits velocity / effects.
-        fireworksBoostDuration = 0; 
+        fireworksBoostDuration = 0;
         fireworksBoostTickExpire = 0;
+        hasFireworkBoost = false;
         // Horizontal buffer.
         sfHorizontalBuffer = 0.0;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -1189,6 +1189,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void handleFireworkBoost(final Player player, final PlayerMoveData lastMove,
             final PlayerMoveData thisMove, final int tick, final MovingData data, final MovingConfig cc) {
         if (data.fireworksBoostDuration <= 0) {
+            data.hasFireworkBoost = false;
             return;
         }
         final int remaining = data.fireworksBoostDuration;
@@ -1199,10 +1200,12 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 || data.fireworksBoostTickExpire < tick;
         if (invalidBoost) {
             data.fireworksBoostDuration = 0;
+            data.hasFireworkBoost = false;
             ElytraBoostHandler.logBoostEvent(player, "reset", tick, remaining);
         } else {
             data.fireworksBoostDuration--;
             if (data.fireworksBoostDuration == 0) {
+                data.hasFireworkBoost = false;
                 ElytraBoostHandler.logBoostEvent(player, "ended", tick, remaining);
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/helper/ElytraBoostHandler.java
@@ -51,6 +51,7 @@ public final class ElytraBoostHandler {
         mData.fireworksBoostDuration = ticks;
         mData.fireworksBoostTickNeedCheck = ticks - 1;
         mData.fireworksBoostTickExpire = tick + ticks;
+        mData.hasFireworkBoost = true;
         logBoostEvent(context.player(), "started", tick, ticks);
         return true;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/AirWorkarounds.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/AirWorkarounds.java
@@ -614,7 +614,7 @@ private static boolean oddLiquid(final double yDistance, final double yDistDiffE
 
     private static boolean isFireworkBoostTransition(final MovingData data, final PlayerMoveData lastMove,
                                                      final double yDistance) {
-        return data.fireworksBoostDuration > 0 && data.keepfrictiontick < 0
+        return data.hasFireworkBoost && data.keepfrictiontick < 0
                 && lastMove.toIsValid && yDistance - lastMove.yDistance > -0.7;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -833,7 +833,8 @@ public class CreativeFly extends Check {
      */
     private boolean handleFireworkBoostAscend(final double yDistance, final double limitV,
             final PlayerMoveData lastMove, final MovingData data) {
-        if (yDistance > limitV && data.fireworksBoostDuration > 0 && lastMove.toIsValid
+        boolean boostAscend = false;
+        if (data.hasFireworkBoost && yDistance > limitV && lastMove.toIsValid
                 && (
                         yDistance >= lastMove.yDistance
                                 || yDistance - lastMove.yDistance < Magic.GRAVITY_MAX
@@ -845,9 +846,9 @@ public class CreativeFly extends Check {
                 && yDistance < 1.67) {
             /* Additional checks for fireworks boost could be implemented here. */
             tags.add("fw_boost_asc");
-            return true;
+            boostAscend = true;
         }
-        return false;
+        return boostAscend;
     }
 
     /**

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/MovingUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/MovingUtil.java
@@ -191,8 +191,8 @@ public class MovingUtil {
          */
 
         // Only the web can stop a player who isn't propelled by a rocket.
-        return data.fireworksBoostDuration > 0 || !BlockProperties.collides(fromLocation.getBlockCache(), 
-                fromLocation.getMinX(), fromLocation.getMinY(), fromLocation.getMinZ(), 
+        return data.hasFireworkBoost || !BlockProperties.collides(fromLocation.getBlockCache(),
+                fromLocation.getMinX(), fromLocation.getMinY(), fromLocation.getMinZ(),
                 fromLocation.getMaxX(), fromLocation.getMinY() + 0.6, fromLocation.getMaxZ(),
                 BlockFlags.F_COBWEB);
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/moving/magic/TestShortMoveExemptions.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/moving/magic/TestShortMoveExemptions.java
@@ -52,6 +52,7 @@ public class TestShortMoveExemptions {
         WorkaroundSet ws = createWorkaroundSet();
         MovingData data = newData(ws);
         data.fireworksBoostDuration = 5;
+        data.hasFireworkBoost = true;
         data.keepfrictiontick = -1;
         PlayerMoveData lastMove = new PlayerMoveData();
         lastMove.toIsValid = true;


### PR DESCRIPTION
## Summary
- cache active firework boost state in `MovingData`
- set/unset new flag when boosting starts or stops
- use the flag in air workaround and movement util
- check the flag first in CreativeFly firework logic
- update unit test for firework boost transitions

## Testing
- `mvn -q -DskipITs -DskipNCPchecks=true test`
- `mvn -q -DskipTests -DskipITs -DskipNCPchecks=true checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d42a35c188329a9e967e79af4fd80

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a boolean flag `hasFireworkBoost` to optimize the detection of active firework boosts across the movement checks system, replacing the reliance on `fireworksBoostDuration` alone.

### Why are these changes being made?

The current implementation checks `fireworksBoostDuration` to determine if a firework boost is active, which can be error-prone and inefficient, particularly for conditional logic centering around quick checks for boost status. Adding a dedicated boolean flag `hasFireworkBoost` improves code clarity and performance by providing direct access to boost status, allowing for more efficient evaluations and potentially reducing computational overhead in boost checks.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in detecting active firework boosts during player movement, ensuring the boost state is correctly tracked and reset in all relevant scenarios.

* **Tests**
  * Updated tests to validate the new firework boost tracking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->