### PR TITLE
Fix boat passenger remount after teleport

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -42,6 +42,7 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.CheckUtils;
 import fr.neatmonster.nocheatplus.utilities.location.LocUtil;
 import fr.neatmonster.nocheatplus.utilities.location.TrigUtil;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Vehicle/passenger related static utility. Registered as generic instance for
@@ -384,11 +385,14 @@ public class PassengerUtil {
         boolean scheduleDelay = cc.schedulevehicleSetPassenger;
         if (data.vehicleSetPassengerTaskId == null) {
             if (vehicle.getType() == EntityType.BOAT) {
-                if (!handleVehicle.getHandle().addPassenger(player, vehicle)) {
-                    vehicle.eject();
-                    // Not schedule set passenger for boat due to location async
-                }
-            } else if (scheduleDelay) {
+                addPassengerWithRetry(player, vehicle, 2).thenAccept(success -> {
+                    if (!success) {
+                        vehicle.eject();
+                    }
+                });
+                return;
+            }
+            if (scheduleDelay) {
                 data.vehicleSetPassengerTaskId = Folia.runSyncDelayedTaskForEntity(player, plugin,
                         (arg) -> new VehicleSetPassengerTask(handleVehicle, vehicle, player).run(), null, 2L);
                 if (data.vehicleSetPassengerTaskId == null) {
@@ -414,6 +418,28 @@ public class PassengerUtil {
         } else if (debug) {
             CheckUtils.debug(player, CheckType.MOVING_VEHICLE,
                     "Set passenger task already scheduled, skip this time.");
+        }
+    }
+
+    private CompletableFuture<Boolean> addPassengerWithRetry(final Entity passenger, final Entity vehicle,
+                                                             final int remaining) {
+        final CompletableFuture<Boolean> result = new CompletableFuture<>();
+        attemptAddPassenger(passenger, vehicle, remaining, result);
+        return result;
+    }
+
+    private void attemptAddPassenger(final Entity passenger, final Entity vehicle, final int remaining,
+                                     final CompletableFuture<Boolean> result) {
+        if (passenger == null || vehicle == null || result.isDone()) {
+            result.complete(false);
+            return;
+        }
+        if (handleVehicle.getHandle().addPassenger(passenger, vehicle)) {
+            result.complete(true);
+        } else if (remaining <= 0 || plugin == null) {
+            result.complete(false);
+        } else {
+            Folia.runSyncDelayedTask(plugin, (arg) -> attemptAddPassenger(passenger, vehicle, remaining - 1, result), 1L);
         }
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtil.java
@@ -422,25 +422,34 @@ public class PassengerUtil {
     }
 
     private CompletableFuture<Boolean> addPassengerWithRetry(final Entity passenger, final Entity vehicle,
-                                                             final int remaining) {
+                                                             final int maxRetries) {
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
-        attemptAddPassenger(passenger, vehicle, remaining, result);
-        return result;
-    }
-
-    private void attemptAddPassenger(final Entity passenger, final Entity vehicle, final int remaining,
-                                     final CompletableFuture<Boolean> result) {
-        if (passenger == null || vehicle == null || result.isDone()) {
+        if (passenger == null || vehicle == null) {
             result.complete(false);
-            return;
+            return result;
         }
         if (handleVehicle.getHandle().addPassenger(passenger, vehicle)) {
             result.complete(true);
-        } else if (remaining <= 0 || plugin == null) {
-            result.complete(false);
-        } else {
-            Folia.runSyncDelayedTask(plugin, (arg) -> attemptAddPassenger(passenger, vehicle, remaining - 1, result), 1L);
+            return result;
         }
+        if (maxRetries <= 0 || plugin == null) {
+            result.complete(false);
+            return result;
+        }
+        final int[] remaining = { maxRetries };
+        final Object task = Folia.runSyncRepeatingTask(plugin, (arg) -> {
+            if (handleVehicle.getHandle().addPassenger(passenger, vehicle)) {
+                result.complete(true);
+                Folia.cancelTask(arg);
+            } else if (--remaining[0] <= 0) {
+                result.complete(false);
+                Folia.cancelTask(arg);
+            }
+        }, 1L, 1L);
+        if (task == null) {
+            result.complete(false);
+        }
+        return result;
     }
 
     private void ensureSetBackLocation(final Player player, final Location location,

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
@@ -37,6 +37,20 @@ public class PassengerUtilTest {
         }
     }
 
+    private static class FailingVehicleAccess extends DummyVehicleAccess {
+        private final int fails;
+        private int calls;
+        FailingVehicleAccess(int fails) { this.fails = fails; }
+        @Override
+        public boolean addPassenger(Entity entity, Entity vehicle) {
+            calls++;
+            if (calls <= fails) {
+                return false;
+            }
+            return super.addPassenger(entity, vehicle);
+        }
+    }
+
     private sun.misc.Unsafe unsafe;
 
     @Before
@@ -91,5 +105,31 @@ public class PassengerUtilTest {
         MovingData data = newData();
         sched.invoke(util, player, vehicle, cfg, data, false);
         assertTrue(access.called);
+    }
+
+    @Test
+    public void testAddPassengerWithRetrySuccessNoPlugin() throws Exception {
+        DummyVehicleAccess access = new DummyVehicleAccess();
+        PassengerUtil util = newUtil(access);
+        Method m = PassengerUtil.class.getDeclaredMethod("addPassengerWithRetry", Entity.class, Entity.class, int.class);
+        m.setAccessible(true);
+        Player player = mock(Player.class);
+        Entity vehicle = mock(Entity.class);
+        @SuppressWarnings("unchecked")
+        java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
+        assertTrue(res.get());
+    }
+
+    @Test
+    public void testAddPassengerWithRetryFailNoPlugin() throws Exception {
+        FailingVehicleAccess access = new FailingVehicleAccess(1);
+        PassengerUtil util = newUtil(access);
+        Method m = PassengerUtil.class.getDeclaredMethod("addPassengerWithRetry", Entity.class, Entity.class, int.class);
+        m.setAccessible(true);
+        Player player = mock(Player.class);
+        Entity vehicle = mock(Entity.class);
+        @SuppressWarnings("unchecked")
+        java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
+        assertFalse(res.get());
     }
 }


### PR DESCRIPTION
## Summary
- retry adding passengers to boats when teleporting
- unit test addPassengerWithRetry

## Testing
- `mvn -q test` *(fails: TestImprobable errors)*
- `mvn -q -DskipTests checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685eaa48d2188329acaa652c9049d763

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a retry mechanism using `CompletableFuture` to ensure players are successfully added as passengers to boats after teleportation, and include unit tests for this functionality.

### Why are these changes being made?

This change addresses an issue where failing to add passengers to boats resulted in an inconsistent user experience after teleportation. The retry mechanism improves reliability and the accompanying tests ensure the robustness of the solution.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->