### PR TITLE
Handle instabreak in fast break check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -234,13 +234,14 @@ public class BlockBreakListener extends CheckListener {
     private void applyFastBreakCheck(final BreakCheckResult result, final Player player,
             final Block block, final GameMode gameMode, final BlockBreakConfig cc,
             final BlockBreakData data, final IPlayerData pData) {
-        if (block == null) {
-            return;
-        }
-        if (!result.cancelled && gameMode != GameMode.CREATIVE
+        if (block != null && !result.cancelled && gameMode != GameMode.CREATIVE
                 && fastBreak.isEnabled(player, pData)
-                && fastBreak.check(new FastBreakContext(player, block, cc, data, pData, isInstaBreak))) {
-            result.cancelled = true;
+                && !FastBreakDecision.shouldSkip(isInstaBreak)) {
+            final FastBreakContext ctx = new FastBreakContext(player, block, cc, data, pData,
+                    isInstaBreak);
+            if (fastBreak.check(ctx)) {
+                result.cancelled = true;
+            }
         }
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -54,6 +54,7 @@ import fr.neatmonster.nocheatplus.stats.Counters;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
+import fr.neatmonster.nocheatplus.checks.blockbreak.FastBreakContext;
 import fr.neatmonster.nocheatplus.worlds.WorldFactoryArgument;
 
 /**
@@ -238,7 +239,7 @@ public class BlockBreakListener extends CheckListener {
         }
         if (!result.cancelled && gameMode != GameMode.CREATIVE
                 && fastBreak.isEnabled(player, pData)
-                && fastBreak.check(player, block, isInstaBreak, cc, data, pData)) {
+                && fastBreak.check(new FastBreakContext(player, block, cc, data, pData, isInstaBreak))) {
             result.cancelled = true;
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -53,13 +53,15 @@ public class FastBreak extends Check {
      *            the player
      * @param block
      *            the block
-     * @param isInstaBreak 
+     * @param isInstaBreak
+     *            indicates that the block was flagged as instantly
+     *            breakable. Values other than {@link AlmostBoolean#NO}
+     *            cause the check to adjust or skip violation handling.
      * @param data 
      * @param cc 
-     * @param elaspedTime
      * @return true, if successful
      */
-    public boolean check(final Player player, final Block block, final AlmostBoolean isInstaBreak, 
+    public boolean check(final Player player, final Block block, final AlmostBoolean isInstaBreak,
             final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
         final long now = Monotonic.millis();
         boolean cancel = false;
@@ -80,23 +82,23 @@ public class FastBreak extends Check {
             elapsedTime = (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
         }
 
+        final long adjustedElapsed = adjustElapsedTime(elapsedTime, isInstaBreak, cc);
+
         // Check if the time used time is lower than expected.
-        if (isInstaBreak.decideOptimistically()) {
-            // Ignore those for now.
-            // Find out why this was commented out long ago a) did not fix mcMMO b) exploits.
-            // Maybe adjust time to min(time, SOMETHING) for MAYBE/YES.
+        if (shouldSkipFastBreak(isInstaBreak)) {
+            // ignore: instant break flagged
         }
-        else if (elapsedTime < 0) {
+        else if (adjustedElapsed < 0) {
             // Ignore it for now.
         }
-        else if (elapsedTime + cc.fastBreakDelay < expectedBreakingTime) {
+        else if (adjustedElapsed + cc.fastBreakDelay < expectedBreakingTime) {
             // lag or cheat or Minecraft.
 
             // Count in server side lag, if desired.
             final float lag = pData.getCurrentWorldDataSafe().shouldAdjustToLag(type) 
                     ? TickTask.getLag(expectedBreakingTime, true) : 1f;
 
-                    final long missingTime = expectedBreakingTime - (long) (lag * elapsedTime);
+                    final long missingTime = expectedBreakingTime - (long) (lag * adjustedElapsed);
 
                     if (missingTime > 0) {
                         // Add as penalty
@@ -134,6 +136,18 @@ public class FastBreak extends Check {
         // (The break time is set in the listener).
 
         return cancel;
+    }
+
+    private boolean shouldSkipFastBreak(final AlmostBoolean isInstaBreak) {
+        return isInstaBreak == AlmostBoolean.YES;
+    }
+
+    private long adjustElapsedTime(final long elapsedTime, final AlmostBoolean isInstaBreak,
+            final BlockBreakConfig cc) {
+        if (isInstaBreak == AlmostBoolean.MAYBE) {
+            return Math.min(elapsedTime, cc.fastBreakDelay);
+        }
+        return elapsedTime;
     }
 
     private void detailDebugStats(final Player player, final AlmostBoolean isInstaBreak,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -57,8 +57,10 @@ public class FastBreak extends Check {
      *            indicates that the block was flagged as instantly
      *            breakable. Values other than {@link AlmostBoolean#NO}
      *            cause the check to adjust or skip violation handling.
-     * @param data 
-     * @param cc 
+     * @param cc
+     *            configuration used for the check
+     * @param data
+     *            player specific data for block breaking
      * @return true, if successful
      */
     public boolean check(final Player player, final Block block, final AlmostBoolean isInstaBreak,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -55,8 +55,12 @@ public class FastBreak extends Check {
      *            the block
      * @param isInstaBreak
      *            indicates that the block was flagged as instantly
-     *            breakable. Values other than {@link AlmostBoolean#NO}
-     *            cause the check to adjust or skip violation handling.
+     *            breakable. The value controls how this check reacts:
+     *            <ul>
+     *            <li>{@code YES} - skip the check entirely.</li>
+     *            <li>{@code MAYBE} - clamp the time to {@code fastBreakDelay}.</li>
+     *            <li>{@code NO} - perform a full check.</li>
+     *            </ul>
      * @param cc
      *            configuration used for the check
      * @param data

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -66,74 +66,79 @@ public class FastBreak extends Check {
         final long now = Monotonic.millis();
         boolean cancel = false;
 
-        // Determine expected breaking time by block type.
-        final Material blockType = block.getType();
-        final long expectedBreakingTime = Math.max(0, Math.round((double) BlockProperties.getBreakingDuration(blockType, player) * (double) cc.fastBreakModSurvival / 100D));
+        if (player != null && block != null && pData != null) {
 
-        final long elapsedTime;
+            // Determine expected breaking time by block type.
+            final Material blockType = block.getType();
+            final long expectedBreakingTime = Math.max(0,
+                    Math.round((double) BlockProperties.getBreakingDuration(blockType, player)
+                            * (double) cc.fastBreakModSurvival / 100D));
+
+            final long elapsedTime;
         // Concept for unbreakable blocks? Context: extreme VL.
         // Should it be breakingTime instead of 0 for inconsistencies?
-        if (cc.fastBreakStrict) {
+            if (cc.fastBreakStrict) {
             // Counting interact...break.
             elapsedTime = (data.fastBreakBreakTime > data.fastBreakfirstDamage) ? 0 : now - data.fastBreakfirstDamage;
-        }
-        else {
+            }
+            else {
             // Counting break...break.
             elapsedTime = (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
-        }
+            }
 
-        final long adjustedElapsed = adjustElapsedTime(elapsedTime, isInstaBreak, cc);
+            final long adjustedElapsed = adjustElapsedTime(elapsedTime, isInstaBreak, cc);
 
-        // Check if the time used time is lower than expected.
-        if (shouldSkipFastBreak(isInstaBreak)) {
-            // ignore: instant break flagged
-        }
-        else if (adjustedElapsed < 0) {
-            // Ignore it for now.
-        }
-        else if (adjustedElapsed + cc.fastBreakDelay < expectedBreakingTime) {
-            // lag or cheat or Minecraft.
+            // Check if the time used time is lower than expected.
+            if (shouldSkipFastBreak(isInstaBreak)) {
+                // ignore: instant break flagged
+            }
+            else if (adjustedElapsed < 0) {
+                // Ignore it for now.
+            }
+            else if (adjustedElapsed + cc.fastBreakDelay < expectedBreakingTime) {
+                // lag or cheat or Minecraft.
 
             // Count in server side lag, if desired.
-            final float lag = pData.getCurrentWorldDataSafe().shouldAdjustToLag(type) 
-                    ? TickTask.getLag(expectedBreakingTime, true) : 1f;
+                final float lag = pData.getCurrentWorldDataSafe().shouldAdjustToLag(type)
+                        ? TickTask.getLag(expectedBreakingTime, true) : 1f;
 
-                    final long missingTime = expectedBreakingTime - (long) (lag * adjustedElapsed);
+                        final long missingTime = expectedBreakingTime - (long) (lag * adjustedElapsed);
 
-                    if (missingTime > 0) {
-                        // Add as penalty
-                        data.fastBreakPenalties.add(now, (float) missingTime);
+                        if (missingTime > 0) {
+                            // Add as penalty
+                            data.fastBreakPenalties.add(now, (float) missingTime);
 
 
                         // Only raise a violation, if the total penalty score exceeds the contention duration (for lag, delay).
-                        if (data.fastBreakPenalties.score(cc.fastBreakBucketFactor) > cc.fastBreakGrace) {
-                            // Potential improvement: add one absolute penalty time for big amounts to stop breaking until then
-                            final double vlAdded = (double) missingTime / 1000.0;
-                            data.fastBreakVL += vlAdded;
-                            final ViolationData vd = new ViolationData(this, player, data.fastBreakVL, vlAdded, cc.fastBreakActions);
-                            if (vd.needsParameters()) {
-                                vd.setParameter(ParameterName.BLOCK_TYPE, blockType.toString());
+                            if (data.fastBreakPenalties.score(cc.fastBreakBucketFactor) > cc.fastBreakGrace) {
+                                // Potential improvement: add one absolute penalty time for big amounts to stop breaking until then
+                                final double vlAdded = (double) missingTime / 1000.0;
+                                data.fastBreakVL += vlAdded;
+                                final ViolationData vd = new ViolationData(this, player, data.fastBreakVL,
+                                        vlAdded, cc.fastBreakActions);
+                                if (vd.needsParameters()) {
+                                    vd.setParameter(ParameterName.BLOCK_TYPE, blockType.toString());
+                                }
+                                cancel = executeActions(vd).willCancel();
                             }
-                            cancel = executeActions(vd).willCancel();
+                            // else: still within contention limits.
                         }
-                        // else: still within contention limits.
-                    }
-        }
-        else if (expectedBreakingTime > cc.fastBreakDelay) {
-            // Fast breaking does not decrease violation level.
-            data.fastBreakVL *= 0.9D;
-        }
+            }
+            else if (expectedBreakingTime > cc.fastBreakDelay) {
+                // Fast breaking does not decrease violation level.
+                data.fastBreakVL *= 0.9D;
+            }
 
-        // Rework to use (then hopefully completed) BlockBreakKey.
-        if (pData.isDebugActive(type)) {
-            detailDebugStats(player, isInstaBreak, blockType, 
-                    elapsedTime, expectedBreakingTime, data, pData);
-        }
-        else {
-            data.stats = null;
-        }
+            // Rework to use (then hopefully completed) BlockBreakKey.
+            if (pData.isDebugActive(type)) {
+                detailDebugStats(player, isInstaBreak, blockType, elapsedTime, expectedBreakingTime, data, pData);
+            }
+            else {
+                data.stats = null;
+            }
 
-        // (The break time is set in the listener).
+            // (The break time is set in the listener).
+        }
 
         return cancel;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreak.java
@@ -33,6 +33,8 @@ import fr.neatmonster.nocheatplus.utilities.PotionUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.time.monotonic.Monotonic;
+import fr.neatmonster.nocheatplus.checks.blockbreak.FastBreakDecision;
+import fr.neatmonster.nocheatplus.checks.blockbreak.FastBreakContext;
 
 /**
  * A check used to verify if the player isn't breaking blocks faster than possible.
@@ -49,26 +51,21 @@ public class FastBreak extends Check {
     /**
      * Checks a player for fastbreak. This is NOT for creative mode.
      * 
-     * @param player
-     *            the player
-     * @param block
-     *            the block
-     * @param isInstaBreak
-     *            indicates that the block was flagged as instantly
-     *            breakable. The value controls how this check reacts:
-     *            <ul>
-     *            <li>{@code YES} - skip the check entirely.</li>
-     *            <li>{@code MAYBE} - clamp the time to {@code fastBreakDelay}.</li>
-     *            <li>{@code NO} - perform a full check.</li>
-     *            </ul>
-     * @param cc
-     *            configuration used for the check
-     * @param data
-     *            player specific data for block breaking
+     * @param ctx
+     *            encapsulates all data needed to evaluate the check
      * @return true, if successful
      */
-    public boolean check(final Player player, final Block block, final AlmostBoolean isInstaBreak,
-            final BlockBreakConfig cc, final BlockBreakData data, final IPlayerData pData) {
+    public boolean check(final FastBreakContext ctx) {
+        if (!isValidContext(ctx)) {
+            return false;
+        }
+        final Player player = ctx.player();
+        final Block block = ctx.block();
+        final BlockBreakConfig cc = ctx.config();
+        final BlockBreakData data = ctx.breakData();
+        final IPlayerData pData = ctx.playerData();
+        final AlmostBoolean isInstaBreak = ctx.isInstaBreak();
+
         final long now = Monotonic.millis();
         boolean cancel = false;
 
@@ -92,10 +89,11 @@ public class FastBreak extends Check {
             elapsedTime = (data.fastBreakBreakTime > now) ? 0 : now - data.fastBreakBreakTime;
             }
 
-            final long adjustedElapsed = adjustElapsedTime(elapsedTime, isInstaBreak, cc);
+            final long adjustedElapsed =
+                    FastBreakDecision.adjustedElapsed(elapsedTime, isInstaBreak, cc.fastBreakDelay);
 
             // Check if the time used time is lower than expected.
-            if (shouldSkipFastBreak(isInstaBreak)) {
+            if (FastBreakDecision.shouldSkip(isInstaBreak)) {
                 // ignore: instant break flagged
             }
             else if (adjustedElapsed < 0) {
@@ -137,9 +135,8 @@ public class FastBreak extends Check {
 
             // Rework to use (then hopefully completed) BlockBreakKey.
             if (pData.isDebugActive(type)) {
-                detailDebugStats(player, isInstaBreak, blockType, elapsedTime, expectedBreakingTime, data, pData);
-            }
-            else {
+                detailDebugStats(ctx, elapsedTime, expectedBreakingTime);
+            } else {
                 data.stats = null;
             }
 
@@ -149,21 +146,14 @@ public class FastBreak extends Check {
         return cancel;
     }
 
-    private boolean shouldSkipFastBreak(final AlmostBoolean isInstaBreak) {
-        return isInstaBreak == AlmostBoolean.YES;
-    }
-
-    private long adjustElapsedTime(final long elapsedTime, final AlmostBoolean isInstaBreak,
-            final BlockBreakConfig cc) {
-        if (isInstaBreak == AlmostBoolean.MAYBE) {
-            return Math.min(elapsedTime, cc.fastBreakDelay);
-        }
-        return elapsedTime;
-    }
-
-    private void detailDebugStats(final Player player, final AlmostBoolean isInstaBreak,
-            final Material blockType, final long elapsedTime, final long expectedBreakingTime,
-            final BlockBreakData data, final IPlayerData pData) {
+    private void detailDebugStats(final FastBreakContext ctx, final long elapsedTime,
+            final long expectedBreakingTime) {
+        final Player player = ctx.player();
+        final Block block = ctx.block();
+        final BlockBreakData data = ctx.breakData();
+        final IPlayerData pData = ctx.playerData();
+        final AlmostBoolean isInstaBreak = ctx.isInstaBreak();
+        final Material blockType = block.getType();
         if (pData.hasPermission(Permissions.ADMINISTRATION_DEBUG, player)) {
             // General stats:
             // Replace stats by new system (BlockBreakKey once complete), commands to inspect / auto-config.
@@ -185,4 +175,7 @@ public class FastBreak extends Check {
         }
     }
 
+    private boolean isValidContext(final FastBreakContext ctx) {
+        return ctx != null && ctx.player() != null && ctx.block() != null && ctx.playerData() != null;
+    }
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContext.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContext.java
@@ -1,0 +1,20 @@
+package fr.neatmonster.nocheatplus.checks.blockbreak;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.blockbreak.BlockBreakConfig;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
+
+/**
+ * Container for FastBreak check parameters.
+ */
+public record FastBreakContext(
+        Player player,
+        Block block,
+        BlockBreakConfig config,
+        BlockBreakData breakData,
+        IPlayerData playerData,
+        AlmostBoolean isInstaBreak) {
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContext.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContext.java
@@ -8,7 +8,20 @@ import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
 
 /**
- * Container for FastBreak check parameters.
+ * Container for parameters used by the fast break check.
+ *
+ * @param player
+ *            the player breaking the block
+ * @param block
+ *            the block being broken
+ * @param config
+ *            configuration reference for block breaking
+ * @param breakData
+ *            cached block breaking state
+ * @param playerData
+ *            cached player data instance
+ * @param isInstaBreak
+ *            predicted instant-break state for this block
  */
 public record FastBreakContext(
         Player player,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecision.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecision.java
@@ -1,0 +1,37 @@
+package fr.neatmonster.nocheatplus.checks.blockbreak;
+
+import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
+
+/**
+ * Utility for deciding how FastBreak behaves depending on instant-break flags.
+ */
+public final class FastBreakDecision {
+
+    private FastBreakDecision() {
+    }
+
+    /**
+     * Determine whether FastBreak should be skipped entirely.
+     *
+     * @param flag value from instant break prediction
+     * @return true if the check should be skipped
+     */
+    public static boolean shouldSkip(final AlmostBoolean flag) {
+        return flag == AlmostBoolean.YES;
+    }
+
+    /**
+     * Adjust elapsed time depending on instant break prediction.
+     *
+     * @param elapsed actual elapsed time in milliseconds
+     * @param flag instant break flag
+     * @param clamp value used for clamping when {@code flag == MAYBE}
+     * @return adjusted elapsed time
+     */
+    public static long adjustedElapsed(final long elapsed, final AlmostBoolean flag, final long clamp) {
+        if (flag == AlmostBoolean.MAYBE) {
+            return Math.min(elapsed, clamp);
+        }
+        return elapsed;
+    }
+}

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContextTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContextTest.java
@@ -1,0 +1,26 @@
+package fr.neatmonster.nocheatplus.checks.blockbreak;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
+
+public class FastBreakContextTest {
+
+    @Test
+    public void testContextEncapsulation() {
+        Player player = mock(Player.class);
+        Block block = mock(Block.class);
+        FastBreakContext ctx = new FastBreakContext(player, block, null, null, null, AlmostBoolean.NO);
+        assertSame(player, ctx.player());
+        assertSame(block, ctx.block());
+        assertNull(ctx.config());
+        assertNull(ctx.breakData());
+        assertNull(ctx.playerData());
+        assertEquals(AlmostBoolean.NO, ctx.isInstaBreak());
+    }
+}

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecisionTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecisionTest.java
@@ -1,0 +1,41 @@
+package fr.neatmonster.nocheatplus.checks.blockbreak;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
+
+public class FastBreakDecisionTest {
+
+    private long clamp;
+
+    @Before
+    public void setup() {
+        clamp = 100;
+    }
+
+    @Test
+    public void testShouldSkip() {
+        assertTrue(FastBreakDecision.shouldSkip(AlmostBoolean.YES));
+        assertFalse(FastBreakDecision.shouldSkip(AlmostBoolean.NO));
+        assertFalse(FastBreakDecision.shouldSkip(AlmostBoolean.MAYBE));
+    }
+
+    @Test
+    public void testAdjustedElapsed_NO() {
+        assertEquals(150, FastBreakDecision.adjustedElapsed(150, AlmostBoolean.NO, clamp));
+    }
+
+    @Test
+    public void testAdjustedElapsed_MAYBE() {
+        assertEquals(80, FastBreakDecision.adjustedElapsed(80, AlmostBoolean.MAYBE, clamp));
+        assertEquals(100, FastBreakDecision.adjustedElapsed(150, AlmostBoolean.MAYBE, clamp));
+    }
+
+    @Test
+    public void testAdjustedElapsed_YES() {
+        assertEquals(50, FastBreakDecision.adjustedElapsed(50, AlmostBoolean.YES, clamp));
+    }
+}


### PR DESCRIPTION
## Summary
- improve `FastBreak.check` to skip or adjust time for instant breaks
- clarify javadoc for the `isInstaBreak` parameter

## Testing
- `mvn -P checks clean verify` *(fails: profile not found and test failures)*

------
https://chatgpt.com/codex/tasks/task_b_685eab20300c8329a5e5c77e7ff9624e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the fast break check by introducing handling for instant break scenarios, which now differentiates between certain block breaking conditions and adjusts elapsed time or skips violation handling accordingly.

### Why are these changes being made?

These changes are made to more accurately handle cases where blocks are flagged as instantly breakable, ensuring that the fast break check properly accounts for such scenarios without falsely penalizing players, and addressing previous limitations in handling these situations. The new approach aims to improve gameplay fairness and reflect true block-breaking conditions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for block break checks by introducing context and utility classes, streamlining parameter handling and logic flow.
* **New Features**
  * Added new helper classes for decision-making in block break detection.
* **Tests**
  * Introduced unit tests for the new context and decision utility classes to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->