### PR TITLE
Extract violation decay factors into config

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
@@ -47,6 +47,8 @@ public class BlockBreakConfig extends ACheckConfig {
 
     public final int        frequencyShortTermLimit;
     public final int        frequencyShortTermTicks;
+    /** Factor multiplied with the violation level when frequency checks pass. */
+    public final double     frequencyVlDecay;
     public final ActionList frequencyActions;
 
     public boolean          improbableFastBreakCheck;
@@ -90,6 +92,7 @@ public class BlockBreakConfig extends ACheckConfig {
         frequencyIntervalSurvival = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_MOD_SURVIVAL);
         frequencyShortTermLimit = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT);
         frequencyShortTermTicks = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS);
+        frequencyVlDecay = config.getDouble(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.95);
         frequencyActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, Permissions.BLOCKBREAK_FREQUENCY);
 
         noSwingActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_NOSWING_ACTIONS, Permissions.BLOCKBREAK_NOSWING);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
@@ -91,7 +91,7 @@ public class Frequency extends Check {
                     cancel = executeActions(player, data.frequencyVL, change, cc.frequencyActions).willCancel();
                 }
                 else if (data.frequencyVL > 0d && fullScore < fullTime * .75)
-                    data.frequencyVL *= 0.95;
+                    data.frequencyVL *= cc.frequencyVlDecay;
 
                 return cancel;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
@@ -33,9 +33,13 @@ public class BlockInteractConfig extends ACheckConfig {
 
     public final long		speedInterval;
     public final int		speedLimit;
+    /** Factor multiplied with the violation level when speed checks pass. */
+    public final double         speedVlDecay;
     public final ActionList speedActions;
 
     public final ActionList visibleActions;
+    /** Factor multiplied with the violation level when visibility checks pass. */
+    public final double         visibleVlDecay;
 
     /**
      * Instantiates a new block interact configuration.
@@ -53,9 +57,11 @@ public class BlockInteractConfig extends ACheckConfig {
 
         speedInterval = data.getLong(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL);
         speedLimit = data.getInt(ConfPaths.BLOCKINTERACT_SPEED_LIMIT);
+        speedVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.99);
         speedActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, Permissions.BLOCKINTERACT_SPEED);
 
         visibleActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, Permissions.BLOCKINTERACT_VISIBLE);
+        visibleVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.99);
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
@@ -55,7 +55,7 @@ public class Speed extends Check {
             }
         }
         else{
-            data.speedVL *= 0.99;
+            data.speedVL *= cc.speedVlDecay;
             data.addPassedCheck(this.type);
         }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Visible.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Visible.java
@@ -224,7 +224,7 @@ public class Visible extends Check {
                 cancel = true;
             }
         } else {
-            data.visibleVL *= 0.99;
+            data.visibleVL *= cc.visibleVlDecay;
             data.addPassedCheck(this.type);
             if (debug) {
                 debug(player, "pitch=" + loc.getPitch() + ",yaw=" + loc.getYaw() + " tags="

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
@@ -95,7 +95,7 @@ public class Against extends Check {
             vd.setParameter(ParameterName.BLOCK_TYPE, ncpAgainst == null ? "air" : ncpAgainst.toString());
             return executeActions(vd).willCancel();
         } else {
-            data.againstVL *= 0.99; // Assume one false positive every 100 blocks.
+            data.againstVL *= cc.againstVlDecay; // Assume one false positive every 100 blocks.
             if (bIData != null) {
                 bIData.addPassedCheck(this.type);
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
@@ -33,6 +33,8 @@ import fr.neatmonster.nocheatplus.worlds.IWorldData;
 public class BlockPlaceConfig extends ACheckConfig {
 
     public final ActionList againstActions;
+    /** Factor multiplied with violation level for the Against check when passed. */
+    public final double    againstVlDecay;
 
     public final boolean    autoSignSkipEmpty;
     public final ActionList autoSignActions;
@@ -44,6 +46,8 @@ public class BlockPlaceConfig extends ACheckConfig {
     public final int        fastPlaceShortTermLimit;
     public final boolean    fastPlaceImprobableFeedOnly;
     public final float      fastPlaceImprobableWeight;
+    /** Factor multiplied with the current violation level when no FastPlace violation occurs. */
+    public final double     fastPlaceVlDecay;
     public final ActionList fastPlaceActions;
 
     public final Set<Material> noSwingExceptions = new HashSet<Material>();
@@ -81,6 +85,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         final ConfigFile config = worldData.getRawConfiguration();
 
         againstActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, Permissions.BLOCKPLACE_AGAINST);
+        againstVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.99);
 
         autoSignSkipEmpty = config.getBoolean(ConfPaths.BLOCKPLACE_AUTOSIGN_SKIPEMPTY);
         autoSignActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AUTOSIGN_ACTIONS, Permissions.BLOCKPLACE_AUTOSIGN);
