### PR TITLE
Validate tick order in fight listener

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -364,18 +364,16 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         return new TraceResult(violation, latencyEstimate, successEntry);
     }
 
+    private static final TargetMoveInfo DEFAULT_TARGET_MOVE_INFO = new TargetMoveInfo(0, 0.0, 0, 0.0);
+
     /**
      * Calculate relative movement of the damaged entity since last attack.
      */
     private TargetMoveInfo computeTargetMoveInfo(final FightData data, final Location damagedLoc,
                                                  final int tick, final boolean worldChanged) {
 
-        if (data == null || damagedLoc == null) {
-            return new TargetMoveInfo(0, 0.0, 0, 0.0);
-        }
-        if (data.lastAttackedX == Double.MAX_VALUE || tick < data.lastAttackTick
-                || worldChanged || tick - data.lastAttackTick > 20) {
-            return new TargetMoveInfo(0, 0.0, 0, 0.0);
+        if (!isValidTargetMoveInput(data, damagedLoc, tick, worldChanged)) {
+            return DEFAULT_TARGET_MOVE_INFO;
         }
         final int age = tick - data.lastAttackTick;
         final double move = TrigUtil.distance(data.lastAttackedX, data.lastAttackedZ,
@@ -383,6 +381,21 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         final long msAge = (long) (50f * TickTask.getLag(50L * age, true) * (float) age);
         final double normalized = msAge == 0 ? move : move * Math.min(20.0, 1000.0 / (double) msAge);
         return new TargetMoveInfo(age, move, msAge, normalized);
+    }
+
+    private boolean isValidTargetMoveInput(final FightData data, final Location damagedLoc,
+                                           final int tick, final boolean worldChanged) {
+        if (data == null || damagedLoc == null) {
+            return false;
+        }
+        if (worldChanged || data.lastAttackedX == Double.MAX_VALUE) {
+            return false;
+        }
+        if (tick < data.lastAttackTick) {
+            return false;
+        }
+        final int age = tick - data.lastAttackTick;
+        return age <= 20;
     }
 
     /**

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/fight/ComputeTargetMoveInfoTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/fight/ComputeTargetMoveInfoTest.java
@@ -1,0 +1,59 @@
+package fr.neatmonster.nocheatplus.checks.fight;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.bukkit.Location;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ComputeTargetMoveInfoTest {
+
+    private sun.misc.Unsafe unsafe;
+
+    @Before
+    public void setup() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        unsafe = (sun.misc.Unsafe) f.get(null);
+    }
+
+    private Object invokeCompute(FightListener listener, FightData data, Location loc, int tick, boolean worldChanged) throws Exception {
+        Method m = FightListener.class.getDeclaredMethod("computeTargetMoveInfo", FightData.class, Location.class, int.class, boolean.class);
+        m.setAccessible(true);
+        return m.invoke(listener, data, loc, tick, worldChanged);
+    }
+
+    private int getTickAge(Object info) throws Exception {
+        Class<?> c = info.getClass();
+        Field f = c.getDeclaredField("tickAge");
+        f.setAccessible(true);
+        return f.getInt(info);
+    }
+
+    @Test
+    public void testOutOfOrderTickReturnsDefault() throws Exception {
+        FightListener listener = (FightListener) unsafe.allocateInstance(FightListener.class);
+        FightData data = (FightData) unsafe.allocateInstance(FightData.class);
+        data.lastAttackedX = 0.0;
+        data.lastAttackedZ = 0.0;
+        data.lastAttackTick = 10;
+        Location loc = new Location(null, 0, 0, 0);
+        Object info = invokeCompute(listener, data, loc, 5, false);
+        assertEquals(0, getTickAge(info));
+    }
+
+    @Test
+    public void testNegativeTickReturnsDefault() throws Exception {
+        FightListener listener = (FightListener) unsafe.allocateInstance(FightListener.class);
+        FightData data = (FightData) unsafe.allocateInstance(FightData.class);
+        data.lastAttackedX = 0.0;
+        data.lastAttackedZ = 0.0;
+        data.lastAttackTick = 10;
+        Location loc = new Location(null, 0, 0, 0);
+        Object info = invokeCompute(listener, data, loc, -1, false);
+        assertEquals(0, getTickAge(info));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure fight listener validates tick order before computing target movement
- supply default move info for invalid inputs
- test out-of-order and negative tick cases for computeTargetMoveInfo

## Testing
- `mvn -q -e -DskipTests=false test`
- `mvn -q -DskipTests=true checkstyle:check`
- `mvn -q -DskipTests=true pmd:check`
- `mvn -q -DskipTests=true com.github.spotbugs:spotbugs-maven-plugin:check` *(fails to display summary due to large output)*

------
https://chatgpt.com/codex/tasks/task_b_685d2f5a29608329ad0249b24a1354f8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor `computeTargetMoveInfo` in `FightListener.java` to use a new helper method `isValidTargetMoveInput` for validating input, and update it to utilize a constant `DEFAULT_TARGET_MOVE_INFO` for the default return value. Add corresponding unit tests to validate the tick order logic in `ComputeTargetMoveInfoTest.java`.

### Why are these changes being made?

The changes improve code clarity and maintainability by encapsulating input validation logic in a separate method, thereby reducing redundancy and potential errors. Additionally, unit tests ensure that invalid tick order inputs are handled correctly, safeguarding against possible edge cases in fight mechanics processing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->