### PR TITLE
Fix overshoot in burnStart logic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -48,21 +48,27 @@ public class NetStatic {
     static BurnInfo computeBurnInfo(final ActionFrequency packetFreq) {
         final int winNum = packetFreq.numberOfBuckets();
         int burnStart = winNum;
-        int empty = 0;
-        boolean firstUsed = false;
-        boolean counting = false;
+        boolean foundFirst = false;
         for (int i = 1; i < winNum; i++) {
             if (packetFreq.bucketScore(i) > 0f) {
-                if (!firstUsed) {
-                    firstUsed = true;
-                } else if (!counting) {
+                if (!foundFirst) {
+                    foundFirst = true;
+                } else {
                     burnStart = i;
-                    counting = true;
+                    break;
                 }
-            } else if (counting) {
-                empty++;
             }
         }
+
+        int empty = 0;
+        if (burnStart < winNum) {
+            for (int i = burnStart + 1; i < winNum; i++) {
+                if (packetFreq.bucketScore(i) <= 0f) {
+                    empty++;
+                }
+            }
+        }
+
         return new BurnInfo(burnStart, empty);
     }
 


### PR DESCRIPTION
## Summary
- refine burnStart loop to break at second occupied bucket
- count empty buckets after burnStart outside the main loop

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_b_685e885494308329b10dbbdbdf42e156