### PR TITLE
Guard duplicate leave events

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -128,6 +128,9 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
      */
     private final Map<UUID, Long> lastLogout = new LinkedHashMap<UUID, Long>(50, 0.75f, true);
 
+    /** Tracks the server tick when a leave event started processing for a player. */
+    private final Map<UUID, Integer> leaveProcessing = new HashMap<UUID, Integer>(50);
+
     /**
      * Keeping track of online players. Currently id/name mappings are not kept
      * on logout, but might be later.
@@ -707,16 +710,47 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
      * @param player
      */
     private void playerLeaves(final Player player) {
+        if (!startLeaveProcessing(player)) {
+            return;
+        }
+        try {
+            processLeave(player);
+        } finally {
+            finishLeaveProcessing(player);
+        }
+    }
+
+    private boolean startLeaveProcessing(Player player) {
+        if (player == null) {
+            return false;
+        }
+        final UUID id = player.getUniqueId();
+        final int tick = TickTask.getTick();
+        final Integer existing = leaveProcessing.get(id);
+        if (existing != null && existing.intValue() == tick) {
+            return false;
+        }
+        leaveProcessing.put(id, tick);
+        return true;
+    }
+
+    private void finishLeaveProcessing(Player player) {
+        if (player != null) {
+            leaveProcessing.remove(player.getUniqueId());
+        }
+    }
+
+    private void processLeave(final Player player) {
         final long timeNow = System.currentTimeMillis();
         final UUID playerId = player.getUniqueId();
         lastLogout.put(playerId, timeNow);
         final PlayerData pData = playerData.get(playerId);
         if (pData != null) {
-            final Collection<Class<? extends IDataOnLeave>> types = factoryRegistry.getGroupedTypes(IDataOnLeave.class);
+            final Collection<Class<? extends IDataOnLeave>> types =
+                factoryRegistry.getGroupedTypes(IDataOnLeave.class);
             pData.onPlayerLeave(player, timeNow, types);
             pData.getGenericInstance(CombinedData.class).lastLogoutTime = timeNow;
-        }
-        else {
+        } else {
             // NOTE: Possibly put lastLogoutTime to OfflinePlayerData.
         }
         removeOnlinePlayer(player);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -729,21 +729,21 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
         }
         final UUID id = player.getUniqueId();
         final int tick = TickTask.getTick();
-        if (tick == leaveProcessing.getOrDefault(id, -1)) {
+        final Integer previousTick = leaveProcessing.put(id, tick);
+        if (previousTick != null && previousTick.intValue() == tick) {
             CheckUtils.debug(player, null, "Duplicate leave event in tick " + tick + " ignored.");
             return false;
         }
-        leaveProcessing.put(id, tick);
         if (leaveProcessing.size() > MAX_LEAVE_PROCESSING) {
             leaveProcessing.clear();
         }
         return true;
     }
 
-    private void finishLeaveProcessing(Player player) {
-        if (player != null) {
-            leaveProcessing.remove(player.getUniqueId());
-        }
+    private void finishLeaveProcessing(final Player player) {
+        // Intentionally left blank to keep the tick marker for the remainder of
+        // the tick. Duplicate leave events within the same tick will be ignored
+        // even after cleanup completes. Map cleanup happens via size capping.
     }
 
     private void processLeave(final Player player) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -131,6 +131,9 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
     /** Tracks the server tick when a leave event started processing for a player. */
     private final Map<UUID, Integer> leaveProcessing = new HashMap<UUID, Integer>(50);
 
+    /** Maximum number of entries to track for leave processing. */
+    private static final int MAX_LEAVE_PROCESSING = 5000;
+
     /**
      * Keeping track of online players. Currently id/name mappings are not kept
      * on logout, but might be later.
@@ -720,17 +723,20 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
         }
     }
 
-    private boolean startLeaveProcessing(Player player) {
+    private boolean startLeaveProcessing(final Player player) {
         if (player == null) {
             return false;
         }
         final UUID id = player.getUniqueId();
         final int tick = TickTask.getTick();
-        final Integer existing = leaveProcessing.get(id);
-        if (existing != null && existing.intValue() == tick) {
+        if (tick == leaveProcessing.getOrDefault(id, -1)) {
+            CheckUtils.debug(player, null, "Duplicate leave event in tick " + tick + " ignored.");
             return false;
         }
         leaveProcessing.put(id, tick);
+        if (leaveProcessing.size() > MAX_LEAVE_PROCESSING) {
+            leaveProcessing.clear();
+        }
         return true;
     }
 


### PR DESCRIPTION
## Summary
- track server tick for leave processing in `PlayerDataManager`
- skip duplicate leave handling within the same tick

## Testing
- `mvn -q test` *(fails: There are test failures)*
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(fails: SpotBugs errors)*

------
https://chatgpt.com/codex/tasks/task_b_685f45f13e088329b929616f88f15b4c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Guard against duplicate leave events for players by tracking and preventing multiple leave events from being processed in the same server tick.

### Why are these changes being made?

These changes address an issue where duplicate leave events for a player could be processed within the same server tick, potentially leading to logic errors or redundant operations. By tracking the server tick at which a leave event starts processing, and ignoring further events if they occur within the same tick, we ensure that only one leave process runs per player per tick, thereby enhancing the stability and accuracy of player event handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->