### PR TITLE
Clean up WrongBlock and fix Reach

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -216,7 +216,7 @@ public class BlockBreakListener extends CheckListener {
             final Block block, final BlockBreakConfig cc, final BlockBreakData data,
             final IPlayerData pData) {
         if (!result.cancelled && wrongBlock.isEnabled(player, pData)
-                && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
+                && wrongBlock.check(player, block, cc, data, pData)) {
             result.cancelled = true;
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -40,13 +40,11 @@ public class WrongBlock extends Check {
      * @param block
      * @param data 
      * @param cc 
-     * @param isInstaBreak 
      * @return
      */
-    
+
     public boolean check(final Player player, final Block block,
-            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData,
-            final AlmostBoolean isInstaBreak) {
+            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
 
         boolean cancel = false;
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Reach.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/Reach.java
@@ -368,25 +368,6 @@ public class Reach extends Check {
 
     return cancel;
 }
-    /**
-
-        final double violation = lenpRel - context.distanceLimit;
-        boolean cancel = false;
-
-        if (violation > 0) {
-            cancel = handleViolation(player, lenpRel, violation, data, cc, pData);
-        } else if (lenpRel - context.distanceLimit * data.reachMod > 0) {
-            cancel = handleSilentViolation(player, lenpRel, context.distanceLimit,
-                    data.reachMod, cc, data);
-        } else {
-            data.reachVL *= 0.8D;
-        }
-
-        updateReachModifier(lenpRel, context, data, cc);
-        sendDebugInfo(player, damaged, traceEntry, lenpRel, data, pData);
-
-        return cancel;
-    }
 
     /**
      * Update the dynamic reach modifier based on the last result.


### PR DESCRIPTION
## Summary
- remove the unused `isInstaBreak` parameter from `WrongBlock.check`
- update `BlockBreakListener` for the new signature
- drop duplicated code from `Reach` that caused compilation errors

## Testing
- `mvn -q -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685e7e7268dc8329b95923c37b53e458

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Remove the `isInstaBreak` parameter from the `WrongBlock` check method and clean up its references; remove redundant code in the `Reach` class.

### Why are these changes being made?
The removal of the `isInstaBreak` parameter simplifies the `WrongBlock` check method as it is not used within the method body, improving code maintainability. The redundant code in the `Reach` class is being removed to enhance code clarity and eliminate any dead code that does not contribute to the functionality.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->