### PR TITLE
Add CraftEntity guards across compatibility modules

### DIFF
--- a/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/BlockCacheCBDev.java
+++ b/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/BlockCacheCBDev.java
@@ -36,6 +36,14 @@ public class BlockCacheCBDev extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_12_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheCBDev(World world) {
         setAccess(world);
     }
@@ -93,7 +101,7 @@ public class BlockCacheCBDev extends BlockCache {
         try{
             // Potentially simplify this code path.
 
-            final net.minecraft.server.v1_12_R1.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_12_R1.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/MCAccessCBDev.java
+++ b/NCPCompatNonFree/NCPCompatCBDev/src/main/java/fr/neatmonster/nocheatplus/compat/cbdev/MCAccessCBDev.java
@@ -47,6 +47,14 @@ public class MCAccessCBDev implements MCAccess {
     private final MobEffectList JUMP;
     private final MobEffectList FASTER_MOVEMENT;
 
+    private net.minecraft.server.v1_12_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -129,7 +137,7 @@ public class MCAccessCBDev implements MCAccess {
     @Override
     public double getHeight(final Entity entity) {
         // (entity.getHeight() returns the length field, but we access nms anyway.)
-        final net.minecraft.server.v1_12_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_12_R1.Entity mcEntity = toNmsEntity(entity);
         final AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -174,7 +182,7 @@ public class MCAccessCBDev implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -244,7 +252,7 @@ public class MCAccessCBDev implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/BlockCacheSpigotCB1_10_R1.java
@@ -33,8 +33,16 @@ import net.minecraft.server.v1_10_R1.EntityShulker;
 public class BlockCacheSpigotCB1_10_R1 extends BlockCache {
 
     protected net.minecraft.server.v1_10_R1.World world;
-    
+
     protected World bukkitWorld;
+
+    private net.minecraft.server.v1_10_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
 
     public BlockCacheSpigotCB1_10_R1(World world) {
         setAccess(world);
@@ -99,7 +107,7 @@ public class BlockCacheSpigotCB1_10_R1 extends BlockCache {
         try{
             // Find some simplification!
 
-            final net.minecraft.server.v1_10_R1.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_10_R1.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_10_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_10_R1/MCAccessSpigotCB1_10_R1.java
@@ -45,6 +45,14 @@ public class MCAccessSpigotCB1_10_R1 implements MCAccess {
     private final MobEffectList JUMP;
     private final MobEffectList FASTER_MOVEMENT;
 
+    private net.minecraft.server.v1_10_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -124,7 +132,7 @@ public class MCAccessSpigotCB1_10_R1 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_10_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_10_R1.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -169,7 +177,7 @@ public class MCAccessSpigotCB1_10_R1 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -239,7 +247,7 @@ public class MCAccessSpigotCB1_10_R1 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/BlockCacheSpigotCB1_11_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/BlockCacheSpigotCB1_11_R1.java
@@ -40,6 +40,14 @@ public class BlockCacheSpigotCB1_11_R1 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_11_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     private final IBlockAccess iBlockAccess = new IBlockAccess() {
 
         @Override
@@ -123,7 +131,7 @@ public class BlockCacheSpigotCB1_11_R1 extends BlockCache {
         try{
             // This method could be simplified.
 
-            final net.minecraft.server.v1_11_R1.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_11_R1.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_11_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_11_R1/MCAccessSpigotCB1_11_R1.java
@@ -47,6 +47,14 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
     private final MobEffectList JUMP;
     private final MobEffectList FASTER_MOVEMENT;
 
+    private net.minecraft.server.v1_11_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -129,7 +137,7 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
     @Override
     public double getHeight(final Entity entity) {
         // (entity.getHeight() returns the length field, but we access nms anyway.)
-        final net.minecraft.server.v1_11_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_11_R1.Entity mcEntity = toNmsEntity(entity);
         final AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -174,7 +182,7 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -244,7 +252,7 @@ public class MCAccessSpigotCB1_11_R1 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/BlockCacheSpigotCB1_8_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/BlockCacheSpigotCB1_8_R1.java
@@ -35,6 +35,14 @@ public class BlockCacheSpigotCB1_8_R1 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_8_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheSpigotCB1_8_R1(World world) {
         setAccess(world);
     }
@@ -86,7 +94,7 @@ public class BlockCacheSpigotCB1_8_R1 extends BlockCache {
         try{
             // Potentially simplify this code path.
 
-            final net.minecraft.server.v1_8_R1.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_8_R1.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/MCAccessSpigotCB1_8_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R1/MCAccessSpigotCB1_8_R1.java
@@ -39,6 +39,14 @@ import net.minecraft.server.v1_8_R1.MobEffectList;
 
 public class MCAccessSpigotCB1_8_R1 implements MCAccess {
 
+    private net.minecraft.server.v1_8_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Constructor to let it fail.
      */
@@ -79,7 +87,7 @@ public class MCAccessSpigotCB1_8_R1 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_8_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_8_R1.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -113,7 +121,7 @@ public class MCAccessSpigotCB1_8_R1 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -179,7 +187,7 @@ public class MCAccessSpigotCB1_8_R1 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/BlockCacheSpigotCB1_8_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/BlockCacheSpigotCB1_8_R2.java
@@ -35,6 +35,14 @@ public class BlockCacheSpigotCB1_8_R2 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_8_R2.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheSpigotCB1_8_R2(World world) {
         setAccess(world);
     }
@@ -86,7 +94,7 @@ public class BlockCacheSpigotCB1_8_R2 extends BlockCache {
         try{
             // Potentially simplify this code path.
 
-            final net.minecraft.server.v1_8_R2.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_8_R2.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/MCAccessSpigotCB1_8_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R2/MCAccessSpigotCB1_8_R2.java
@@ -39,6 +39,14 @@ import net.minecraft.server.v1_8_R2.MobEffectList;
 
 public class MCAccessSpigotCB1_8_R2 implements MCAccess {
 
+    private net.minecraft.server.v1_8_R2.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Constructor to let it fail.
      */
@@ -79,7 +87,7 @@ public class MCAccessSpigotCB1_8_R2 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_8_R2.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_8_R2.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -113,7 +121,7 @@ public class MCAccessSpigotCB1_8_R2 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -179,7 +187,7 @@ public class MCAccessSpigotCB1_8_R2 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/BlockCacheSpigotCB1_8_R3.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/BlockCacheSpigotCB1_8_R3.java
@@ -35,6 +35,14 @@ public class BlockCacheSpigotCB1_8_R3 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_8_R3.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheSpigotCB1_8_R3(World world) {
         setAccess(world);
     }
@@ -86,7 +94,7 @@ public class BlockCacheSpigotCB1_8_R3 extends BlockCache {
         try{
             // Potentially simplify this code path.
 
-            final net.minecraft.server.v1_8_R3.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_8_R3.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/MCAccessSpigotCB1_8_R3.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_8_R3/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_8_R3/MCAccessSpigotCB1_8_R3.java
@@ -39,6 +39,14 @@ import net.minecraft.server.v1_8_R3.MobEffectList;
 
 public class MCAccessSpigotCB1_8_R3 implements MCAccess {
 
+    private net.minecraft.server.v1_8_R3.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -99,7 +107,7 @@ public class MCAccessSpigotCB1_8_R3 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_8_R3.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_8_R3.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -133,7 +141,7 @@ public class MCAccessSpigotCB1_8_R3 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -200,7 +208,7 @@ public class MCAccessSpigotCB1_8_R3 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/BlockCacheSpigotCB1_9_R1.java
@@ -36,6 +36,14 @@ public class BlockCacheSpigotCB1_9_R1 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_9_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheSpigotCB1_9_R1(World world) {
         setAccess(world);
     }
@@ -97,7 +105,7 @@ public class BlockCacheSpigotCB1_9_R1 extends BlockCache {
         try{
             // Consider simplifying this method in the future
 
-            final net.minecraft.server.v1_9_R1.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_9_R1.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/MCAccessSpigotCB1_9_R1.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R1/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R1/MCAccessSpigotCB1_9_R1.java
@@ -45,6 +45,14 @@ public class MCAccessSpigotCB1_9_R1 implements MCAccess {
     private final MobEffectList JUMP;
     private final MobEffectList FASTER_MOVEMENT;
 
+    private net.minecraft.server.v1_9_R1.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -124,7 +132,7 @@ public class MCAccessSpigotCB1_9_R1 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_9_R1.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_9_R1.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -167,7 +175,7 @@ public class MCAccessSpigotCB1_9_R1 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -233,7 +241,7 @@ public class MCAccessSpigotCB1_9_R1 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/BlockCacheSpigotCB1_9_R2.java
@@ -36,6 +36,14 @@ public class BlockCacheSpigotCB1_9_R2 extends BlockCache {
 
     protected World bukkitWorld;
 
+    private net.minecraft.server.v1_9_R2.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     public BlockCacheSpigotCB1_9_R2(World world) {
         setAccess(world);
     }
@@ -99,7 +107,7 @@ public class BlockCacheSpigotCB1_9_R2 extends BlockCache {
         try{
             // Consider refactoring to avoid nested loops
 
-            final net.minecraft.server.v1_9_R2.Entity mcEntity  = ((CraftEntity) entity).getHandle();
+            final net.minecraft.server.v1_9_R2.Entity mcEntity = toNmsEntity(entity);
 
             final AxisAlignedBB box = new AxisAlignedBB(minX, minY, minZ, maxX, maxY, maxZ);
             @SuppressWarnings("rawtypes")

--- a/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
+++ b/NCPCompatNonFree/NCPCompatSpigotCB1_9_R2/src/main/java/fr/neatmonster/nocheatplus/compat/spigotcb1_9_R2/MCAccessSpigotCB1_9_R2.java
@@ -45,6 +45,14 @@ public class MCAccessSpigotCB1_9_R2 implements MCAccess {
     private final MobEffectList JUMP;
     private final MobEffectList FASTER_MOVEMENT;
 
+    private net.minecraft.server.v1_9_R2.Entity toNmsEntity(final Entity entity) {
+        if (!(entity instanceof CraftEntity)) {
+            throw new IllegalArgumentException("Expected CraftEntity, got "
+                    + (entity == null ? "null" : entity.getClass().getName()));
+        }
+        return ((CraftEntity) entity).getHandle();
+    }
+
     /**
      * Test for availability in constructor.
      */
@@ -124,7 +132,7 @@ public class MCAccessSpigotCB1_9_R2 implements MCAccess {
 
     @Override
     public double getHeight(final Entity entity) {
-        final net.minecraft.server.v1_9_R2.Entity mcEntity = ((CraftEntity) entity).getHandle();
+        final net.minecraft.server.v1_9_R2.Entity mcEntity = toNmsEntity(entity);
         AxisAlignedBB boundingBox = mcEntity.getBoundingBox();
         final double entityHeight = Math.max(mcEntity.length, Math.max(mcEntity.getHeadHeight(), boundingBox.e - boundingBox.b));
         if (entity instanceof LivingEntity) {
@@ -169,7 +177,7 @@ public class MCAccessSpigotCB1_9_R2 implements MCAccess {
 
     @Override
     public double getWidth(final Entity entity) {
-        return ((CraftEntity) entity).getHandle().width;
+        return toNmsEntity(entity).width;
     }
 
     @Override
@@ -239,7 +247,7 @@ public class MCAccessSpigotCB1_9_R2 implements MCAccess {
 
     @Override
     public boolean isComplexPart(final Entity entity) {
-        return ((CraftEntity) entity).getHandle() instanceof EntityComplexPart;
+        return toNmsEntity(entity) instanceof EntityComplexPart;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure all entity casts in compatibility modules validate CraftEntity first
- add `toNmsEntity` helpers that throw on invalid entities
- update usages in BlockCache and MCAccess implementations

## Testing
- `mvn -q -P nonfree_build test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685d2f5575848329883f6de8bf79582e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made? 

Add CraftEntity guards across multiple compatibility modules by implementing a helper method to standardize entity conversion and enforcing checks to ensure only CraftEntity instances are processed.

### Why are these changes being made?

These changes address the need for consistent handling of entity types within the modules to prevent runtime errors and enhance code maintainability by abstracting repeated conversion logic into a centralized method. This approach reduces code duplication, enhances readability, and ensures proper error handling when dealing with entity conversions to their NMS counterparts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->