### PR TITLE
Extract decay factors into config

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
@@ -48,7 +48,10 @@ public class BlockBreakConfig extends ACheckConfig {
     public final int        frequencyShortTermLimit;
     public final int        frequencyShortTermTicks;
     public final ActionList frequencyActions;
-    /** Decay factor for the frequency violation level. */
+    /**
+     * Fraction of the frequency violation level retained per tick. Values
+     * below {@code 1.0} make the level drop faster.
+     */
     public final double  frequencyVlDecay;
 
     public boolean          improbableFastBreakCheck;
@@ -93,7 +96,7 @@ public class BlockBreakConfig extends ACheckConfig {
         frequencyShortTermLimit = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT);
         frequencyShortTermTicks = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS);
         frequencyActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, Permissions.BLOCKBREAK_FREQUENCY);
-        frequencyVlDecay = config.getDouble(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.95);
+        frequencyVlDecay = config.getDouble(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.0, 1.0, 0.95);
 
         noSwingActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_NOSWING_ACTIONS, Permissions.BLOCKBREAK_NOSWING);
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakConfig.java
@@ -48,6 +48,8 @@ public class BlockBreakConfig extends ACheckConfig {
     public final int        frequencyShortTermLimit;
     public final int        frequencyShortTermTicks;
     public final ActionList frequencyActions;
+    /** Decay factor for the frequency violation level. */
+    public final double  frequencyVlDecay;
 
     public boolean          improbableFastBreakCheck;
 
@@ -91,6 +93,7 @@ public class BlockBreakConfig extends ACheckConfig {
         frequencyShortTermLimit = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT);
         frequencyShortTermTicks = config.getInt(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS);
         frequencyActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, Permissions.BLOCKBREAK_FREQUENCY);
+        frequencyVlDecay = config.getDouble(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.95);
 
         noSwingActions = config.getOptimizedActionList(ConfPaths.BLOCKBREAK_NOSWING_ACTIONS, Permissions.BLOCKBREAK_NOSWING);
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/Frequency.java
@@ -91,7 +91,7 @@ public class Frequency extends Check {
                     cancel = executeActions(player, data.frequencyVL, change, cc.frequencyActions).willCancel();
                 }
                 else if (data.frequencyVL > 0d && fullScore < fullTime * .75)
-                    data.frequencyVL *= 0.95;
+                    data.frequencyVL *= cc.frequencyVlDecay;
 
                 return cancel;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
@@ -34,11 +34,17 @@ public class BlockInteractConfig extends ACheckConfig {
     public final long		speedInterval;
     public final int		speedLimit;
     public final ActionList speedActions;
-    /** Decay factor for speed violation level. */
+    /**
+     * Fraction of the speed violation level retained per tick. Lower values
+     * cause faster decay.
+     */
     public final double speedVlDecay;
 
     public final ActionList visibleActions;
-    /** Decay factor for visible violation level. */
+    /**
+     * Fraction of the visible violation level retained per tick. Lower values
+     * cause faster decay.
+     */
     public final double visibleVlDecay;
 
     /**
@@ -58,10 +64,10 @@ public class BlockInteractConfig extends ACheckConfig {
         speedInterval = data.getLong(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL);
         speedLimit = data.getInt(ConfPaths.BLOCKINTERACT_SPEED_LIMIT);
         speedActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, Permissions.BLOCKINTERACT_SPEED);
-        speedVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.99);
+        speedVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.0, 1.0, 0.99);
 
         visibleActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, Permissions.BLOCKINTERACT_VISIBLE);
-        visibleVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.99);
+        visibleVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.0, 1.0, 0.99);
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractConfig.java
@@ -34,8 +34,12 @@ public class BlockInteractConfig extends ACheckConfig {
     public final long		speedInterval;
     public final int		speedLimit;
     public final ActionList speedActions;
+    /** Decay factor for speed violation level. */
+    public final double speedVlDecay;
 
     public final ActionList visibleActions;
+    /** Decay factor for visible violation level. */
+    public final double visibleVlDecay;
 
     /**
      * Instantiates a new block interact configuration.
@@ -54,8 +58,10 @@ public class BlockInteractConfig extends ACheckConfig {
         speedInterval = data.getLong(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL);
         speedLimit = data.getInt(ConfPaths.BLOCKINTERACT_SPEED_LIMIT);
         speedActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, Permissions.BLOCKINTERACT_SPEED);
+        speedVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.99);
 
         visibleActions = data.getOptimizedActionList(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, Permissions.BLOCKINTERACT_VISIBLE);
+        visibleVlDecay = data.getDouble(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.99);
     }
 
 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Speed.java
@@ -55,7 +55,7 @@ public class Speed extends Check {
             }
         }
         else{
-            data.speedVL *= 0.99;
+            data.speedVL *= cc.speedVlDecay;
             data.addPassedCheck(this.type);
         }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Visible.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/Visible.java
@@ -224,7 +224,7 @@ public class Visible extends Check {
                 cancel = true;
             }
         } else {
-            data.visibleVL *= 0.99;
+            data.visibleVL *= cc.visibleVlDecay;
             data.addPassedCheck(this.type);
             if (debug) {
                 debug(player, "pitch=" + loc.getPitch() + ",yaw=" + loc.getYaw() + " tags="

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/Against.java
@@ -95,7 +95,7 @@ public class Against extends Check {
             vd.setParameter(ParameterName.BLOCK_TYPE, ncpAgainst == null ? "air" : ncpAgainst.toString());
             return executeActions(vd).willCancel();
         } else {
-            data.againstVL *= 0.99; // Assume one false positive every 100 blocks.
+            data.againstVL *= cc.againstVlDecay; // Assume one false positive every 100 blocks.
             if (bIData != null) {
                 bIData.addPassedCheck(this.type);
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
@@ -33,7 +33,10 @@ import fr.neatmonster.nocheatplus.worlds.IWorldData;
 public class BlockPlaceConfig extends ACheckConfig {
 
     public final ActionList againstActions;
-    /** Factor to decrease the against violation level on pass. */
+    /**
+     * Fraction of the against violation level retained per tick. Lower values
+     * make decay faster.
+     */
     public final double     againstVlDecay;
 
     public final boolean    autoSignSkipEmpty;
@@ -47,7 +50,10 @@ public class BlockPlaceConfig extends ACheckConfig {
     public final boolean    fastPlaceImprobableFeedOnly;
     public final float      fastPlaceImprobableWeight;
     public final ActionList fastPlaceActions;
-    /** Factor applied when reducing fast place violation level. */
+    /**
+     * Fraction of the fast place violation level retained per tick. Lower
+     * values make decay faster.
+     */
     public final double     fastPlaceVlDecay;
 
     public final Set<Material> noSwingExceptions = new HashSet<Material>();
@@ -85,7 +91,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         final ConfigFile config = worldData.getRawConfiguration();
 
         againstActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, Permissions.BLOCKPLACE_AGAINST);
-        againstVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.99);
+        againstVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.0, 1.0, 0.99);
 
         autoSignSkipEmpty = config.getBoolean(ConfPaths.BLOCKPLACE_AUTOSIGN_SKIPEMPTY);
         autoSignActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AUTOSIGN_ACTIONS, Permissions.BLOCKPLACE_AUTOSIGN);
