### PR TITLE
Handle failed passenger addition

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -386,7 +386,10 @@ public class PassengerUtil {
         if (data.vehicleSetPassengerTaskId == null) {
             if (vehicle.getType() == EntityType.BOAT) {
                 if (!handleVehicle.getHandle().addPassenger(player, vehicle)) {
-                    vehicle.eject();
+                    if (debug) {
+                        CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
+                                "Failed to add passenger to boat.");
+                    }
                     // Not schedule set passenger for boat due to location async
                 }
             } else if (scheduleDelay) {

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
@@ -4,8 +4,12 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -13,10 +17,15 @@ import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Test;
 
+import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
 import fr.neatmonster.nocheatplus.components.registry.event.IHandle;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
+import fr.neatmonster.nocheatplus.logging.LogManager;
+import fr.neatmonster.nocheatplus.logging.LoggerID;
+import fr.neatmonster.nocheatplus.logging.StreamID;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
 
 public class PassengerUtilTest {
 
@@ -35,6 +44,29 @@ public class PassengerUtilTest {
             called = true;
             return true;
         }
+    }
+
+    private static class TestLogManager implements LogManager {
+        final List<String> messages = new ArrayList<>();
+        @Override public void debug(StreamID streamID, String message) { messages.add(message); }
+        @Override public void info(StreamID streamID, String message) {}
+        @Override public void warning(StreamID streamID, String message) {}
+        @Override public void severe(StreamID streamID, String message) {}
+        @Override public void log(StreamID streamID, java.util.logging.Level level, String message) {}
+        @Override public void debug(StreamID streamID, Throwable t) {}
+        @Override public void info(StreamID streamID, Throwable t) {}
+        @Override public void warning(StreamID streamID, Throwable t) {}
+        @Override public void severe(StreamID streamID, Throwable t) {}
+        @Override public void log(StreamID streamID, java.util.logging.Level level, Throwable t) {}
+        @Override public StreamID getVoidStreamID() { return new StreamID("void"); }
+        @Override public StreamID getInitStreamID() { return new StreamID("init"); }
+        @Override public String getDefaultPrefix() { return "test"; }
+        @Override public boolean hasLogger(String name) { return false; }
+        @Override public boolean hasLogger(LoggerID loggerID) { return false; }
+        @Override public LoggerID getLoggerID(String name) { return new LoggerID(name); }
+        @Override public boolean hasStream(String name) { return false; }
+        @Override public boolean hasStream(StreamID streamID) { return false; }
+        @Override public StreamID getStreamID(String name) { return new StreamID(name); }
     }
 
     private sun.misc.Unsafe unsafe;
@@ -91,5 +123,46 @@ public class PassengerUtilTest {
         MovingData data = newData();
         sched.invoke(util, player, vehicle, cfg, data, false);
         assertTrue(access.called);
+    }
+
+    @Test
+    public void testScheduleSetPassengerBoatAddFailLogsDebug() throws Exception {
+        DummyVehicleAccess access = new DummyVehicleAccess() {
+            @Override public boolean addPassenger(Entity entity, Entity vehicle) { called = true; return false; }
+        };
+        PassengerUtil util = newUtil(access);
+        TestLogManager log = new TestLogManager();
+        InvocationHandler handler = (proxy, method, args) -> {
+            if (method.getName().equals("getLogManager")) return log;
+            return defaultValue(method.getReturnType());
+        };
+        NoCheatPlusAPI api = (NoCheatPlusAPI) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class[]{NoCheatPlusAPI.class}, handler);
+        Field apiField = NCPAPIProvider.class.getDeclaredField("noCheatPlusAPI");
+        apiField.setAccessible(true);
+        apiField.set(null, api);
+        Method sched = PassengerUtil.class.getDeclaredMethod("handlePassengerScheduling", Player.class,
+                Entity.class, MovingConfig.class, MovingData.class, boolean.class);
+        sched.setAccessible(true);
+        Player player = mock(Player.class);
+        Entity vehicle = mock(Entity.class);
+        when(vehicle.getType()).thenReturn(EntityType.BOAT);
+        MovingConfig cfg = newConfig();
+        MovingData data = newData();
+        sched.invoke(util, player, vehicle, cfg, data, true);
+        assertTrue(access.called);
+        assertEquals(2, log.messages.size());
+        assertTrue(log.messages.get(0).contains("Failed to add passenger"));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) return null;
+        if (type == boolean.class) return false;
+        if (type == char.class) return '\0';
+        if (type == byte.class || type == short.class || type == int.class) return 0;
+        if (type == long.class) return 0L;
+        if (type == float.class) return 0f;
+        if (type == double.class) return 0d;
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- improve PassengerUtil: debug log on failed addPassenger instead of ejecting vehicle
- add unit test for debug logging when boat passenger addition fails

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q -DskipTests=true checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685dd3962c048329ac574d47c7d94091