### PR TITLE
Cap block model heights to 1.0

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
@@ -36,7 +36,7 @@ public class BukkitFence implements BukkitShapeModel {
     public BukkitFence(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
@@ -36,7 +36,7 @@ public class BukkitGate implements BukkitShapeModel {
     public BukkitGate(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
@@ -34,7 +34,7 @@ public class BukkitShulkerBox implements BukkitShapeModel {
 
         if (state instanceof ShulkerBox) {
             if (!((ShulkerBox) state).getInventory().getViewers().isEmpty()) {
-                return new double[] {0.0, 0.0, 0.0, 1.0, 1.5, 1.0};
+                return new double[] {0.0, 0.0, 0.0, 1.0, Math.min(1.5, 1.0), 1.0};
             }
         }
         return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -33,7 +33,7 @@ public class BukkitStatic implements BukkitShapeModel {
      * @return New instance.
      */
     public static BukkitStatic ofHeight(double height) {
-        return ofInsetAndHeight(0.0, height);
+        return ofInsetAndHeight(0.0, Math.min(height, 1.0));
     }
 
     /**
@@ -44,7 +44,8 @@ public class BukkitStatic implements BukkitShapeModel {
      * @return New instance.
      */
     public static BukkitStatic ofInsetAndHeight(double xzInset, double height) {
-        return ofBounds(xzInset, 0.0, xzInset, 1.0 - xzInset, height, 1.0 - xzInset);
+        double capped = Math.min(height, 1.0);
+        return ofBounds(xzInset, 0.0, xzInset, 1.0 - xzInset, capped, 1.0 - xzInset);
     }
 
     /**

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
@@ -44,24 +44,24 @@ public class BukkitWall implements BukkitShapeModel {
     private final double[] southnorth;
 
     public BukkitWall(double inset, double height) {
-        this(inset, 1.0 - inset, height, 0.0);
+        this(inset, 1.0 - inset, Math.min(height, 1.0), 0.0);
     }
 
     public BukkitWall(double inset, double height, double sideInset) {
-        this(inset, 1.0 - inset, height, sideInset);
+        this(inset, 1.0 - inset, Math.min(height, 1.0), sideInset);
     }
 
     public BukkitWall(double minXZ, double maxXZ, double height, double sideInset) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
         this.sideInset = sideInset;
-        east = new double[] {maxXZ, 0.0, sideInset, 1.0, height, 1.0 - sideInset};
-        north = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, height, minXZ};
-        west = new double[] {0.0, 0.0, sideInset, minXZ, height, 1.0 - sideInset};
-        south = new double[] {sideInset, 0.0, maxXZ, 1.0 - sideInset, height, 1.0};
-        eastwest = new double[] {0.0, 0.0, sideInset, 1.0, height, 1.0 - sideInset};
-        southnorth = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, height, 1.0};
+        east = new double[] {maxXZ, 0.0, sideInset, 1.0, this.height, 1.0 - sideInset};
+        north = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, this.height, minXZ};
+        west = new double[] {0.0, 0.0, sideInset, minXZ, this.height, 1.0 - sideInset};
+        south = new double[] {sideInset, 0.0, maxXZ, 1.0 - sideInset, this.height, 1.0};
+        eastwest = new double[] {0.0, 0.0, sideInset, 1.0, this.height, 1.0 - sideInset};
+        southnorth = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, this.height, 1.0};
     }
 
     @Override

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
@@ -19,7 +19,7 @@ public class BukkitWallTest {
         MultipleFacing data = mock(MultipleFacing.class);
         Set<BlockFace> faces = EnumSet.of(BlockFace.SOUTH, BlockFace.EAST);
         when(data.getFaces()).thenReturn(faces);
-        double[] expected = {0.3125, 0.0, 0.0, 1.0 - 0.3125, 1.5, 1.0};
+        double[] expected = {0.3125, 0.0, 0.0, 1.0 - 0.3125, 1.0, 1.0};
         double[] res = invokeMultipleFacing(wall, data);
         assertArrayEquals(expected, res, 0.0);
     }
@@ -33,7 +33,7 @@ public class BukkitWallTest {
         when(data.getHeight(BlockFace.EAST)).thenReturn(Wall.Height.NONE);
         when(data.getHeight(BlockFace.NORTH)).thenReturn(Wall.Height.NONE);
         when(data.getHeight(BlockFace.SOUTH)).thenReturn(Wall.Height.NONE);
-        double[] expected = {0.25,0.0,0.25,0.75,1.5,0.75,0.0,0.0,0.3125,0.25,1.5,0.6875};
+        double[] expected = {0.25,0.0,0.25,0.75,1.0,0.75,0.0,0.0,0.3125,0.25,1.0,0.6875};
         double[] res = invokeWall(wall, data);
         assertArrayEquals(expected, res, 0.0);
     }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ShapeModelHeightTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ShapeModelHeightTest.java
@@ -1,0 +1,38 @@
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.bukkit.MCAccessBukkitModern;
+
+public class ShapeModelHeightTest {
+
+    @Test
+    public void testHeightsWithinBounds() throws Exception {
+        Set<BukkitShapeModel> models = new HashSet<>();
+        for (Field f : MCAccessBukkitModern.class.getDeclaredFields()) {
+            if (BukkitShapeModel.class.isAssignableFrom(f.getType())) {
+                f.setAccessible(true);
+                models.add((BukkitShapeModel) f.get(null));
+            }
+        }
+        for (BukkitShapeModel model : models) {
+            if (model instanceof BukkitFence || model instanceof BukkitGate || model instanceof BukkitWall) {
+                Field hf = model.getClass().getDeclaredField("height");
+                hf.setAccessible(true);
+                double height = hf.getDouble(model);
+                assertTrue(height <= 1.0 + 1e-9);
+            } else if (model instanceof BukkitStatic) {
+                double[] bounds = ((BukkitStatic) model).getShape(null, null, 0, 0, 0);
+                for (int i = 5; i < bounds.length; i += 6) {
+                    assertTrue(bounds[i] <= 1.0 + 1e-9);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cap heights when creating `BukkitStatic`, `BukkitFence`, `BukkitGate` and `BukkitWall`
- clamp open shulker boxes to height 1.0
- adjust wall tests for new height
- add regression test ensuring block model heights do not exceed 1.0

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_685d2f579d308329ba00d3cae096d86d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Cap block model heights to a maximum of 1.0 across various classes in the Bukkit model codebase and update tests accordingly.

### Why are these changes being made?
These changes resolve an issue where block model heights could exceed 1.0, which could lead to inconsistencies within the game environment and affect server performance negatively. Implementing a consistent maximum height of 1.0 ensures uniformity in appearance and behavior across different block types, aligning with standard game mechanics and server requirements. The new test ensures that all block models adhere to this height constraint.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->