### PR TITLE
Introduce JAR_URL_SEPARATOR constant

### DIFF
--- a/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
+++ b/NCPBuildBase/src/main/java/fr/neatmonster/nocheatplus/utilities/build/ResourceUtil.java
@@ -27,6 +27,12 @@ import fr.neatmonster.nocheatplus.utilities.build.URLUtil;
 
 public class ResourceUtil {
 
+    /**
+     * Separator between the JAR file path and the internal resource path
+     * in a JAR URL, e.g. "jar:file:/plugin.jar!/path".
+     */
+    private static final String JAR_URL_SEPARATOR = "!";
+
     private ResourceUtil() {
     }
 
@@ -47,14 +53,15 @@ public class ResourceUtil {
         if (codeSource == null) {
             return null;
         }
-        final String csPath = codeSource.getLocation().getPath();
-        if (!URLUtil.isJarURL(csPath)) {
+        final String codeSourcePath = codeSource.getLocation().getPath();
+        if (!URLUtil.isJarURL(codeSourcePath)) {
             return null;
         }
         if (!classPath.startsWith("jar")) {
             return null;
         }
-        final String absPath = classPath.substring(0, classPath.lastIndexOf('!') + 1)
+        // JAR URLs separate the file part and the entry path with '!'.
+        final String absPath = classPath.substring(0, classPath.lastIndexOf(JAR_URL_SEPARATOR) + 1)
                 + "/" + path;
         try {
             final URL url = new URL(absPath);


### PR DESCRIPTION
## Summary
- add `JAR_URL_SEPARATOR` constant for jar URL syntax
- use the constant when building jar resource paths
- rename `csPath` to `codeSourcePath`
- document jar URL delimiter usage

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685e813fa8388329a0b7a5e00e6ddaec

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a `JAR_URL_SEPARATOR` constant in the `ResourceUtil` class to replace the hardcoded '!' character, thereby improving code readability and maintainability.

### Why are these changes being made?

Centralizing the JAR URL separator as a constant makes it easier to update this part of the codebase if the separator changes in the future, and enhances code clarity by giving semantic meaning to what the '!' character represents, reducing magic values in the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->