### PR TITLE
Clarify manhattan distance semantics

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/TrigUtil.java
@@ -485,7 +485,11 @@ public class TrigUtil {
     }
 
     /**
-     * Manhattan.
+     * Manhattan distance on the horizontal plane using exact world coordinates.
+     * <p>
+     * Unlike other variants this method does not round the coordinates to block
+     * positions. Callers should convert to block coordinates separately if they
+     * require discrete values.
      *
      * @param x1
      *            the x1


### PR DESCRIPTION
## Summary
- clarify that `TrigUtil.manhattan(double x1, double z1, double x2, double z2)` operates on world coordinates without rounding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d2f50ec24832981af0c97410cd4fb