### PR TITLE
Clean up WrongBlock check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -214,7 +214,7 @@ public class BlockBreakListener extends CheckListener {
             final Block block, final BlockBreakConfig cc, final BlockBreakData data,
             final IPlayerData pData) {
         if (!result.cancelled && wrongBlock.isEnabled(player, pData)
-                && wrongBlock.check(player, block, cc, data, pData, isInstaBreak)) {
+                && wrongBlock.check(player, block, cc, data, pData)) {
             result.cancelled = true;
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/WrongBlock.java
@@ -38,14 +38,12 @@ public class WrongBlock extends Check {
      * @param player
      * @param block
      * @param data 
-     * @param cc 
-     * @param isInstaBreak 
+     * @param cc
      * @return
      */
-    
+
     public boolean check(final Player player, final Block block,
-            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData,
-            final AlmostBoolean isInstaBreak) {
+            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
 
         boolean cancel = false;
 


### PR DESCRIPTION
## Summary
- remove unused `isInstaBreak` parameter in `WrongBlock.check`
- update call site in `BlockBreakListener`
- clarify Javadoc for `WrongBlock.check`

## Testing
- `mvn -P checks clean verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f717f808329b2a9a71665aa41bc