@@ -99,7 +105,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         fastPlaceImprobableFeedOnly = config.getBoolean(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY);
         fastPlaceImprobableWeight = (float) config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT);
         fastPlaceActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, Permissions.BLOCKPLACE_FASTPLACE);
-        fastPlaceVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.95);
+        fastPlaceVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.0, 1.0, 0.95);
 
         config.readMaterialFromList(ConfPaths.BLOCKPLACE_NOSWING_EXCEPTIONS, noSwingExceptions);
         noSwingActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_NOSWING_ACTIONS, Permissions.BLOCKPLACE_NOSWING);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceConfig.java
@@ -33,6 +33,8 @@ import fr.neatmonster.nocheatplus.worlds.IWorldData;
 public class BlockPlaceConfig extends ACheckConfig {
 
     public final ActionList againstActions;
+    /** Factor to decrease the against violation level on pass. */
+    public final double     againstVlDecay;
 
     public final boolean    autoSignSkipEmpty;
     public final ActionList autoSignActions;
@@ -45,6 +47,8 @@ public class BlockPlaceConfig extends ACheckConfig {
     public final boolean    fastPlaceImprobableFeedOnly;
     public final float      fastPlaceImprobableWeight;
     public final ActionList fastPlaceActions;
+    /** Factor applied when reducing fast place violation level. */
+    public final double     fastPlaceVlDecay;
 
     public final Set<Material> noSwingExceptions = new HashSet<Material>();
     public final ActionList noSwingActions;
@@ -81,6 +85,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         final ConfigFile config = worldData.getRawConfiguration();
 
         againstActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, Permissions.BLOCKPLACE_AGAINST);
+        againstVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.99);
 
         autoSignSkipEmpty = config.getBoolean(ConfPaths.BLOCKPLACE_AUTOSIGN_SKIPEMPTY);
         autoSignActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_AUTOSIGN_ACTIONS, Permissions.BLOCKPLACE_AUTOSIGN);
@@ -94,6 +99,7 @@ public class BlockPlaceConfig extends ACheckConfig {
         fastPlaceImprobableFeedOnly = config.getBoolean(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY);
         fastPlaceImprobableWeight = (float) config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT);
         fastPlaceActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, Permissions.BLOCKPLACE_FASTPLACE);
+        fastPlaceVlDecay = config.getDouble(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.95);
 
         config.readMaterialFromList(ConfPaths.BLOCKPLACE_NOSWING_EXCEPTIONS, noSwingExceptions);
         noSwingActions = config.getOptimizedActionList(ConfPaths.BLOCKPLACE_NOSWING_ACTIONS, Permissions.BLOCKPLACE_NOSWING);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/FastPlace.java
@@ -101,7 +101,7 @@ public class FastPlace extends Check {
             cancel = executeActions(player, data.fastPlaceVL, change, cc.fastPlaceActions).willCancel();
         }
         else if (data.fastPlaceVL > 0d && fullScore < cc.fastPlaceLimit * .75) {
-            data.fastPlaceVL *= 0.95;
+            data.fastPlaceVL *= cc.fastPlaceVlDecay;
         }
 
         return cancel;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
