### PR TITLE
Improve log dispatch safety

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/AbstractLogNodeDispatcher.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/AbstractLogNodeDispatcher.java
@@ -92,9 +92,8 @@ public abstract class AbstractLogNodeDispatcher implements LogNodeDispatcher { /
     protected ContentLogger<String> initLogger = null;
 
     public <C> void dispatch(LogNode<C> node, Level level, C content) {
-        // NOTE: Try/catch ?
         if (isWithinContext(node)) {
-            node.logger.log(level, content);
+            logSafely(node, level, content);
         } else {
             scheduleLog(node, level, content);
         }
@@ -115,7 +114,7 @@ public abstract class AbstractLogNodeDispatcher implements LogNodeDispatcher { /
             return false;
         }
         for (final LogRecord<?> record : records) {
-            record.run();
+            logSafely(record.getNode(), record.getLevel(), record.getContent());
         }
         return true;
     }
@@ -231,6 +230,19 @@ public abstract class AbstractLogNodeDispatcher implements LogNodeDispatcher { /
     protected void logINIT(final Level level, final String message) {
         if (initLogger != null) {
             initLogger.log(level, message);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void logSafely(LogNode<?> node, Level level, Object content) {
+        if (node == null || node.logger == null) {
+            logINIT(Level.WARNING, "Skipped log record due to missing node or logger.");
+            return;
+        }
+        try {
+            ((ContentLogger<Object>) node.logger).log(level, content);
+        } catch (Exception e) {
+            logINIT(Level.WARNING, "Logging failed: " + e.getMessage());
         }
     }
 

--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/LogRecord.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/logging/details/LogRecord.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
  *
  */
 public class LogRecord<C> implements Runnable {
-    
+
     private final LogNode<C> node;
     private final Level level;
     private final C content;
@@ -32,11 +32,23 @@ public class LogRecord<C> implements Runnable {
         this.level = level;
         this.content = content;
     }
-    
+
     @Override
     public void run() {
-        // NOTE: Determine appropriate location for checks or try-catch handling.
+        // NOTE: Direct invocation, actual handling is done by the dispatcher.
         node.logger.log(level, content);
     }
-    
+
+    public LogNode<C> getNode() {
+        return node;
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public C getContent() {
+        return content;
+    }
+
 }


### PR DESCRIPTION
## Summary
- validate log node and logger before calling
- provide accessor methods in `LogRecord`
- wrap logger usage in a safe helper to avoid exceptions

## Testing
- `mvn -q verify` *(fails: SpotBugs found medium warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685d2f5447f48329896da5e4b04dfd51

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a safe logging mechanism in `AbstractLogNodeDispatcher` by introducing a `logSafely` method and updating `dispatch` and `runLogs` methods to use this new method, alongside adding getters in `LogRecord`.

### Why are these changes being made?

These changes are being made to increase the safety and robustness of log dispatching by handling potential null pointers and exceptions during logging operations. By introducing `logSafely`, the dispatcher can now log warnings if the node or logger is missing, or if any logging operation fails, thus preventing crashes and ensuring that the system handles logging errors gracefully.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->