### PR TITLE
Add cactus block model

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -121,6 +121,8 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     private static final BukkitShapeModel MODEL_GROUND_HEAD = BukkitStatic.ofInsetAndHeight(0.25, 0.5);
     private static final BukkitShapeModel MODEL_SINGLE_CHEST = BukkitStatic.ofInsetAndHeight(0.0625, 0.875);
     private static final BukkitShapeModel MODEL_HONEY_BLOCK = BukkitStatic.ofInsetAndHeight(0.0625, 0.9375);
+    /** Bounds for cactus blocks: inset by 1/16 and full height. */
+    private static final BukkitShapeModel MODEL_CACTUS = BukkitStatic.ofInsetAndHeight(0.0625, 1.0);
     private static final BukkitShapeModel MODEL_SCULK_SHRIEKER = BukkitStatic.ofInsetAndHeight(0.0, 0.5);
 
     // Static blocks with full height sorted by inset.
@@ -299,7 +301,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
         addModel(Material.LADDER, MODEL_LADDER);
         addModel(Material.BREWING_STAND, MODEL_BREWING_STAND);
         addModel(Material.DRAGON_EGG, MODEL_INSET16_1_HEIGHT100);
-        addModel(Material.CACTUS, MODEL_HONEY_BLOCK);
+        addModel(Material.CACTUS, MODEL_CACTUS);
     }
 
     private void registerMiscModelCollections() {

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCactusModelTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitCactusModelTest.java
@@ -1,0 +1,22 @@
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.bukkit.MCAccessBukkitModern;
+import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitShapeModel;
+
+public class BukkitCactusModelTest {
+
+    @Test
+    public void testCactusModelBounds() throws Exception {
+        Field f = MCAccessBukkitModern.class.getDeclaredField("MODEL_CACTUS");
+        f.setAccessible(true);
+        BukkitShapeModel model = (BukkitShapeModel) f.get(null);
+        double[] bounds = model.getShape(null, null, 0, 0, 0);
+        assertArrayEquals(new double[] {0.0625, 0.0, 0.0625, 0.9375, 1.0, 0.9375}, bounds, 0.0);
+    }
+}


### PR DESCRIPTION
## Summary
- define a dedicated cactus model
- register the cactus model instead of the honey block model
- test cactus model bounds

## Testing
- `mvn -q test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685d2f5139bc8329af3c7eea4a68b232

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new cactus block model with appropriate bounds and implement a corresponding unit test.

### Why are these changes being made?

The change corrects the block bounds definition specifically for cactus blocks, updating from a previously incorrect reference to the honey block model. A new unit test ensures the cactus model's bounding values are accurate, aiding in correct rendering and interaction behavior in-game.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->