### PR TITLE
Cache bucket scores in NetStatic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -51,8 +51,13 @@ public class NetStatic {
         int empty = 0;
         boolean firstUsed = false;
         boolean counting = false;
+        final float[] bucketScores = new float[winNum];
+        for (int i = 0; i < winNum; i++) {
+            bucketScores[i] = packetFreq.bucketScore(i);
+        }
         for (int i = 1; i < winNum; i++) {
-            if (packetFreq.bucketScore(i) > 0f) {
+            final float bucket = bucketScores[i];
+            if (bucket > 0f) {
                 if (!firstUsed) {
                     firstUsed = true;
                 } else if (!counting) {


### PR DESCRIPTION
## Summary
- cache bucket scores before iterating
- use cached scores inside computeBurnInfo

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685e87c50db08329996e266515d3906e