### PR TITLE
Guard repeated leave events

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -129,6 +129,11 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
     private final Map<UUID, Long> lastLogout = new LinkedHashMap<UUID, Long>(50, 0.75f, true);
 
     /**
+     * Tracks ongoing leave processing and the tick in which it started.
+     */
+    private final Map<UUID, Long> leaveInProgress = new HashMap<UUID, Long>();
+
+    /**
      * Keeping track of online players. Currently id/name mappings are not kept
      * on logout, but might be later.
      */
@@ -204,7 +209,11 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
             @RegisterMethodWithOrder(tag = "system.nocheatplus.datamanager", afterTag = ".*")
             @Override
             public void onEvent(final PlayerQuitEvent event) {
-                playerLeaves(event.getPlayer());
+                final Player player = event.getPlayer();
+                if (registerPlayerLeave(player)) {
+                    playerLeaves(player);
+                    completePlayerLeave(player);
+                }
             }
         },
         new MiniListener<PlayerKickEvent>() {
@@ -214,7 +223,11 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
             @RegisterMethodWithOrder(tag = "system.nocheatplus.datamanager", afterTag = "feature.*")
             @Override
             public void onEvent(final PlayerKickEvent event) {
-                playerLeaves(event.getPlayer());
+                final Player player = event.getPlayer();
+                if (registerPlayerLeave(player)) {
+                    playerLeaves(player);
+                    completePlayerLeave(player);
+                }
             }
         },
         new MiniListener<AsyncPlayerPreLoginEvent>() {
@@ -699,27 +712,96 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
         // Data stuff.
         final Collection<Class<? extends IDataOnJoin>> types = factoryRegistry.getGroupedTypes(IDataOnJoin.class);
         pData.onPlayerJoin(player, player.getWorld(), timeNow, worldDataManager, types);
-        pData.getGenericInstance(CombinedData.class).lastJoinTime = timeNow; 
+        pData.getGenericInstance(CombinedData.class).lastJoinTime = timeNow;
+    }
+
+    /**
+     * Check if a leave action for this player should be skipped.
+     *
+     * @param playerId the player id
+     * @param timeNow  current time in milliseconds
+     * @return {@code true} if leave processing should be skipped
+     */
+    private boolean shouldSkipLeave(final UUID playerId, final long timeNow) {
+        final Long inProgress = leaveInProgress.get(playerId);
+        if (inProgress != null) {
+            return true;
+        }
+        final Long last = lastLogout.get(playerId);
+        return last != null && timeNow - last < 50L;
+    }
+
+    /**
+     * Mark the start of leave processing.
+     *
+     * @param playerId the player id
+     * @param timeNow  current time in milliseconds
+     */
+    private void markLeaveStart(final UUID playerId, final long timeNow) {
+        leaveInProgress.put(playerId, timeNow);
+    }
+
+    /**
+     * Clear the leave processing state.
+     *
+     * @param playerId the player id
+     */
+    private void markLeaveEnd(final UUID playerId) {
+        leaveInProgress.remove(playerId);
+    }
+
+    /**
+     * Register a leave event. Returns {@code true} if it is the first leave
+     * processed within the configured interval.
+     *
+     * @param player the player
+     * @return {@code true} if processing should continue
+     */
+    public boolean registerPlayerLeave(final Player player) {
+        if (player == null) {
+            return false;
+        }
+        final long timeNow = System.currentTimeMillis();
+        final UUID playerId = player.getUniqueId();
+        if (shouldSkipLeave(playerId, timeNow)) {
+            return false;
+        }
+        markLeaveStart(playerId, timeNow);
+        lastLogout.put(playerId, timeNow);
+        return true;
+    }
+
+    /**
+     * Mark leave processing as finished for the given player.
+     *
+     * @param player the player
+     */
+    public void completePlayerLeave(final Player player) {
+        if (player != null) {
+            markLeaveEnd(player.getUniqueId());
+        }
     }
 
     /**
      * Quit or kick.
      * @param player
      */
-    private void playerLeaves(final Player player) {
-        final long timeNow = System.currentTimeMillis();
+    public void playerLeaves(final Player player) {
+        if (player == null) {
+            return;
+        }
         final UUID playerId = player.getUniqueId();
-        lastLogout.put(playerId, timeNow);
+        final long timeNow = lastLogout.getOrDefault(playerId, System.currentTimeMillis());
         final PlayerData pData = playerData.get(playerId);
         if (pData != null) {
             final Collection<Class<? extends IDataOnLeave>> types = factoryRegistry.getGroupedTypes(IDataOnLeave.class);
             pData.onPlayerLeave(player, timeNow, types);
             pData.getGenericInstance(CombinedData.class).lastLogoutTime = timeNow;
-        }
-        else {
+        } else {
             // NOTE: Possibly put lastLogoutTime to OfflinePlayerData.
         }
         removeOnlinePlayer(player);
+        markLeaveEnd(playerId);
     }
 
     private void playerChangedWorld(final PlayerChangedWorldEvent event) {

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -1434,11 +1434,13 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     }
 
     private void onLeave(final Player player) {
+        if (!pDataMan.registerPlayerLeave(player)) {
+            return;
+        }
         for (final JoinLeaveListener jlListener : joinLeaveListeners) {
-            try{
+            try {
                 jlListener.playerLeaves(player);
-            }
-            catch(Throwable t) {
+            } catch (Throwable t) {
                 logManager.severe(Streams.INIT, "JoinLeaveListener(" + jlListener.getClass().getName() + ") generated an exception (leave): " + t.getClass().getSimpleName());
                 logManager.severe(Streams.INIT, t);
             }
@@ -1446,6 +1448,8 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         if (clearExemptionsOnLeave) {
             NCPExemptionManager.unexempt(player);
         }
+        pDataMan.playerLeaves(player);
+        pDataMan.completePlayerLeave(player);
     }
 
     private void scheduleConsistencyCheckers() {


### PR DESCRIPTION
## Summary
- prevent duplicate leave processing via timestamp guard
- wrap player leave logic with register/complete methods
- guard plugin-level leave handling

## Testing
- `mvn -q verify` *(fails: medium spotbugs warnings, build status unclear)*

------
https://chatgpt.com/codex/tasks/task_b_685d2f587c208329b4389bef4ef563c5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logic to prevent processing repeated leave events for players, by implementing tracking of ongoing leave processing and ensuring that subsequent leave events within a short interval are ignored.

### Why are these changes being made?

These changes address an issue where rapid, repeated player leave events could cause redundant processing. By keeping track of leave events in progress and employing a time-based condition to skip unnecessary ones, we reduce unnecessary load and improve efficiency within the system. This is achieved by introducing new methods to manage leave state and updating existing code to use these checks.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->