### PR TITLE
Validate tick and add regression tests

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -377,10 +377,6 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
     private TargetMoveInfo computeTargetMoveInfo(final FightData data, final Location damagedLoc,
                                                  final int tick, final boolean worldChanged) {
 
-        if (tick < 0) {
-            throw new IllegalArgumentException("tick must be >= 0");
-        }
-
         if (isInvalidMoveInfo(data, damagedLoc, tick, worldChanged)) {
             return DEFAULT_TARGET_MOVE_INFO;
         }
@@ -397,6 +393,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
         return data == null || damagedLoc == null
                 || data.lastAttackedX == Double.MAX_VALUE
                 || tick < data.lastAttackTick
+                || tick < 0
                 || worldChanged
                 || tick - data.lastAttackTick > 20;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -377,15 +377,16 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
     private TargetMoveInfo computeTargetMoveInfo(final FightData data, final Location damagedLoc,
                                                  final int tick, final boolean worldChanged) {
 
-        if (isInvalidMoveInfo(data, damagedLoc, tick, worldChanged)) {
-            return DEFAULT_TARGET_MOVE_INFO;
+        TargetMoveInfo result = DEFAULT_TARGET_MOVE_INFO;
+        if (!isInvalidMoveInfo(data, damagedLoc, tick, worldChanged)) {
+            final int age = tick - data.lastAttackTick;
+            final double move = TrigUtil.distance(data.lastAttackedX, data.lastAttackedZ,
+                                                  damagedLoc.getX(), damagedLoc.getZ());
+            final long msAge = (long) (50f * TickTask.getLag(50L * age, true) * (float) age);
+            final double normalized = msAge == 0 ? move : move * Math.min(20.0, 1000.0 / (double) msAge);
+            result = new TargetMoveInfo(age, move, msAge, normalized);
         }
-        final int age = tick - data.lastAttackTick;
-        final double move = TrigUtil.distance(data.lastAttackedX, data.lastAttackedZ,
-                                              damagedLoc.getX(), damagedLoc.getZ());
-        final long msAge = (long) (50f * TickTask.getLag(50L * age, true) * (float) age);
-        final double normalized = msAge == 0 ? move : move * Math.min(20.0, 1000.0 / (double) msAge);
-        return new TargetMoveInfo(age, move, msAge, normalized);
+        return result;
     }
 
     private static boolean isInvalidMoveInfo(final FightData data, final Location damagedLoc,

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/ComputeTargetMoveInfoTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/ComputeTargetMoveInfoTest.java
@@ -73,4 +73,13 @@ public class ComputeTargetMoveInfoTest {
         f.setAccessible(true);
         assertEquals(0, f.getInt(info));
     }
+
+    @Test
+    public void testValidTickReturnsNonZeroAge() throws Exception {
+        FightData data = newData(5);
+        Object info = compute.invoke(listener, data, location, 10, false);
+        Field f = info.getClass().getDeclaredField("tickAge");
+        f.setAccessible(true);
+        assertEquals(5, f.getInt(info));
+    }
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/ComputeTargetMoveInfoTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/ComputeTargetMoveInfoTest.java
@@ -1,0 +1,76 @@
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.Before;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.checks.fight.FightData;
+import fr.neatmonster.nocheatplus.checks.fight.FightListener;
+
+public class ComputeTargetMoveInfoTest {
+
+    private static sun.misc.Unsafe getUnsafe() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (sun.misc.Unsafe) f.get(null);
+    }
+
+    private static World createWorld() {
+        return (World) Proxy.newProxyInstance(World.class.getClassLoader(), new Class[]{World.class},
+                (proxy, method, args) -> {
+                    if ("getName".equals(method.getName())) return "dummy";
+                    Class<?> r = method.getReturnType();
+                    if (r == boolean.class) return false;
+                    if (r.isPrimitive()) return 0;
+                    return null;
+                });
+    }
+
+    private FightListener listener;
+    private Method compute;
+    private Location location;
+    private sun.misc.Unsafe unsafe;
+
+    @Before
+    public void setup() throws Exception {
+        unsafe = getUnsafe();
+        listener = (FightListener) unsafe.allocateInstance(FightListener.class);
+        compute = FightListener.class.getDeclaredMethod("computeTargetMoveInfo",
+                FightData.class, Location.class, int.class, boolean.class);
+        compute.setAccessible(true);
+        location = new Location(createWorld(), 0.0, 64.0, 0.0);
+    }
+
+    private FightData newData(int lastAttackTick) throws Exception {
+        FightData data = (FightData) unsafe.allocateInstance(FightData.class);
+        data.lastAttackTick = lastAttackTick;
+        data.lastAttackedX = 0.0;
+        data.lastAttackedZ = 0.0;
+        return data;
+    }
+
+    @Test
+    public void testOutOfOrderTickReturnsDefault() throws Exception {
+        FightData data = newData(10);
+        Object info = compute.invoke(listener, data, location, 5, false);
+        Field f = info.getClass().getDeclaredField("tickAge");
+        f.setAccessible(true);
+        assertEquals(0, f.getInt(info));
+    }
+
+    @Test
+    public void testNegativeTickReturnsDefault() throws Exception {
+        FightData data = newData(0);
+        Object info = compute.invoke(listener, data, location, -1, false);
+        Field f = info.getClass().getDeclaredField("tickAge");
+        f.setAccessible(true);
+        assertEquals(0, f.getInt(info));
+    }
+}


### PR DESCRIPTION
## Summary
- return default move info when tick input is invalid
- check tick value in `isInvalidMoveInfo`
- add ComputeTargetMoveInfoTest covering negative and out-of-order tick values

## Testing
- `mvn -q test` *(fails: TestImprobable errors)*
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685ead34b88c83298bc8edd0b02257eb

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the explicit check for a negative `tick` value in `FightListener.java` and instead incorporate the negative check into the `isInvalidMoveInfo` method, while also adding regression tests in `ComputeTargetMoveInfoTest.java` to verify the correct handling of out-of-order and negative tick values.

### Why are these changes being made?

The changes improve code maintainability by using a centralized validation approach within the `isInvalidMoveInfo` method, eliminating redundancy and potential for inconsistent tick validation. The added regression tests ensure future code stability by verifying that the system returns default target move info for out-of-order and negative tick values, indicating robustness in handling invalid input scenarios.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->