### PR TITLE
Ensure CHAT_CAPTCHA requires world and player activation

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
@@ -23,11 +23,16 @@ import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ColorUtil;
+import fr.neatmonster.nocheatplus.worlds.IWorldData;
 
 /**
  * NOTE: EARLY REFACTORING STATE, MOST METHODS NEED SYNC OVER DATA !
- * @author mc_dev
+ * <p>
+ * The check should only run if the player's {@link IWorldData} and
+ * {@link IPlayerData} both report {@link CheckType#CHAT_CAPTCHA} as active.
+ * </p>
  *
+ * @author mc_dev
  */
 public class Captcha extends Check implements ICaptcha{
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatCaptchaUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatCaptchaUtil.java
@@ -1,0 +1,34 @@
+package fr.neatmonster.nocheatplus.checks.chat;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.worlds.IWorldData;
+
+/**
+ * Utility methods for chat captcha related checks.
+ */
+public final class ChatCaptchaUtil {
+
+    private ChatCaptchaUtil() {
+    }
+
+    /**
+     * Determine if the captcha check is active for both the player's world and
+     * player data.
+     *
+     * @param player the player
+     * @param pData  the player data
+     * @return {@code true} if the check is active for both world and player
+     */
+    public static boolean isCaptchaEnabled(Player player, IPlayerData pData) {
+        if (player == null || pData == null) {
+            return false;
+        }
+        final IWorldData worldData = pData.getCurrentWorldDataSafe();
+        return worldData != null
+                && worldData.isCheckActive(CheckType.CHAT_CAPTCHA)
+                && pData.isCheckActive(CheckType.CHAT_CAPTCHA, player, worldData);
+    }
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
@@ -50,6 +50,7 @@ import fr.neatmonster.nocheatplus.players.PlayerFactoryArgument;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
 import fr.neatmonster.nocheatplus.utilities.ds.prefixtree.SimpleCharPrefixTree;
 import fr.neatmonster.nocheatplus.worlds.WorldFactoryArgument;
+import fr.neatmonster.nocheatplus.checks.chat.ChatCaptchaUtil;
 
 /**
  * Central location to listen to events that are relevant for the chat checks.
@@ -281,8 +282,10 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
         // (No forced permission update, because the associated permissions are treated as hints rather.)
 
         // Reset captcha of player if needed.
-        synchronized(data) {
-            captcha.resetCaptcha(player, cc, data, pData);
+        if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)) {
+            synchronized (data) {
+                captcha.resetCaptcha(player, cc, data, pData);
+            }
         }
         // Fast relog check.
         if (relog.isEnabled(player, pData) && relog.unsafeLoginCheck(player, cc, data,pData)) {
@@ -314,13 +317,12 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
          * implementation.
          */
         synchronized (data) {
-            if (captcha.isEnabled(player, pData)) {
-                if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
-                    // shouldCheckCaptcha: only if really enabled.
-                    // Possible addition: check cc.captchaOnLogin before shouldCheckCaptcha.
-                    // Consider scheduling this after other plugin messages.
-                    captcha.sendNewCaptcha(player, cc, data);
-                }
+            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
+                    && captcha.shouldCheckCaptcha(player, cc, data, pData)) {
+                // shouldCheckCaptcha: only if really enabled.
+                // Possible addition: check cc.captchaOnLogin before shouldCheckCaptcha.
+                // Consider scheduling this after other plugin messages.
+                captcha.sendNewCaptcha(player, cc, data);
             }
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
@@ -21,6 +21,7 @@ import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
+import fr.neatmonster.nocheatplus.checks.chat.ChatCaptchaUtil;
 
 /**
  * Check only for commands
@@ -46,7 +47,7 @@ public class Commands extends Check {
         final ChatData data = pData.getGenericInstance(ChatData.class);
 
         final boolean captchaEnabled = !cc.captchaSkipCommands
-                && pData.isCheckActive(CheckType.CHAT_CAPTCHA, player);
+                && ChatCaptchaUtil.isCaptchaEnabled(player, pData);
 
         if (handleCaptcha(player, message, captcha, cc, data, pData, captchaEnabled)) {
             return true;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ICaptcha.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ICaptcha.java
@@ -17,10 +17,13 @@ package fr.neatmonster.nocheatplus.checks.chat;
 import org.bukkit.entity.Player;
 
 import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.checks.CheckType;
 
 /**
  * Captcha related operations.<br>
  * Auxiliary interface, most methods should need sync over data, unless stated otherwise.
+ * The check must only run if both the player's world data and player data
+ * indicate that {@link CheckType#CHAT_CAPTCHA} is active.
  * @author mc_dev
  *
  */

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
@@ -340,47 +340,69 @@ public class Text extends Check implements INotifyReload {
 
         float shortTermScore = Math.max(cc.textFreqShortTermMin, score);
         data.chatShortTermFrequency.add(time, shortTermScore);
-        float shortTermAccumulated = cc.textFreqShortTermWeight * data.chatShortTermFrequency.score(cc.textFreqShortTermFactor);
+        float shortTermAccumulated = cc.textFreqShortTermWeight
+                * data.chatShortTermFrequency.score(cc.textFreqShortTermFactor);
         boolean shortTermViolation = shortTermAccumulated > cc.textFreqShortTermLevel;
 
         boolean cancel = false;
         if (normalViolation || shortTermViolation) {
             lastCancelledMessage = lcMessage;
             lastCancelledTime = time;
-
-            final double added = shortTermViolation ? (shortTermAccumulated - cc.textFreqShortTermLevel) / 3.0
-                    : (accumulated - cc.textFreqNormLevel) / 10.0;
+            final double added = getVlAddition(cc, accumulated, shortTermAccumulated, shortTermViolation);
             data.textVL += added;
-
-            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
-                    && captcha.shouldStartCaptcha(player, cc, data, pData)) {
-                captcha.sendNewCaptcha(player, cc, data);
-                cancel = true;
-            } else {
-                if (shortTermViolation) {
-                    if (executeActions(player, data.textVL, added, cc.textFreqShortTermActions).willCancel()) {
-                        cancel = true;
-                    }
-                } else if (normalViolation) {
-                    if (executeActions(player, data.textVL, added, cc.textFreqNormActions).willCancel()) {
-                        cancel = true;
-                    }
-                }
-            }
-        } else if (cc.chatWarningCheck && time - data.chatWarningTime > cc.chatWarningTimeout
-                && (100f * accumulated / cc.textFreqNormLevel > cc.chatWarningLevel
-                        || 100f * shortTermAccumulated / cc.textFreqShortTermLevel > cc.chatWarningLevel)) {
-            NCPAPIProvider.getNoCheatPlusAPI().sendMessageOnTick(player.getName(),
-                    ColorUtil.replaceColors(cc.chatWarningMessage));
+            cancel = handleViolationActions(player, captcha, cc, data, pData, shortTermViolation, normalViolation,
+                    added);
+        } else if (shouldWarnPlayer(cc, data, time, accumulated, shortTermAccumulated)) {
+            warnPlayer(player, cc);
             data.chatWarningTime = time;
         } else {
-            data.textVL *= 0.95;
-            if (cc.textAllowVLReset && normalScore < 2.0f * cc.textFreqNormWeight
-                    && shortTermScore < 2.0f * cc.textFreqShortTermWeight) {
-                data.textVL = 0.0;
-            }
+            adjustVlOnCleanMessage(cc, data, normalScore, shortTermScore);
         }
         return new EvalResult(cancel, accumulated, shortTermAccumulated);
+    }
+
+    private double getVlAddition(final ChatConfig cc, final float accumulated, final float shortTermAccumulated,
+            final boolean shortTermViolation) {
+        return shortTermViolation ? (shortTermAccumulated - cc.textFreqShortTermLevel) / 3.0
+                : (accumulated - cc.textFreqNormLevel) / 10.0;
+    }
+
+    private boolean handleViolationActions(final Player player, final ICaptcha captcha, final ChatConfig cc,
+            final ChatData data, final IPlayerData pData, final boolean shortTermViolation,
+            final boolean normalViolation, final double added) {
+        if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
+                && captcha.shouldStartCaptcha(player, cc, data, pData)) {
+            captcha.sendNewCaptcha(player, cc, data);
+            return true;
+        }
+        if (shortTermViolation) {
+            return executeActions(player, data.textVL, added, cc.textFreqShortTermActions).willCancel();
+        }
+        if (normalViolation) {
+            return executeActions(player, data.textVL, added, cc.textFreqNormActions).willCancel();
+        }
+        return false;
+    }
+
+    private boolean shouldWarnPlayer(final ChatConfig cc, final ChatData data, final long time,
+            final float accumulated, final float shortTermAccumulated) {
+        return cc.chatWarningCheck && time - data.chatWarningTime > cc.chatWarningTimeout
+                && (100f * accumulated / cc.textFreqNormLevel > cc.chatWarningLevel
+                        || 100f * shortTermAccumulated / cc.textFreqShortTermLevel > cc.chatWarningLevel);
+    }
+
+    private void warnPlayer(final Player player, final ChatConfig cc) {
+        NCPAPIProvider.getNoCheatPlusAPI().sendMessageOnTick(player.getName(),
+                ColorUtil.replaceColors(cc.chatWarningMessage));
+    }
+
+    private void adjustVlOnCleanMessage(final ChatConfig cc, final ChatData data, final float normalScore,
+            final float shortTermScore) {
+        data.textVL *= 0.95;
+        if (cc.textAllowVLReset && normalScore < 2.0f * cc.textFreqNormWeight
+                && shortTermScore < 2.0f * cc.textFreqShortTermWeight) {
+            data.textVL = 0.0;
+        }
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
@@ -35,6 +35,7 @@ import fr.neatmonster.nocheatplus.config.ConfigManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
+import fr.neatmonster.nocheatplus.checks.chat.ChatCaptchaUtil;
 
 /**
  * Some alternative more or less advanced analysis methods.
@@ -179,7 +180,8 @@ public class Text extends Check implements INotifyReload {
     private boolean handleCaptcha(final Player player, final String message, final ICaptcha captcha,
             final ChatConfig cc, final ChatData data, final IPlayerData pData,
             boolean isMainThread, final boolean alreadyCancelled) {
-        if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
+        if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
+                && captcha.shouldCheckCaptcha(player, cc, data, pData)) {
             captcha.checkCaptcha(player, message, cc, data, isMainThread);
             return true;
         }
@@ -350,7 +352,8 @@ public class Text extends Check implements INotifyReload {
                     : (accumulated - cc.textFreqNormLevel) / 10.0;
             data.textVL += added;
 
-            if (captcha.shouldStartCaptcha(player, cc, data, pData)) {
+            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
+                    && captcha.shouldStartCaptcha(player, cc, data, pData)) {
                 captcha.sendNewCaptcha(player, cc, data);
                 cancel = true;
             } else {


### PR DESCRIPTION
## Summary
- add `ChatCaptchaUtil` to verify captcha activation against both player and world data
- check captcha activation in `ChatListener`, `Commands`, and `Text`
- gate captcha reset on login behind the same activation check
- document requirement in `Captcha` and `ICaptcha`

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f5a2138832992c77073f0b00844

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Ensure that the CHAT_CAPTCHA check is only executed if both the player's world data and player data indicate that the check is active by refactoring relevant code and implementing a utility method to verify the active status.

### Why are these changes being made?
These changes improve the accuracy and efficiency of the CAPTCHA checks by ensuring they only run when relevant, thus avoiding unnecessary processing and enhancing security measures in chat interactions. This approach centralizes the check activation logic, simplifying future maintenance and reducing redundancy.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->