### PR TITLE
Handle pre-release server versions

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_21.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/init/vanilla/BlocksMC1_21.java
@@ -48,7 +48,7 @@ public class BlocksMC1_21 implements BlockPropertiesSetup {
             BlockInit.setAs("TEST_INSTANCE_BLOCK", Material.STONE);
         }
 
-        if (ServerVersion.compareMinecraftVersion("1.21") >= 0) {
+        if (ServerVersion.compareMinecraftVersion("1.21.0") >= 0) {
             BlockInit.setAsIfExists("RESIN_BLOCK", Material.ANDESITE);
             BlockInit.setAsIfExists("RESIN_BRICKS", Material.ANDESITE);
             BlockInit.setAsIfExists("RESIN_BRICK_SLAB", Material.ANDESITE_SLAB);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/versions/ServerVersion.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/versions/ServerVersion.java
@@ -132,6 +132,15 @@ public class ServerVersion {
      */
     private static String parseMinecraftVersionGeneric(String serverVersion) {
         String lcServerVersion = serverVersion.trim().toLowerCase();
+
+        // Detect pre-release versions explicitly.
+        java.util.regex.Matcher preMatcher = java.util.regex.Pattern
+                .compile("(\\d+(?:\\.\\d+)*-pre\\d*)")
+                .matcher(lcServerVersion);
+        if (preMatcher.find()) {
+            return preMatcher.group(1);
+        }
+
         for (String candidate : new String[] {
                 GenericVersion.parseVersionDelimiters(lcServerVersion, "(mc:", ")"),
                 GenericVersion.parseVersionDelimiters(lcServerVersion, "(mc:", "-pre"),
@@ -179,6 +188,17 @@ public class ServerVersion {
         return minecraftVersion;
     }
 
+    private static String stripPreRelease(String version) {
+        if (version == null) {
+            return null;
+        }
+        int idx = version.indexOf("-pre");
+        if (idx != -1) {
+            return version.substring(0, idx);
+        }
+        return version;
+    }
+
     /**
      * Convenience for compareVersions(getMinecraftVersion(), version).
      * 
@@ -188,7 +208,7 @@ public class ServerVersion {
      *         Minecraft version is higher.
      */
     public static int compareMinecraftVersion(String toVersion) {
-        return GenericVersion.compareVersions(getMinecraftVersion(), toVersion);
+        return GenericVersion.compareVersions(stripPreRelease(getMinecraftVersion()), toVersion);
     }
 
     /**
@@ -205,7 +225,7 @@ public class ServerVersion {
      * @return
      */
     public static boolean isMinecraftVersionBetween(String versionLow, boolean includeLow, String versionHigh, boolean includeHigh) {
-        return GenericVersion.isVersionBetween(getMinecraftVersion(), versionLow, includeLow, versionHigh, includeHigh);
+        return GenericVersion.isVersionBetween(stripPreRelease(getMinecraftVersion()), versionLow, includeLow, versionHigh, includeHigh);
     }
 
     /**
@@ -230,7 +250,7 @@ public class ServerVersion {
         if (mcVersion == GenericVersion.UNKNOWN_VERSION) {
             return valueUnknown;
         } else {
-            final int cmp = GenericVersion.compareVersions(mcVersion, cmpVersion);
+            final int cmp = GenericVersion.compareVersions(stripPreRelease(mcVersion), cmpVersion);
             if (cmp == 0) {
                 return valueEQ;
             } else if (cmp < 0) {

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestMinecraftVersion.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestMinecraftVersion.java
@@ -65,4 +65,14 @@ public class TestMinecraftVersion {
         }
     }
 
+    @Test
+    public void testPreReleaseCheck() {
+        String parsed = ServerVersion.parseMinecraftVersion("1.21-pre1");
+        ServerVersion.setMinecraftVersion(parsed);
+        if (ServerVersion.compareMinecraftVersion("1.21.0") >= 0) {
+            fail("Pre-release should not satisfy the release check.");
+        }
+        ServerVersion.setMinecraftVersion(GenericVersion.UNKNOWN_VERSION);
+    }
+
 }

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/compat/registry/AttributeAccessFactory.java
@@ -36,7 +36,7 @@ public class AttributeAccessFactory {
         final IAttributeAccess fallBackReflect = new DummyAttributeAccess();
         IAttributeAccess fallBackDedicated = null;
         try {
-            fallBackDedicated = ServerVersion.compareMinecraftVersion("1.21") < 0
+            fallBackDedicated = ServerVersion.compareMinecraftVersion("1.21.0") < 0
                     ? BukkitAttributeAccess.createIfSupported()
                     : NSBukkitAttributeAccess.createIfSupported();
         }


### PR DESCRIPTION
## Summary
- differentiate pre-release versions in server version checks
- preserve `-pre` suffix during parsing so they don't map to final releases
- ensure block setup and attribute checks use full `1.21.0` comparison
- test that `1.21-pre1` fails release check

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f628918832980c07accc3efbde2

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the version comparison logic to handle pre-release server versions by modifying the `ServerVersion` class and adding tests to validate the behavior, ensuring pre-release versions do not qualify as stable releases.

### Why are these changes being made?

Pre-release versions were previously not distinguished from stable server versions in version comparisons, causing potential compatibility issues. This change explicitly detects and handles pre-release versions to improve accuracy in determining server compatibility, ensuring that features meant for stable versions are not prematurely activated.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->