@@ -54,7 +54,10 @@ public class ChatConfig extends ACheckConfig {
     public final int          commandsShortTermTicks;
     public final double       commandsShortTermLevel;
     public final ActionList   commandsActions;
-    /** Decay factor for command violation level. */
+    /**
+     * Fraction of the command violation level retained per tick. Smaller
+     * values cause faster decay.
+     */
     public final double       commandsVlDecay;
 
     // Potentially add sub check types
@@ -88,7 +91,10 @@ public class ChatConfig extends ACheckConfig {
     public final float        textPlayerWeight;
     public final boolean      textEngineMaximum;
     public final boolean	  textAllowVLReset;
-    /** Decay factor for text violation level. */
+    /**
+     * Fraction of the text violation level retained per tick. Smaller values
+     * cause faster decay.
+     */
     public final double       textVlDecay;
     public final boolean      textDebug;
 
@@ -135,7 +141,7 @@ public class ChatConfig extends ACheckConfig {
         commandsShortTermTicks = config.getInt(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS);
         commandsShortTermLevel = config.getDouble(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL);
         commandsActions = config.getOptimizedActionList(ConfPaths.CHAT_COMMANDS_ACTIONS, Permissions.CHAT_COMMANDS);
-        commandsVlDecay = config.getDouble(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.99);
+        commandsVlDecay = config.getDouble(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.0, 1.0, 0.99);
 
         textGlobalCheck = config.getBoolean(ConfPaths.CHAT_TEXT_GL_CHECK, true);
         textPlayerCheck = config.getBoolean(ConfPaths.CHAT_TEXT_PP_CHECK, true);
@@ -167,7 +173,7 @@ public class ChatConfig extends ACheckConfig {
         textDebug = config.getBoolean(ConfPaths.CHAT_TEXT_DEBUG, false);
         textFreqNormActions = config.getOptimizedActionList(ConfPaths.CHAT_TEXT_FREQ_NORM_ACTIONS, Permissions.CHAT_TEXT);
         textAllowVLReset = config.getBoolean(ConfPaths.CHAT_TEXT_ALLOWVLRESET);
-        textVlDecay = config.getDouble(ConfPaths.CHAT_TEXT_VL_DECAY, 0.95);
+        textVlDecay = config.getDouble(ConfPaths.CHAT_TEXT_VL_DECAY, 0.0, 1.0, 0.95);
 
         chatWarningCheck = config.getBoolean(ConfPaths.CHAT_WARNING_CHECK);
         chatWarningLevel = (float) config.getDouble(ConfPaths.CHAT_WARNING_LEVEL);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatConfig.java
@@ -54,6 +54,8 @@ public class ChatConfig extends ACheckConfig {
     public final int          commandsShortTermTicks;
     public final double       commandsShortTermLevel;
     public final ActionList   commandsActions;
+    /** Decay factor for command violation level. */
+    public final double       commandsVlDecay;
 
     // Potentially add sub check types
     public final boolean      textGlobalCheck;
@@ -86,6 +88,8 @@ public class ChatConfig extends ACheckConfig {
     public final float        textPlayerWeight;
     public final boolean      textEngineMaximum;
     public final boolean	  textAllowVLReset;
+    /** Decay factor for text violation level. */
+    public final double       textVlDecay;
     public final boolean      textDebug;
 
     public final boolean      chatWarningCheck;
@@ -131,6 +135,7 @@ public class ChatConfig extends ACheckConfig {
         commandsShortTermTicks = config.getInt(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS);
         commandsShortTermLevel = config.getDouble(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL);
         commandsActions = config.getOptimizedActionList(ConfPaths.CHAT_COMMANDS_ACTIONS, Permissions.CHAT_COMMANDS);
+        commandsVlDecay = config.getDouble(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.99);
 
         textGlobalCheck = config.getBoolean(ConfPaths.CHAT_TEXT_GL_CHECK, true);
         textPlayerCheck = config.getBoolean(ConfPaths.CHAT_TEXT_PP_CHECK, true);
@@ -162,6 +167,7 @@ public class ChatConfig extends ACheckConfig {
         textDebug = config.getBoolean(ConfPaths.CHAT_TEXT_DEBUG, false);
         textFreqNormActions = config.getOptimizedActionList(ConfPaths.CHAT_TEXT_FREQ_NORM_ACTIONS, Permissions.CHAT_TEXT);
         textAllowVLReset = config.getBoolean(ConfPaths.CHAT_TEXT_ALLOWVLRESET);
+        textVlDecay = config.getDouble(ConfPaths.CHAT_TEXT_VL_DECAY, 0.95);
 
         chatWarningCheck = config.getBoolean(ConfPaths.CHAT_WARNING_CHECK);
         chatWarningLevel = (float) config.getDouble(ConfPaths.CHAT_WARNING_LEVEL);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
@@ -126,7 +126,7 @@ public class Commands extends Check {
             player.sendMessage(ColorUtil.replaceColors(cc.chatWarningMessage));
             data.chatWarningTime = now;
         } else {
-            data.commandsVL *= 0.99;
+            data.commandsVL *= cc.commandsVlDecay;
         }
         return false;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
@@ -410,7 +410,7 @@ public class Text extends Check implements INotifyReload {
                     ColorUtil.replaceColors(cc.chatWarningMessage));
             data.chatWarningTime = time;
         } else {
-            data.textVL *= 0.95;
+            data.textVL *= cc.textVlDecay;
             if (cc.textAllowVLReset && normalScore < 2.0f * cc.textFreqNormWeight
                     && shortTermScore < 2.0f * cc.textFreqShortTermWeight) {
                 data.textVL = 0.0;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedConfig.java
@@ -42,7 +42,10 @@ public class CombinedConfig extends ACheckConfig {
     /** Do mind that this flag is not used by all components. */
     public final float          improbableLevel;
     public final ActionList     improbableActions;
-    /** Decay factor for improbable violation level. */
+    /**
+     * Fraction of the improbable violation level retained per tick. Lower
+     * values cause faster decay.
+     */
     public final double     improbableVlDecay;
 
     // Invulnerable management.
@@ -73,7 +76,7 @@ public class CombinedConfig extends ACheckConfig {
 
         improbableLevel = (float) config.getDouble(ConfPaths.COMBINED_IMPROBABLE_LEVEL);
         improbableActions = config.getOptimizedActionList(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, Permissions.COMBINED_IMPROBABLE);
-        improbableVlDecay = config.getDouble(ConfPaths.COMBINED_IMPROBABLE_VL_DECAY, 0.95);
+        improbableVlDecay = config.getDouble(ConfPaths.COMBINED_IMPROBABLE_VL_DECAY, 0.0, 1.0, 0.95);
 
         invulnerableCheck = config.getBoolean(ConfPaths.COMBINED_INVULNERABLE_CHECK);
         invulnerableInitialTicksJoin = config.getInt(ConfPaths.COMBINED_INVULNERABLE_INITIALTICKS_JOIN);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedConfig.java
@@ -42,6 +42,8 @@ public class CombinedConfig extends ACheckConfig {
     /** Do mind that this flag is not used by all components. */
     public final float          improbableLevel;
     public final ActionList     improbableActions;
+    /** Decay factor for improbable violation level. */
+    public final double     improbableVlDecay;
 
     // Invulnerable management.
     public final boolean                    invulnerableCheck;
@@ -71,6 +73,7 @@ public class CombinedConfig extends ACheckConfig {
 
         improbableLevel = (float) config.getDouble(ConfPaths.COMBINED_IMPROBABLE_LEVEL);
         improbableActions = config.getOptimizedActionList(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, Permissions.COMBINED_IMPROBABLE);
+        improbableVlDecay = config.getDouble(ConfPaths.COMBINED_IMPROBABLE_VL_DECAY, 0.95);
 
         invulnerableCheck = config.getBoolean(ConfPaths.COMBINED_INVULNERABLE_CHECK);
         invulnerableInitialTicksJoin = config.getInt(ConfPaths.COMBINED_INVULNERABLE_INITIALTICKS_JOIN);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/Improbable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/Improbable.java
@@ -138,7 +138,7 @@ public class Improbable extends Check implements IDisableListener{
             cancel = executeActions(vd).willCancel();
         }
         else
-            data.improbableVL *= 0.95;
+            data.improbableVL *= cc.improbableVlDecay;
         return cancel;
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastClick.java
@@ -188,7 +188,7 @@ public class FastClick extends Check {
             return createAndExecuteViolationData(player, data, cc, violation);
         }
         if (data != null) {
-            data.fastClickVL *= 0.99;
+            data.fastClickVL *= cc.fastClickVlDecay;
         }
         return false;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
@@ -46,7 +46,10 @@ public class InventoryConfig extends ACheckConfig {
     public final Set<String> inventoryExemptions = new HashSet<String>();
     public final float      fastClickImprobableWeight;
     public final ActionList fastClickActions;
-    /** Decay factor for fast click violation level. */
+    /**
+     * Fraction of the fast click violation level retained per tick. Lower
+     * values cause faster decay.
+     */
     public final double fastClickVlDecay;
 
     public final long		fastConsumeDuration;
@@ -95,7 +98,7 @@ public class InventoryConfig extends ACheckConfig {
         data.readStringlFromList(ConfPaths.INVENTORY_FASTCLICK_EXCLUDE, inventoryExemptions);
         fastClickImprobableWeight = (float) data.getDouble(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT);
         fastClickActions = data.getOptimizedActionList(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, Permissions.INVENTORY_FASTCLICK);
-        fastClickVlDecay = data.getDouble(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.99);
+        fastClickVlDecay = data.getDouble(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.0, 1.0, 0.99);
 
         if (ServerVersion.compareMinecraftVersion("1.9") >= 0) {
             /** Note: Disable check should use

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryConfig.java
@@ -46,6 +46,8 @@ public class InventoryConfig extends ACheckConfig {
     public final Set<String> inventoryExemptions = new HashSet<String>();
     public final float      fastClickImprobableWeight;
     public final ActionList fastClickActions;
+    /** Decay factor for fast click violation level. */
+    public final double fastClickVlDecay;
 
     public final long		fastConsumeDuration;
     public final boolean    fastConsumeWhitelist;
@@ -93,6 +95,7 @@ public class InventoryConfig extends ACheckConfig {
         data.readStringlFromList(ConfPaths.INVENTORY_FASTCLICK_EXCLUDE, inventoryExemptions);
         fastClickImprobableWeight = (float) data.getDouble(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT);
         fastClickActions = data.getOptimizedActionList(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, Permissions.INVENTORY_FASTCLICK);
+        fastClickVlDecay = data.getDouble(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.99);
 
         if (ServerVersion.compareMinecraftVersion("1.9") >= 0) {
             /** Note: Disable check should use

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -104,6 +104,8 @@ public class MovingConfig extends ACheckConfig {
 
     // PassableAccuracy: also use if ray-tracing is not used
     public ActionList passableActions;
+    /** Decay factor for passable violation level. */
+    public double     passableVlDecay;
     public double     passableHorizontalMargins;
     public double     passableVerticalMargins;
     public boolean    passableUntrackedTeleportCheck;
@@ -137,6 +139,8 @@ public class MovingConfig extends ACheckConfig {
     public boolean    sfSetBackPolicyVoid;
     public boolean    sfSetBackPolicyApplyFallDamage;
     public ActionList survivalFlyActions;
+    /** Decay factor for survival fly violation level. */
+    public double     survivalFlyVlDecay;
 
     public boolean 	sfHoverCheck; // Placeholder for potential sub check
     public int 		sfHoverTicks;
@@ -189,6 +193,8 @@ public class MovingConfig extends ACheckConfig {
 
     public HashMap<EntityType, Double> vehicleEnvelopeHorizontalSpeedCap = new HashMap<EntityType, Double>();
     public ActionList vehicleEnvelopeActions;
+    /** Decay factor for vehicle envelope violation level. */
+    public double     vehicleEnvelopeVlDecay;
 
     // Trace
     public int traceMaxAge;
@@ -338,6 +344,7 @@ public class MovingConfig extends ACheckConfig {
     private void loadPassableSettings(final ConfigFile config) {
         passableActions = config.getOptimizedActionList(ConfPaths.MOVING_PASSABLE_ACTIONS,
                 Permissions.MOVING_PASSABLE);
+        passableVlDecay = config.getDouble(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.99);
         passableHorizontalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_XZ_FACTOR, 0.1, 1.0, 0.999999);
         passableVerticalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_Y_FACTOR, 0.1, 1.0, 0.999999);
         passableUntrackedTeleportCheck = config.getBoolean(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE);
@@ -382,6 +389,7 @@ public class MovingConfig extends ACheckConfig {
         survivalFlyVLFreezeInAir = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR);
         survivalFlyActions = config.getOptimizedActionList(ConfPaths.MOVING_SURVIVALFLY_ACTIONS,
                 Permissions.MOVING_SURVIVALFLY);
+        survivalFlyVlDecay = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.95);
 
         sfHoverCheck = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK);
         sfHoverTicks = config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS);
@@ -455,6 +463,7 @@ public class MovingConfig extends ACheckConfig {
                 vehicleEnvelopeHorizontalSpeedCap, 4.0, true);
         vehicleEnvelopeActions = config.getOptimizedActionList(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS,
                 Permissions.MOVING_VEHICLE_ENVELOPE);
+        vehicleEnvelopeVlDecay = config.getDouble(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.99);
         List<String> types;
         if (config.get(ConfPaths.MOVING_VEHICLE_IGNOREDVEHICLES) == null) {
             types = Arrays.asList("arrow", "spectral_arrow", "tipped_arrow");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingConfig.java
@@ -104,7 +104,10 @@ public class MovingConfig extends ACheckConfig {
 
     // PassableAccuracy: also use if ray-tracing is not used
     public ActionList passableActions;
-    /** Decay factor for passable violation level. */
+    /**
+     * Fraction of the passable violation level retained per tick. Lower values
+     * cause faster decay.
+     */
     public double     passableVlDecay;
     public double     passableHorizontalMargins;
     public double     passableVerticalMargins;
@@ -139,7 +142,10 @@ public class MovingConfig extends ACheckConfig {
     public boolean    sfSetBackPolicyVoid;
     public boolean    sfSetBackPolicyApplyFallDamage;
     public ActionList survivalFlyActions;
-    /** Decay factor for survival fly violation level. */
+    /**
+     * Fraction of the survival fly violation level retained per tick. Lower
+     * values cause faster decay.
+     */
     public double     survivalFlyVlDecay;
 
     public boolean 	sfHoverCheck; // Placeholder for potential sub check
@@ -193,7 +199,10 @@ public class MovingConfig extends ACheckConfig {
 
     public HashMap<EntityType, Double> vehicleEnvelopeHorizontalSpeedCap = new HashMap<EntityType, Double>();
     public ActionList vehicleEnvelopeActions;
-    /** Decay factor for vehicle envelope violation level. */
+    /**
+     * Fraction of the vehicle envelope violation level retained per tick.
+     * Values below {@code 1.0} make decay faster.
+     */
     public double     vehicleEnvelopeVlDecay;
 
     // Trace
@@ -344,7 +353,7 @@ public class MovingConfig extends ACheckConfig {
     private void loadPassableSettings(final ConfigFile config) {
         passableActions = config.getOptimizedActionList(ConfPaths.MOVING_PASSABLE_ACTIONS,
                 Permissions.MOVING_PASSABLE);
-        passableVlDecay = config.getDouble(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.99);
+        passableVlDecay = config.getDouble(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.0, 1.0, 0.99);
         passableHorizontalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_XZ_FACTOR, 0.1, 1.0, 0.999999);
         passableVerticalMargins = config.getDouble(ConfPaths.MOVING_PASSABLE_RT_Y_FACTOR, 0.1, 1.0, 0.999999);
         passableUntrackedTeleportCheck = config.getBoolean(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE);
@@ -389,7 +398,7 @@ public class MovingConfig extends ACheckConfig {
         survivalFlyVLFreezeInAir = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_LENIENCY_FREEZEINAIR);
         survivalFlyActions = config.getOptimizedActionList(ConfPaths.MOVING_SURVIVALFLY_ACTIONS,
                 Permissions.MOVING_SURVIVALFLY);
-        survivalFlyVlDecay = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.95);
+        survivalFlyVlDecay = config.getDouble(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.0, 1.0, 0.95);
 
         sfHoverCheck = config.getBoolean(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK);
         sfHoverTicks = config.getInt(ConfPaths.MOVING_SURVIVALFLY_HOVER_TICKS);
@@ -463,7 +472,7 @@ public class MovingConfig extends ACheckConfig {
                 vehicleEnvelopeHorizontalSpeedCap, 4.0, true);
         vehicleEnvelopeActions = config.getOptimizedActionList(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS,
                 Permissions.MOVING_VEHICLE_ENVELOPE);
-        vehicleEnvelopeVlDecay = config.getDouble(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.99);
+        vehicleEnvelopeVlDecay = config.getDouble(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.0, 1.0, 0.99);
         List<String> types;
         if (config.get(ConfPaths.MOVING_VEHICLE_IGNOREDVEHICLES) == null) {
             types = Arrays.asList("arrow", "spectral_arrow", "tipped_arrow");

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/Passable.java
@@ -103,7 +103,7 @@ public class Passable extends Check {
         // Finally handle violations.
         if (newTag == null) {
             // (Might consider if vl>=1: only decrease if from and loc are passable too, though micro...)
-            data.passableVL *= 0.99;
+            data.passableVL *= cc.passableVlDecay;
             return null;
         }
         else {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -487,7 +487,7 @@ public class SurvivalFly extends Check {
                     && lastMove.toIsValid
                     && lastMove.yDistance < -Magic.GRAVITY_MIN
                     && thisMove.yDistance - lastMove.yDistance < -Magic.GRAVITY_MIN)) {
-            data.survivalFlyVL *= 0.95;
+            data.survivalFlyVL *= cc.survivalFlyVlDecay;
             if (hDistanceAboveLimit < 0.0 && result <= 0.0 && !isSamePos && data.sfHorizontalBuffer < cc.hBufMax
                     && !data.sfLowJump) {
                 hBufRegain(hDistance, Math.min(0.2, Math.abs(hDistanceAboveLimit)), data, cc);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/ConfPaths.java
@@ -209,6 +209,7 @@ public abstract class ConfPaths {
     public static final String  BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT     = BLOCKBREAK_FREQUENCY_SHORTTERM + "limit";
     public static final String  BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS     = BLOCKBREAK_FREQUENCY_SHORTTERM + "ticks";
     public static final String  BLOCKBREAK_FREQUENCY_ACTIONS             = BLOCKBREAK_FREQUENCY + "actions";
+    public static final String  BLOCKBREAK_FREQUENCY_VL_DECAY            = BLOCKBREAK_FREQUENCY + "vldecay";
 
     private static final String BLOCKBREAK_NOSWING                       = BLOCKBREAK + "noswing.";
     public static final String  BLOCKBREAK_NOSWING_CHECK                 = BLOCKBREAK_NOSWING + SUB_ACTIVE;
@@ -242,10 +243,12 @@ public abstract class ConfPaths {
     public static final String BLOCKINTERACT_SPEED_INTERVAL              = BLOCKINTERACT_SPEED + "interval";
     public static final String BLOCKINTERACT_SPEED_LIMIT                 = BLOCKINTERACT_SPEED + "limit";
     public static final String BLOCKINTERACT_SPEED_ACTIONS               = BLOCKINTERACT_SPEED + "actions";
+    public static final String BLOCKINTERACT_SPEED_VL_DECAY              = BLOCKINTERACT_SPEED + "vldecay";
 
     private static final String BLOCKINTERACT_VISIBLE                    = BLOCKINTERACT + "visible.";
     public static final String  BLOCKINTERACT_VISIBLE_CHECK              = BLOCKINTERACT_VISIBLE + SUB_ACTIVE;
     public static final String  BLOCKINTERACT_VISIBLE_ACTIONS            = BLOCKINTERACT_VISIBLE + "actions";
+    public static final String  BLOCKINTERACT_VISIBLE_VL_DECAY           = BLOCKINTERACT_VISIBLE + "vldecay";
 
     // BLOCKPLACE
     public static final String  BLOCKPLACE                               = CHECKS + "blockplace.";
@@ -254,6 +257,7 @@ public abstract class ConfPaths {
     private static final String BLOCKPLACE_AGAINST                       = BLOCKPLACE + "against.";
     public static final String  BLOCKPLACE_AGAINST_CHECK                 = BLOCKPLACE_AGAINST + SUB_ACTIVE;
     public static final String BLOCKPLACE_AGAINST_ACTIONS                = BLOCKPLACE_AGAINST + "actions";
+    public static final String BLOCKPLACE_AGAINST_VL_DECAY               = BLOCKPLACE_AGAINST + "vldecay";
 
     private static final String BLOCKPLACE_AUTOSIGN                         = BLOCKPLACE + "autosign.";
     public static final String  BLOCKPLACE_AUTOSIGN_CHECK                = BLOCKPLACE_AUTOSIGN + SUB_ACTIVE;
@@ -274,6 +278,7 @@ public abstract class ConfPaths {
     public static final String  BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY = BLOCKPLACE_FASTPLACE_IMPROBABLE + "feedonly";
     public static final String  BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT   = BLOCKPLACE_FASTPLACE_IMPROBABLE + "weight";
     public static final String  BLOCKPLACE_FASTPLACE_ACTIONS             = BLOCKPLACE_FASTPLACE + "actions";
+    public static final String  BLOCKPLACE_FASTPLACE_VL_DECAY            = BLOCKPLACE_FASTPLACE + "vldecay";
 
     private static final String BLOCKPLACE_NOSWING                       = BLOCKPLACE + "noswing.";
     public static final String  BLOCKPLACE_NOSWING_CHECK                 = BLOCKPLACE_NOSWING + SUB_ACTIVE;
@@ -336,6 +341,7 @@ public abstract class ConfPaths {
     public static final String  CHAT_COMMANDS_SHORTTERM_TICKS            = CHAT_COMMANDS_SHORTTERM + "ticks";
     public static final String  CHAT_COMMANDS_SHORTTERM_LEVEL            = CHAT_COMMANDS_SHORTTERM + "level";
     public static final String  CHAT_COMMANDS_ACTIONS                    = CHAT_COMMANDS + "actions";
+    public static final String  CHAT_COMMANDS_VL_DECAY                   = CHAT_COMMANDS + "vldecay";
 
     // Text
     private static final String CHAT_TEXT                                = CHAT + "text.";
@@ -343,6 +349,7 @@ public abstract class ConfPaths {
     public static final String CHAT_TEXT_DEBUG                           = CHAT_TEXT + "debug";
     public static final String CHAT_TEXT_ENGINE_MAXIMUM                  = CHAT_TEXT + "maximum";
     public static final String CHAT_TEXT_ALLOWVLRESET                    = CHAT_TEXT + "allowvlreset";
+    public static final String CHAT_TEXT_VL_DECAY                        = CHAT_TEXT + "vldecay";
     /**
      * Expiration time for per-player word processor data in milliseconds.
      */
@@ -443,6 +450,7 @@ public abstract class ConfPaths {
     public static final String  COMBINED_IMPROBABLE_CHECK                = COMBINED_IMPROBABLE + SUB_ACTIVE;
     public static final String  COMBINED_IMPROBABLE_LEVEL                = COMBINED_IMPROBABLE + "level";
     public static final String  COMBINED_IMPROBABLE_ACTIONS              = COMBINED_IMPROBABLE + "actions";
+    public static final String  COMBINED_IMPROBABLE_VL_DECAY             = COMBINED_IMPROBABLE + "vldecay";
 
     private static final String COMBINED_INVULNERABLE                       = COMBINED + "invulnerable.";
     public static final String  COMBINED_INVULNERABLE_CHECK                 = COMBINED_INVULNERABLE + SUB_ACTIVE;
@@ -583,6 +591,7 @@ public abstract class ConfPaths {
     private static final String INVENTORY_FASTCLICK_IMPROBABLE           = INVENTORY_FASTCLICK + "improbable.";
     public static final String  INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT    = INVENTORY_FASTCLICK_IMPROBABLE + "weight";
     public static final String  INVENTORY_FASTCLICK_ACTIONS              = INVENTORY_FASTCLICK + "actions";
+    public static final String  INVENTORY_FASTCLICK_VL_DECAY             = INVENTORY_FASTCLICK + "vldecay";
 
     private static final String INVENTORY_FASTCONSUME                    = INVENTORY + "fastconsume.";
     public static final String  INVENTORY_FASTCONSUME_CHECK              = INVENTORY_FASTCONSUME + SUB_ACTIVE;
@@ -672,6 +681,7 @@ public abstract class ConfPaths {
     public static final String  MOVING_PASSABLE_CHECK                       = MOVING_PASSABLE + SUB_ACTIVE;
     //private static final String MOVING_PASSABLE_RAYTRACING                  = MOVING_PASSABLE + "raytracing.";
     public static final String  MOVING_PASSABLE_ACTIONS                     = MOVING_PASSABLE + "actions";
+    public static final String  MOVING_PASSABLE_VL_DECAY                    = MOVING_PASSABLE + "vldecay";
     public static final String  MOVING_PASSABLE_RT_XZ_FACTOR                = MOVING_PASSABLE + "horizontalmargins";
     public static final String  MOVING_PASSABLE_RT_Y_FACTOR                 = MOVING_PASSABLE + "verticalmargins";
     private static final String MOVING_PASSABLE_UNTRACKED                   = MOVING_PASSABLE + "untracked.";
@@ -709,6 +719,7 @@ public abstract class ConfPaths {
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE  = MOVING_SURVIVALFLY_SETBACKPOLICY + "falldamage";
     public static final String MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID  = MOVING_SURVIVALFLY_SETBACKPOLICY + "voidtovoid";
     public static final String MOVING_SURVIVALFLY_ACTIONS                   = MOVING_SURVIVALFLY + "actions";
+    public static final String MOVING_SURVIVALFLY_VL_DECAY                  = MOVING_SURVIVALFLY + "vldecay";
     private static final String MOVING_SURVIVALFLY_VLFREQUENCY              = MOVING_SURVIVALFLY_LENIENCY + "violationfrequency.";
     public static final String MOVING_SURVIVALFLY_VLFREQUENCY_ACTIVE        = MOVING_SURVIVALFLY_VLFREQUENCY + "active";
     public static final String MOVING_SURVIVALFLY_VLFREQUENCY_DEBUG         = MOVING_SURVIVALFLY_VLFREQUENCY + "debug";
@@ -774,6 +785,7 @@ public abstract class ConfPaths {
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIVE              = MOVING_VEHICLE_ENVELOPE + SUB_ACTIVE;
     public static final String  MOVING_VEHICLE_ENVELOPE_HSPEEDCAP           = MOVING_VEHICLE_ENVELOPE + "hdistcap"; // Section.
     public static final String  MOVING_VEHICLE_ENVELOPE_ACTIONS             = MOVING_VEHICLE_ENVELOPE + "actions";
+    public static final String  MOVING_VEHICLE_ENVELOPE_VL_DECAY            = MOVING_VEHICLE_ENVELOPE + "vldecay";
 
     private static final String MOVING_MESSAGE                              = MOVING + "message.";
     public static final  String MOVING_MESSAGE_ILLEGALPLAYERMOVE            = MOVING_MESSAGE + "illegalplayermove";

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/DefaultConfig.java
@@ -136,6 +136,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_TICKS, 5, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_SHORTTERM_LIMIT, 7, 785);
         set(ConfPaths.BLOCKBREAK_FREQUENCY_ACTIONS, "cancel vl>5 log:bbfrequency:3:5:i cancel vl>40 log:bbfrequency:0:5:if cancel cmdc:kickfrequency:0:5", 1154);
+        set(ConfPaths.BLOCKBREAK_FREQUENCY_VL_DECAY, 0.95, 1154);
         // NoSwing
         set(ConfPaths.BLOCKBREAK_NOSWING_CHECK, "default", 785);
         set(ConfPaths.BLOCKBREAK_NOSWING_ACTIONS, "cancel vl>10 log:noswing:0:5:i cancel", 785);
@@ -161,11 +162,13 @@ public class DefaultConfig extends ConfigFile {
         // Speed
         set(ConfPaths.BLOCKINTERACT_SPEED_CHECK, "default", 785);
         set(ConfPaths.BLOCKINTERACT_SPEED_INTERVAL, 2000, 785);
-        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154); 
+        set(ConfPaths.BLOCKINTERACT_SPEED_LIMIT, 55, 1154);
         set(ConfPaths.BLOCKINTERACT_SPEED_ACTIONS, "cancel vl>10 cancel log:bspeed:5:4:i cancel vl>500 cancel log:bspeed:0:5:icf cmdc:kickbspeed:2:5", 1154);
+        set(ConfPaths.BLOCKINTERACT_SPEED_VL_DECAY, 0.99, 1154);
         // Visible
         set(ConfPaths.BLOCKINTERACT_VISIBLE_CHECK, "default", 785);
-        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154); 
+        set(ConfPaths.BLOCKINTERACT_VISIBLE_ACTIONS, "cancel vl>30 log:bvisible:8:5:if cancel", 1154);
+        set(ConfPaths.BLOCKINTERACT_VISIBLE_VL_DECAY, 0.99, 1154);
 
 
         /* BlockPlace */
@@ -173,6 +176,7 @@ public class DefaultConfig extends ConfigFile {
         // Against
         set(ConfPaths.BLOCKPLACE_AGAINST_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_AGAINST_ACTIONS, "cancel log:against:1:5:i vl>10 cancel log:against:0:2:if cmdc:kickagainst:0:10", 1154);
+        set(ConfPaths.BLOCKPLACE_AGAINST_VL_DECAY, 0.99, 1154); // Assume one false positive every 100 blocks.
         // AutoSign
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_AUTOSIGN_SKIPEMPTY, false, 785);
@@ -188,6 +192,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_FEEDONLY, false, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_IMPROBABLE_WEIGHT, 0.3, 1154);
         set(ConfPaths.BLOCKPLACE_FASTPLACE_ACTIONS, "cancel vl>5 cancel log:fastplace:8:3:i vl>20 cancel log:fastplace:2:4:i vl>80 cancel log:fastplace:0:10:if cmdc:kickfastplace:1:10", 1154);
+        set(ConfPaths.BLOCKPLACE_FASTPLACE_VL_DECAY, 0.95, 1154);
         // Reach
         set(ConfPaths.BLOCKPLACE_REACH_CHECK, "default", 785);
         set(ConfPaths.BLOCKPLACE_REACH_ACTIONS, "cancel", 1154);
@@ -236,10 +241,12 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_TICKS, 18, 785);
         set(ConfPaths.CHAT_COMMANDS_SHORTTERM_LEVEL, 3, 785);
         set(ConfPaths.CHAT_COMMANDS_ACTIONS, "log:commands:0:5:cf cancel cmdc:kickcommands vl>20 log:commands:0:5:cf cancel cmdc:tempkick1", 1154);
+        set(ConfPaths.CHAT_COMMANDS_VL_DECAY, 0.99, 1154);
         // Text (ordering on purpose).
         // Normal
         set(ConfPaths.CHAT_TEXT_CHECK, "default", 785);
         set(ConfPaths.CHAT_TEXT_ALLOWVLRESET, true, 785);
+        set(ConfPaths.CHAT_TEXT_VL_DECAY, 0.95, 1154);
         // Expiration duration for per-player cache in milliseconds.
         set(ConfPaths.CHAT_TEXT_EXPIRATION_TIME, 600000L, 785);
         set(ConfPaths.CHAT_TEXT_FREQ_NORM_MIN, 0.0, 785);
@@ -308,6 +315,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.COMBINED_IMPROBABLE_CHECK , "default", 785);
         set(ConfPaths.COMBINED_IMPROBABLE_LEVEL, 250, 1154);
         set(ConfPaths.COMBINED_IMPROBABLE_ACTIONS, "cancel vl>20 log:improbable:8:9:if cancel vl>1500 cancel log:improbable:0:10:if cmdc:kickimprobable:0:5", 1154);
+        set(ConfPaths.COMBINED_IMPROBABLE_VL_DECAY, 0.95, 1154);
         // Invulnerable
         set(ConfPaths.COMBINED_INVULNERABLE_CHECK, true, 785); // Not a check type yet.
         set(ConfPaths.COMBINED_INVULNERABLE_TRIGGERS_ALWAYS, false, 785);
@@ -411,6 +419,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.INVENTORY_FASTCLICK_LIMIT_CHEST, 155, 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_IMPROBABLE_WEIGHT, 0.7, 1154);
         set(ConfPaths.INVENTORY_FASTCLICK_ACTIONS, "cancel vl>150 cancel log:fastclick:7:5:i vl>400 cancel log:fastclick:1:5:if vl>3000 cancel log:fastclick:1:2:if cmdc:kickfastclick:2:5", 1154);
+        set(ConfPaths.INVENTORY_FASTCLICK_VL_DECAY, 0.99, 1154);
         // InstantBow
         set(ConfPaths.INVENTORY_INSTANTBOW_CHECK, "default", 785);
         set(ConfPaths.INVENTORY_INSTANTBOW_STRICT, true, 785);
@@ -535,6 +544,7 @@ public class DefaultConfig extends ConfigFile {
         // Passable
         set(ConfPaths.MOVING_PASSABLE_CHECK, "default", 785);
         set(ConfPaths.MOVING_PASSABLE_ACTIONS, "cancel vl>15 cancel log:passable:7:9:i vl>100 cancel log:passable:1:4:if", 1154);
+        set(ConfPaths.MOVING_PASSABLE_VL_DECAY, 0.99, 1154);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_TELEPORT_ACTIVE, true, 785);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_ACTIVE, true, 785);
         set(ConfPaths.MOVING_PASSABLE_UNTRACKED_CMD_TRYTELEPORT, true, 785);
@@ -561,10 +571,11 @@ public class DefaultConfig extends ConfigFile {
         // MOVING_SURVIVALFLY_SETBACKPOLICY_FALLDAMAGE -> MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_APPLYFALLDAMAGE, true, 785);
         set(ConfPaths.MOVING_SURVIVALFLY_SETBACKPOLICY_VOIDTOVOID, false, 1154);
-        set(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, "cancel log:flyfile:6:15:f" 
-            + " vl>100 cancel log:survivalfly:10:11:i log:flyfile:6:15:f" 
-            + " vl>700 cancel log:survivalfly:8:5:i log:flyfile:1:3:f" 
-            + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15", 1154);     
+        set(ConfPaths.MOVING_SURVIVALFLY_ACTIONS, "cancel log:flyfile:6:15:f"
+            + " vl>100 cancel log:survivalfly:10:11:i log:flyfile:6:15:f"
+            + " vl>700 cancel log:survivalfly:8:5:i log:flyfile:1:3:f"
+            + " vl>2100 cancel log:survivalflyhighvl:0:4:icf cmdc:kickfly:0:15", 1154);
+        set(ConfPaths.MOVING_SURVIVALFLY_VL_DECAY, 0.95, 1154);
         // SurvivalFly - Hover Subcheck
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_CHECK, true, 785); // Not a check type yet.
         set(ConfPaths.MOVING_SURVIVALFLY_HOVER_STEP, 5, 785);
@@ -608,6 +619,7 @@ public class DefaultConfig extends ConfigFile {
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".default", 0.9, 1154);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_HSPEEDCAP + ".pig", 0.3, 1154);
         set(ConfPaths.MOVING_VEHICLE_ENVELOPE_ACTIONS, "cancel vl>50 cancel log:vehicleenvelope:10:6:if vl>300 cancel log:vehicleenvelope:0:10:if cmdc:kickvehiclefly:0:10", 1154);
+        set(ConfPaths.MOVING_VEHICLE_ENVELOPE_VL_DECAY, 0.99, 1154);
         // Messages
         set(ConfPaths.MOVING_MESSAGE_ILLEGALPLAYERMOVE, "Illegal move.", 785);
         set(ConfPaths.MOVING_MESSAGE_ILLEGALVEHICLEMOVE, "Illegal vehicle move.", 785);


### PR DESCRIPTION
## Summary
- expose VL decay factors in `ConfPaths` and `DefaultConfig`
- load decay fields in various check config classes
- use new fields in checks to reduce violation level over time
- document each decay factor

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check` *(fails: lines exceed limit)*

------
https://chatgpt.com/codex/tasks/task_b_685eaa96daa48329b8ad784bd31abe17

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Extract decay factors into configuration files for various violation level calculations across multiple checks.

### Why are these changes being made?

These changes are being made to centralize the decay factors for violation level adjustments into configuration files, which will enhance customization flexibility and maintainability. This approach allows server administrators to adjust decay rates without modifying the code, thus improving scalability and simplifying future updates or tweaks based on server requirements or performance analyses.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->