@@ -93,6 +98,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         fastPlaceShortTermLimit = config.getInt(ConfPaths.BLOCKPLACE_FASTPLACE_SHORTTERM_LIMIT);
         fastPlaceImprobableFeedOnly = config.getBoolean(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY);
         fastPlaceImprobableWeight = (float) config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT);
+        fastPlaceVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.95);
         fastPlaceActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, Permissions.BLOCKPLACE_FASTPLACE);
 
         config.readMaterialFromList(ConfPaths.BLOCKPLACE_NOSWING_EXCEPTIONS, noSwingExceptions);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
@@ -101,7 +101,7 @@ public class FastPlace extends Check {
             cancel = executeActions(player, data.fastPlaceVL, change, cc.fastPlaceActions).willCancel();
         }
         else if (data.fastPlaceVL > 0d && fullScore < cc.fastPlaceLimit * .75) {
-            data.fastPlaceVL *= 0.95;
+            data.fastPlaceVL *= cc.fastPlaceVlDecay;
         }
 
         return cancel;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
@@ -53,6 +53,8 @@ public class ChatConfig extends ACheckConfig {
     public final double       commandsLevel;
     public final int          commandsShortTermTicks;
     public final double       commandsShortTermLevel;
+    /** Factor multiplied with the violation level when command spam subsides. */
+    public final double       commandsVlDecay;
     public final ActionList   commandsActions;
 
     // Potentially add sub check types
@@ -69,6 +71,8 @@ public class ChatConfig extends ACheckConfig {
     public final float        textFreqShortTermLevel;
     public final float        textFreqShortTermMin;
     public final ActionList   textFreqShortTermActions;
+    /** Factor multiplied with the violation level when chat spam subsides. */
+    public final double       textVlDecay;
     public final float        textMessageLetterCount;
     public final float        textMessageUpperCase;
     public final float        textMessagePartition;
@@ -130,6 +134,7 @@ public class ChatConfig extends ACheckConfig {
         commandsLevel = config.getDouble(ConfPaths.CHAT_COMMANDS_LEVEL);
         commandsShortTermTicks = config.getInt(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS);
         commandsShortTermLevel = config.getDouble(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL);
+        commandsVlDecay = config.getDouble(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.99);
         commandsActions = config.getOptimizedActionList(ConfPaths.CHAT_COMMANDS_ACTIONS, Permissions.CHAT_COMMANDS);
 
         textGlobalCheck = config.getBoolean(ConfPaths.CHAT_TEXT_GL_CHECK, true);
@@ -162,6 +167,7 @@ public class ChatConfig extends ACheckConfig {
         textDebug = config.getBoolean(ConfPaths.CHAT_TEXT_DEBUG, false);
         textFreqNormActions = config.getOptimizedActionList(ConfPaths.CHAT_TEXT_FREQ_NORM_ACTIONS, Permissions.CHAT_TEXT);
         textAllowVLReset = config.getBoolean(ConfPaths.CHAT_TEXT_ALLOWVLRESET);
+        textVlDecay = config.getDouble(ConfPaths.CHAT_TEXT_VL_DECAY, 0.95);
 
         chatWarningCheck = config.getBoolean(ConfPaths.CHAT_WARNING_CHECK);
         chatWarningLevel = (float) config.getDouble(ConfPaths.CHAT_WARNING_LEVEL);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
@@ -126,7 +126,7 @@ public class Commands extends Check {
             player.sendMessage(ColorUtil.replaceColors(cc.chatWarningMessage));
             data.chatWarningTime = now;
         } else {
-            data.commandsVL *= 0.99;
+            data.commandsVL *= cc.commandsVlDecay;
         }
         return false;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
@@ -371,7 +371,7 @@ public class Text extends Check implements INotifyReload {
                     ColorUtil.replaceColors(cc.chatWarningMessage));
             data.chatWarningTime = time;
         } else {
-            data.textVL *= 0.95;
+            data.textVL *= cc.textVlDecay;
             if (cc.textAllowVLReset && normalScore < 2.0f * cc.textFreqNormWeight
                     && shortTermScore < 2.0f * cc.textFreqShortTermWeight) {
                 data.textVL = 0.0;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightConfig.java
@@ -77,6 +77,8 @@ public class FightConfig extends ACheckConfig {
     public final ActionList reachActions;
 
     public final ActionList selfHitActions;
+    /** Factor multiplied with violation level when self hit attempts cease. */
+    public final double selfHitVlDecay;
 
     public final int        speedLimit;
     public final int        speedBuckets;
@@ -166,6 +168,7 @@ public class FightConfig extends ACheckConfig {
         reachActions = config.getOptimizedActionList(ConfPaths.FIGHT_REACH_ACTIONS, Permissions.FIGHT_REACH);
 
         selfHitActions = config.getOptimizedActionList(ConfPaths.FIGHT_SELFHIT_ACTIONS, Permissions.FIGHT_SELFHIT);
+        selfHitVlDecay = config.getDouble(ConfPaths.FIGHT_SELFHIT_VL_DECAY, 0.99);
 
         speedLimit = config.getInt(ConfPaths.FIGHT_SPEED_LIMIT);
         speedBuckets = config.getInt(ConfPaths.FIGHT_SPEED_BUCKETS_N, 6);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/SelfHit.java
@@ -33,7 +33,7 @@ public class SelfHit extends Check {
         // Treat self hitting as instant violation.
         data.selfHitVL.add(System.currentTimeMillis(), 1.0f);
         // NOTE: This lets VL decrease slightly over 30 seconds, one could also use a number, but  this is more tolerant.
-        cancel = executeActions(damager, data.selfHitVL.score(0.99f), 1.0f, cc.selfHitActions).willCancel();
+        cancel = executeActions(damager, data.selfHitVL.score((float) cc.selfHitVlDecay), 1.0f, cc.selfHitActions).willCancel();
 
         return cancel;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
@@ -192,7 +192,7 @@ public class FastClick extends Check {
             }
             return executeActions(vd).willCancel();
         }
-        data.fastClickVL *= 0.99;
+        data.fastClickVL *= cc.fastClickVlDecay;
         return false;
     }
     

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
@@ -45,6 +45,8 @@ public class InventoryConfig extends ACheckConfig {
     public final int        chestOpenLimit;
     public final Set<String> inventoryExemptions = new HashSet<String>();
     public final float      fastClickImprobableWeight;
+    /** Factor multiplied with the violation level when FastClick passes checks. */
+    public final double     fastClickVlDecay;
     public final ActionList fastClickActions;
 
     public final long		fastConsumeDuration;
@@ -92,6 +94,7 @@ public class InventoryConfig extends ACheckConfig {
         chestOpenLimit = data.getInt(ConfPaths.INVENTORY_FASTCLICK_LIMIT_CHEST);
         data.readStringlFromList(ConfPaths.INVENTORY_FASTCLICK_EXCLUDE, inventoryExemptions);
         fastClickImprobableWeight = (float) data.getDouble(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT);
+        fastClickVlDecay = data.getDouble(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.99);
         fastClickActions = data.getOptimizedActionList(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, Permissions.INVENTORY_FASTCLICK);
 
         if (ServerVersion.compareMinecraftVersion("1.9") >= 0) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -106,6 +106,8 @@ public class MovingConfig extends ACheckConfig {
     public ActionList passableActions;
     public double     passableHorizontalMargins;
     public double     passableVerticalMargins;
+    /** Factor multiplied with violation level when Passable passes checks. */
+    public double     passableVlDecay;
     public boolean    passableUntrackedTeleportCheck;
     public boolean    passableUntrackedCommandCheck;
     public boolean    passableUntrackedCommandTryTeleport;
@@ -133,6 +135,8 @@ public class MovingConfig extends ACheckConfig {
     public double     hBufMax;
     public long       survivalFlyVLFreezeCount;
     public boolean    survivalFlyVLFreezeInAir;
+    /** Factor multiplied with violation level when SurvivalFly passes checks. */
+    public double     survivalFlyVlDecay;
     // Set back policy.
     public boolean    sfSetBackPolicyVoid;
     public boolean    sfSetBackPolicyApplyFallDamage;
@@ -189,6 +193,8 @@ public class MovingConfig extends ACheckConfig {
 
     public HashMap<EntityType, Double> vehicleEnvelopeHorizontalSpeedCap = new HashMap<EntityType, Double>();
     public ActionList vehicleEnvelopeActions;
+    /** Factor multiplied with violation level when VehicleEnvelope passes checks. */
+    public double vehicleEnvelopeVlDecay;
 
     // Trace
     public int traceMaxAge;
@@ -340,6 +346,7 @@ public class MovingConfig extends ACheckConfig {
                 Permissions.MOVING_PASSABLE);
         passableHorizontalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_XZ_FACTOR, 0.1, 1.0, 0.999999);
         passableVerticalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_Y_FACTOR, 0.1, 1.0, 0.999999);
+        passableVlDecay = config.getDouble(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.99);
         passableUntrackedTeleportCheck = config.getBoolean(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE);
         passableUntrackedCommandCheck = config.getBoolean(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_ACTIVE);
         passableUntrackedCommandTryTeleport = config.getBoolean(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_TRYTELEPORT);
@@ -380,6 +387,7 @@ public class MovingConfig extends ACheckConfig {
         hBufMax = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_HBUFMAX);
         survivalFlyVLFreezeCount = config.getInt(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT);
         survivalFlyVLFreezeInAir = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR);
+        survivalFlyVlDecay = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.95);
         survivalFlyActions = config.getOptimizedActionList(ConfPaths.MOVING_SURVIVALFLY_ACTIONS,
                 Permissions.MOVING_SURVIVALFLY);
 
@@ -455,6 +463,7 @@ public class MovingConfig extends ACheckConfig {
                 vehicleEnvelopeHorizontalSpeedCap, 4.0, true);
         vehicleEnvelopeActions = config.getOptimizedActionList(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS,
                 Permissions.MOVING_VEHICLE_ENVELOPE);
+        vehicleEnvelopeVlDecay = config.getDouble(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.99);
         List<String> types;
         if (config.get(ConfPaths.MOVING_VEHICLE_IGNOREDVEHICLES) == null) {
             types = Arrays.asList("arrow", "spectral_arrow", "tipped_arrow");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
@@ -103,7 +103,7 @@ public class Passable extends Check {
         // Finally handle violations.
         if (newTag == null) {
             // (Might consider if vl>=1: only decrease if from and loc are passable too, though micro...)
-            data.passableVL *= 0.99;
+            data.passableVL *= cc.passableVlDecay;
             return null;
         }
         else {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -487,7 +487,7 @@ public class SurvivalFly extends Check {
                     && lastMove.toIsValid
                     && lastMove.yDistance < -Magic.GRAVITY_MIN
                     && thisMove.yDistance - lastMove.yDistance < -Magic.GRAVITY_MIN)) {
-            data.survivalFlyVL *= 0.95;
+            data.survivalFlyVL *= cc.survivalFlyVlDecay;
             if (hDistanceAboveLimit < 0.0 && result <= 0.0 && !isSamePos && data.sfHorizontalBuffer < cc.hBufMax
                     && !data.sfLowJump) {
                 hBufRegain(hDistance, Math.min(0.2, Math.abs(hDistanceAboveLimit)), data, cc);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/vehicle/VehicleEnvelope.java
@@ -169,7 +169,7 @@ public class VehicleEnvelope extends Check {
             }
         }
         else {
-            data.vehicleEnvelopeVL *= 0.99; // Random cool down for now.
+            data.vehicleEnvelopeVL *= cc.vehicleEnvelopeVlDecay; // Random cool down for now.
             // Do not set a set back here.
         }
         return null;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -209,6 +209,8 @@ public abstract class ConfPaths {
     public static final String  BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT     = BLOCKBREAK_FREQUENCY_SHORTTERM + "limit";
     public static final String  BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS     = BLOCKBREAK_FREQUENCY_SHORTTERM + "ticks";
     public static final String  BLOCKBREAK_FREQUENCY_ACTIONS             = BLOCKBREAK_FREQUENCY + "actions";
+    /** Factor used to decay violation level for the Frequency check. */
+    public static final String  BLOCKBREAK_FREQUENCY_VL_DECAY            = BLOCKBREAK_FREQUENCY + "vldecay";
 
     private static final String BLOCKBREAK_NOSWING                       = BLOCKBREAK + "noswing.";
     public static final String  BLOCKBREAK_NOSWING_CHECK                 = BLOCKBREAK_NOSWING + SUB_ACTIVE;
@@ -241,11 +243,15 @@ public abstract class ConfPaths {
     public static final String BLOCKINTERACT_SPEED_CHECK                 = BLOCKINTERACT_SPEED + SUB_ACTIVE;
     public static final String BLOCKINTERACT_SPEED_INTERVAL              = BLOCKINTERACT_SPEED + "interval";
     public static final String BLOCKINTERACT_SPEED_LIMIT                 = BLOCKINTERACT_SPEED + "limit";
+    /** Factor used to decay violation level for block interaction speed. */
+    public static final String BLOCKINTERACT_SPEED_VL_DECAY              = BLOCKINTERACT_SPEED + "vldecay";
     public static final String BLOCKINTERACT_SPEED_ACTIONS               = BLOCKINTERACT_SPEED + "actions";
 
     private static final String BLOCKINTERACT_VISIBLE                    = BLOCKINTERACT + "visible.";
     public static final String  BLOCKINTERACT_VISIBLE_CHECK              = BLOCKINTERACT_VISIBLE + SUB_ACTIVE;
     public static final String  BLOCKINTERACT_VISIBLE_ACTIONS            = BLOCKINTERACT_VISIBLE + "actions";
+    /** Factor used to decay violation level for visibility check. */
+    public static final String  BLOCKINTERACT_VISIBLE_VL_DECAY           = BLOCKINTERACT_VISIBLE + "vldecay";
 
     // BLOCKPLACE
     public static final String  BLOCKPLACE                               = CHECKS + "blockplace.";
@@ -254,6 +260,8 @@ public abstract class ConfPaths {
     private static final String BLOCKPLACE_AGAINST                       = BLOCKPLACE + "against.";
     public static final String  BLOCKPLACE_AGAINST_CHECK                 = BLOCKPLACE_AGAINST + SUB_ACTIVE;
     public static final String BLOCKPLACE_AGAINST_ACTIONS                = BLOCKPLACE_AGAINST + "actions";
+    /** Factor used to decay violation level for the Against check. */
+    public static final String BLOCKPLACE_AGAINST_VL_DECAY               = BLOCKPLACE_AGAINST + "vldecay";
 
     private static final String BLOCKPLACE_AUTOSIGN                         = BLOCKPLACE + "autosign.";
     public static final String  BLOCKPLACE_AUTOSIGN_CHECK                = BLOCKPLACE_AUTOSIGN + SUB_ACTIVE;
@@ -273,6 +281,8 @@ public abstract class ConfPaths {
     private static final String BLOCKPLACE_FASTPLACE_IMPROBABLE          = BLOCKPLACE_FASTPLACE + "improbable.";
     public static final String  BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY = BLOCKPLACE_FASTPLACE_IMPROBABLE + "feedonly";
     public static final String  BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT   = BLOCKPLACE_FASTPLACE_IMPROBABLE + "weight";
+    /** Factor used to decay violation level for the FastPlace check. */
+    public static final String  BLOCKPLACE_FASTPLACE_VL_DECAY            = BLOCKPLACE_FASTPLACE + "vldecay";
     public static final String  BLOCKPLACE_FASTPLACE_ACTIONS             = BLOCKPLACE_FASTPLACE + "actions";
 
     private static final String BLOCKPLACE_NOSWING                       = BLOCKPLACE + "noswing.";
@@ -336,6 +346,8 @@ public abstract class ConfPaths {
     public static final String  CHAT_COMMANDS_SHORTTERM_TICKS            = CHAT_COMMANDS_SHORTTERM + "ticks";
     public static final String  CHAT_COMMANDS_SHORTTERM_LEVEL            = CHAT_COMMANDS_SHORTTERM + "level";
     public static final String  CHAT_COMMANDS_ACTIONS                    = CHAT_COMMANDS + "actions";
+    /** Factor used to decay violation level for command spam. */
+    public static final String  CHAT_COMMANDS_VL_DECAY                   = CHAT_COMMANDS + "vldecay";
 
     // Text
     private static final String CHAT_TEXT                                = CHAT + "text.";
@@ -343,6 +355,8 @@ public abstract class ConfPaths {
     public static final String CHAT_TEXT_DEBUG                           = CHAT_TEXT + "debug";
     public static final String CHAT_TEXT_ENGINE_MAXIMUM                  = CHAT_TEXT + "maximum";
     public static final String CHAT_TEXT_ALLOWVLRESET                    = CHAT_TEXT + "allowvlreset";
+    /** Factor used to decay violation level for chat spam. */
+    public static final String CHAT_TEXT_VL_DECAY                        = CHAT_TEXT + "vldecay";
     public static final String CHAT_TEXT_FREQ                            = CHAT_TEXT + "frequency.";
     public static final String CHAT_TEXT_FREQ_NORM                       = CHAT_TEXT_FREQ + "normal.";
     public static final String CHAT_TEXT_FREQ_NORM_FACTOR                = CHAT_TEXT_FREQ_NORM + "factor";
@@ -439,6 +453,8 @@ public abstract class ConfPaths {
     public static final String  COMBINED_IMPROBABLE_CHECK                = COMBINED_IMPROBABLE + SUB_ACTIVE;
     public static final String  COMBINED_IMPROBABLE_LEVEL                = COMBINED_IMPROBABLE + "level";
     public static final String  COMBINED_IMPROBABLE_ACTIONS              = COMBINED_IMPROBABLE + "actions";
+    /** Factor used to decay violation level for improbable behavior. */
+    public static final String  COMBINED_IMPROBABLE_VL_DECAY             = COMBINED_IMPROBABLE + "vldecay";
 
     private static final String COMBINED_INVULNERABLE                       = COMBINED + "invulnerable.";
     public static final String  COMBINED_INVULNERABLE_CHECK                 = COMBINED_INVULNERABLE + SUB_ACTIVE;
@@ -538,6 +554,8 @@ public abstract class ConfPaths {
 	public static final String FIGHT_SELFHIT_EXCLUDEPROJECTILE           = FIGHT_SELFHIT + "excludeprojectile";
 	public static final String FIGHT_SELFHIT_MESSAGE                     = FIGHT_SELFHIT + "warn_player";
     public static final String FIGHT_SELFHIT_ACTIONS                     = FIGHT_SELFHIT + "actions";
+    /** Factor used to decay violation level for self hit detection. */
+    public static final String FIGHT_SELFHIT_VL_DECAY                     = FIGHT_SELFHIT + "vldecay";
 
 
     private static final String FIGHT_SPEED                              = FIGHT + "speed.";
@@ -578,6 +596,8 @@ public abstract class ConfPaths {
     public static final String  INVENTORY_FASTCLICK_LIMIT_CHEST          = INVENTORY_FASTCLICK_LIMIT + "chest";
     private static final String INVENTORY_FASTCLICK_IMPROBABLE           = INVENTORY_FASTCLICK + "improbable.";
     public static final String  INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT    = INVENTORY_FASTCLICK_IMPROBABLE + "weight";
+    /** Factor used to decay violation level for fast clicking. */
+    public static final String  INVENTORY_FASTCLICK_VL_DECAY             = INVENTORY_FASTCLICK + "vldecay";
     public static final String  INVENTORY_FASTCLICK_ACTIONS              = INVENTORY_FASTCLICK + "actions";
 
     private static final String INVENTORY_FASTCONSUME                    = INVENTORY + "fastconsume.";
@@ -668,6 +688,8 @@ public abstract class ConfPaths {
     public static final String  MOVING_PASSABLE_CHECK                       = MOVING_PASSABLE + SUB_ACTIVE;
     //private static final String MOVING_PASSABLE_RAYTRACING                  = MOVING_PASSABLE + "raytracing.";
     public static final String  MOVING_PASSABLE_ACTIONS                     = MOVING_PASSABLE + "actions";
+    /** Factor used to decay violation level for the passable check. */
+    public static final String  MOVING_PASSABLE_VL_DECAY                    = MOVING_PASSABLE + "vldecay";
     public static final String  MOVING_PASSABLE_RT_XZ_FACTOR                = MOVING_PASSABLE + "horizontalmargins";
     public static final String  MOVING_PASSABLE_RT_Y_FACTOR                 = MOVING_PASSABLE + "verticalmargins";
     private static final String MOVING_PASSABLE_UNTRACKED                   = MOVING_PASSABLE + "untracked.";
@@ -699,6 +721,8 @@ public abstract class ConfPaths {
     public static final String  MOVING_SURVIVALFLY_LENIENCY_HBUFMAX         = MOVING_SURVIVALFLY_LENIENCY + "hbufmax";
     public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT     = MOVING_SURVIVALFLY_LENIENCY + "freezecount";
     public static final String  MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR     = MOVING_SURVIVALFLY_LENIENCY + "freezeinair";
+    /** Factor used to decay violation level for survival fly. */
+    public static final String  MOVING_SURVIVALFLY_VL_DECAY                 = MOVING_SURVIVALFLY_LENIENCY + "vldecay";
     private static final String MOVING_SURVIVALFLY_SETBACKPOLICY            = MOVING_SURVIVALFLY + "setbackpolicy.";
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE = MOVING_SURVIVALFLY_SETBACKPOLICY + "applyfalldamage";
     @Moved(newPath = MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE)
@@ -770,6 +794,8 @@ public abstract class ConfPaths {
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIVE              = MOVING_VEHICLE_ENVELOPE + SUB_ACTIVE;
     public static final String  MOVING_VEHICLE_ENVELOPE_HSPEEDCAP           = MOVING_VEHICLE_ENVELOPE + "hdistcap"; // Section.
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIONS             = MOVING_VEHICLE_ENVELOPE + "actions";
+    /** Factor used to decay violation level for the VehicleEnvelope check. */
+    public static final String  MOVING_VEHICLE_ENVELOPE_VL_DECAY            = MOVING_VEHICLE_ENVELOPE + "vldecay";
 
     private static final String MOVING_MESSAGE                              = MOVING + "message.";
     public static final  String MOVING_MESSAGE_ILLEGALPLAYERMOVE            = MOVING_MESSAGE + "illegalplayermove";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -135,6 +135,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKBREAK_FREQUENCY_MOD_SURVIVAL, 45, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS, 5, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT, 7, 785);
+        set(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.95, 1154);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, "cancel vl>5 log:bbfrequency:3:5:i cancel vl>40 log:bbfrequency:0:5:if cancel cmdc:kickfrequency:0:5", 1154);
         // NoSwing
         set(ConfPaths.BLOCKBREAK_NOSWING_CHECK, "default", 785);
@@ -161,17 +162,20 @@ public class DefaultConfig extends ConfigFile {
         // Speed
         set(ConfPaths.BLOCKINTERACT_SPEED_CHECK, "default", 785);
         set(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL, 2000, 785);
-        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154); 
+        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154);
+        set(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.99, 1154);
         set(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, "cancel vl>10 cancel log:bspeed:5:4:i cancel vl>500 cancel log:bspeed:0:5:icf cmdc:kickbspeed:2:5", 1154);
         // Visible
         set(ConfPaths.BLOCKINTERACT_VISIBLE_CHECK, "default", 785);
-        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154); 
+        set(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.99, 1154);
+        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154);
 
 
         /* BlockPlace */
         set(ConfPaths.BLOCKPLACE_ACTIVE, "default", 1144);
         // Against
         set(ConfPaths.BLOCKPLACE_AGAINST_CHECK, "default", 785);
+        set(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.99, 1154);
         set(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, "cancel log:against:1:5:i vl>10 cancel log:against:0:2:if cmdc:kickagainst:0:10", 1154);
         // AutoSign
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_CHECK, "default", 785);
@@ -187,6 +191,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKPLACE_FASTPLACE_SHORTTERM_LIMIT, 6, 785);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT, 0.3, 1154);
+        set(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.95, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, "cancel vl>5 cancel log:fastplace:8:3:i vl>20 cancel log:fastplace:2:4:i vl>80 cancel log:fastplace:0:10:if cmdc:kickfastplace:1:10", 1154);
         // Reach
         set(ConfPaths.BLOCKPLACE_REACH_CHECK, "default", 785);
@@ -235,11 +240,13 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.CHAT_COMMANDS_LEVEL, 10, 785);
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS, 18, 785);
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL, 3, 785);
+        set(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.99, 1154);
         set(ConfPaths.CHAT_COMMANDS_ACTIONS, "log:commands:0:5:cf cancel cmdc:kickcommands vl>20 log:commands:0:5:cf cancel cmdc:tempkick1", 1154);
         // Text (ordering on purpose).
         // Normal
         set(ConfPaths.CHAT_TEXT_CHECK, "default", 785);
         set(ConfPaths.CHAT_TEXT_ALLOWVLRESET, true, 785);
+        set(ConfPaths.CHAT_TEXT_VL_DECAY, 0.95, 1154);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_MIN, 0.0, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_FACTOR, 0.9D, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_WEIGHT, 6, 785);
@@ -305,6 +312,7 @@ public class DefaultConfig extends ConfigFile {
         // Improbable
         set(ConfPaths.COMBINED_IMPROBABLE_CHECK , "default", 785);
         set(ConfPaths.COMBINED_IMPROBABLE_LEVEL, 250, 1154);
+        set(ConfPaths.COMBINED_IMPROBABLE_VL_DECAY, 0.95, 1154);
         set(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, "cancel vl>20 log:improbable:8:9:if cancel vl>1500 cancel log:improbable:0:10:if cmdc:kickimprobable:0:5", 1154);
         // Invulnerable
         set(ConfPaths.COMBINED_INVULNERABLE_CHECK, true, 785); // Not a check type yet.
@@ -383,6 +391,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.FIGHT_REACH_ACTIONS, "cancel vl>1 cancel log:freach:8:9:i vl>5 cancel log:freach:2:6:i vl>12 cancel log:freachhighvl:1:5:if vl>35 cancel log:freachhighvl:0:5:if cmdc:kicksuspiciouscombat:2:1", 1154);
         // SelfHit, legacy
         set(ConfPaths.FIGHT_SELFHIT_CHECK, "default", 785);
+        set(ConfPaths.FIGHT_SELFHIT_VL_DECAY, 0.99, 1154);
         set(ConfPaths.FIGHT_SELFHIT_ACTIONS, "cancel log:fselfhit:0:5:icf cmdc:kickselfhit:0:5", 1154);
         // Speed
         set(ConfPaths.FIGHT_SPEED_CHECK, "default", 785);
@@ -408,6 +417,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.INVENTORY_FASTCLICK_LIMIT_NORMAL, 15, 785);
         set(ConfPaths.INVENTORY_FASTCLICK_LIMIT_CHEST, 155, 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT, 0.7, 1154);
+        set(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.99, 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, "cancel vl>150 cancel log:fastclick:7:5:i vl>400 cancel log:fastclick:1:5:if vl>3000 cancel log:fastclick:1:2:if cmdc:kickfastclick:2:5", 1154);
         // InstantBow
         set(ConfPaths.INVENTORY_INSTANTBOW_CHECK, "default", 785);
@@ -532,6 +542,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_NOFALL_ACTIONS, "cancel vl>2 cancel log:nofall:0:5:if", 1154); //vl>6 cancel log:nofall:0:1:if cmdc:kickfly:0:5", 1154);
         // Passable
         set(ConfPaths.MOVING_PASSABLE_CHECK, "default", 785);
+        set(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.99, 1154);
         set(ConfPaths.MOVING_PASSABLE_ACTIONS, "cancel vl>15 cancel log:passable:7:9:i vl>100 cancel log:passable:1:4:if", 1154);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE, true, 785);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_ACTIVE, true, 785);
@@ -556,6 +567,7 @@ public class DefaultConfig extends ConfigFile {
         // More leniency features
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZECOUNT, 40, 1144);
         set(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR, true, 1143);
+        set(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.95, 1154);
         // MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE -> MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID, false, 1154);
@@ -605,6 +617,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIVE, "default", 785);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".default", 0.9, 1154);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".pig", 0.3, 1154);
+        set(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.99, 1154);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS, "cancel vl>50 cancel log:vehicleenvelope:10:6:if vl>300 cancel log:vehicleenvelope:0:10:if cmdc:kickvehiclefly:0:10", 1154);
         // Messages
         set(ConfPaths.MOVING_MESSAGE_ILLEGALPLAYERMOVE, "Illegal move.", 785);


### PR DESCRIPTION
## Summary
- add configuration fields for violation decay across checks
- load new fields in config classes
- apply decay factors instead of magic numbers
- document effect on violation level

## Testing
- `mvn -q verify` *(fails: spotbugs flagged EI_EXPOSE_REP and other issues)*

------
https://chatgpt.com/codex/tasks/task_b_685d474d93cc8329be2e92935bae4553