### PR TITLE
Fix time capture in inventory interaction

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -520,14 +520,14 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
     private void rememberBowInteract(final InventoryData data) {
         final long now = System.currentTimeMillis();
         data.instantBowInteract = (data.instantBowInteract > 0 && now - data.instantBowInteract < 800)
-                ? Math.min(System.currentTimeMillis(), data.instantBowInteract) : System.currentTimeMillis();
+                ? Math.min(now, data.instantBowInteract) : now;
     }
 
     private void rememberFoodInteract(final InventoryData data, final Material type) {
         final long now = System.currentTimeMillis();
         data.instantEatFood = type;
         data.instantEatInteract = (data.instantEatInteract > 0 && now - data.instantEatInteract < 800)
-                ? Math.min(System.currentTimeMillis(), data.instantEatInteract) : System.currentTimeMillis();
+                ? Math.min(now, data.instantEatInteract) : now;
         data.instantBowInteract = 0;
     }
 


### PR DESCRIPTION
## Summary
- store a single timestamp in `rememberBowInteract` and `rememberFoodInteract`
- use it consistently to avoid extra calls

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_685d2f5348ec8329aee6617bc7e02648

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the time capture logic in the `rememberBowInteract` and `rememberFoodInteract` methods to consistently use a single computed `now` value.

### Why are these changes being made?

The existing implementation calls `System.currentTimeMillis()` multiple times, leading to potential inconsistencies in the captured time within a single interaction logic. By storing the current time once in the `now` variable and using it consistently, the logic becomes more reliable and efficient, reducing the risk of errors in timing comparisons.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->