### PR TITLE
Fix instant eat condition handling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -525,9 +525,14 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
 
     private void rememberFoodInteract(final InventoryData data, final Material type) {
         final long now = System.currentTimeMillis();
-        data.instantEatFood = type;
-        data.instantEatInteract = (data.instantEatInteract > 0 && now - data.instantEatInteract < 800)
-                ? Math.min(System.currentTimeMillis(), data.instantEatInteract) : System.currentTimeMillis();
+        final long diff = now - data.instantEatInteract;
+
+        final boolean qualifies = data.instantEatInteract <= 0 || diff < 800;
+        data.instantEatInteract = (qualifies && data.instantEatInteract > 0)
+                ? Math.min(now, data.instantEatInteract)
+                : now;
+
+        data.instantEatFood = qualifies ? type : null;
         data.instantBowInteract = 0;
     }
 

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/inventory/TestInstantEatInteraction.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/inventory/TestInstantEatInteraction.java
@@ -1,0 +1,46 @@
+package fr.neatmonster.nocheatplus.checks.inventory;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.bukkit.Material;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestInstantEatInteraction {
+
+    private sun.misc.Unsafe unsafe;
+    private InventoryListener listener;
+
+    @Before
+    public void setup() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        unsafe = (sun.misc.Unsafe) f.get(null);
+        listener = (InventoryListener) unsafe.allocateInstance(InventoryListener.class);
+    }
+
+    private void invokeRememberFood(InventoryData data, Material mat) throws Exception {
+        Method m = InventoryListener.class.getDeclaredMethod("rememberFoodInteract", InventoryData.class, Material.class);
+        m.setAccessible(true);
+        m.invoke(listener, data, mat);
+    }
+
+    @Test
+    public void testValidTimingSetsFood() throws Exception {
+        InventoryData data = new InventoryData();
+        data.instantEatInteract = System.currentTimeMillis() - 500;
+        invokeRememberFood(data, Material.BREAD);
+        assertEquals(Material.BREAD, data.instantEatFood);
+    }
+
+    @Test
+    public void testInvalidTimingClearsFood() throws Exception {
+        InventoryData data = new InventoryData();
+        data.instantEatInteract = System.currentTimeMillis() - 900;
+        invokeRememberFood(data, Material.APPLE);
+        assertNull(data.instantEatFood);
+    }
+}


### PR DESCRIPTION
## Summary
- refine instant food interaction logic
- add regression tests for instant eat timing

## Testing
- `mvn -DskipTests verify`
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f52e2948329af943fe5fc1c5f81