### PR TITLE
Refactor burnStart calculation

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -50,7 +50,6 @@ public class NetStatic {
         int burnStart = winNum;
         int empty = 0;
         boolean firstUsed = false;
-        boolean counting = false;
         final float[] bucketScores = new float[winNum];
         for (int i = 0; i < winNum; i++) {
             bucketScores[i] = packetFreq.bucketScore(i);
@@ -60,11 +59,17 @@ public class NetStatic {
             if (bucket > 0f) {
                 if (!firstUsed) {
                     firstUsed = true;
-                } else if (!counting) {
+                } else {
                     burnStart = i;
-                    counting = true;
+                    break;
                 }
-            } else if (counting) {
+            }
+        }
+        if (burnStart < winNum) {
+            for (int i = burnStart + 1; i < winNum; i++) {
+                if (bucketScores[i] > 0f) {
+                    break;
+                }
                 empty++;
             }
         }


### PR DESCRIPTION
## Summary
- stop iterating once the second occupied bucket is found
- count empty buckets after `burnStart` in a separate step

## Testing
- `mvn -q verify` *(fails: TestImprobable errors)*
- `mvn -q checkstyle:check pmd:check com.github.spotbugs:spotbugs-maven-plugin:4.9.3.0:check` *(fails: spotbugs warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685ea9ace34883298290ecd46aad4035