### PR TITLE
Cap block model height to 1.0

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/MCAccessBukkitModern.java
@@ -87,7 +87,7 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
     // Blocks that change shape based on interaction or redstone.
     private static final BukkitShapeModel MODEL_DOOR = new BukkitDoor();
     private static final BukkitShapeModel MODEL_TRAP_DOOR = new BukkitTrapDoor();
-    private static final BukkitShapeModel MODEL_GATE = new BukkitGate(0.375, 1.5);
+    private static final BukkitShapeModel MODEL_GATE = new BukkitGate(0.375, 1.0);
     private static final BukkitShapeModel MODEL_SHULKER_BOX = new BukkitShulkerBox();
     private static final BukkitShapeModel MODEL_CHORUS_PLANT = new BukkitChorusPlant();
     private static final BukkitShapeModel MODEL_DRIP_LEAF = new BukkitDripLeaf();
@@ -111,8 +111,8 @@ public class MCAccessBukkitModern extends MCAccessBukkit {
 
     // Blocks that have a different shape with neighbor blocks (bukkit takes care though).
     private static final BukkitShapeModel MODEL_THIN_FENCE = new BukkitFence(0.4375, 1.0);
-    private static final BukkitShapeModel MODEL_THICK_FENCE = new BukkitFence(0.375, 1.5);
-    private static final BukkitShapeModel MODEL_THICK_FENCE2 = new BukkitWall(0.25, 1.5, 0.3125); // .75 .25 0 max: .25 .75 .5
+    private static final BukkitShapeModel MODEL_THICK_FENCE = new BukkitFence(0.375, 1.0);
+    private static final BukkitShapeModel MODEL_THICK_FENCE2 = new BukkitWall(0.25, 1.0, 0.3125); // .75 .25 0 max: .25 .75 .5
     private static final BukkitShapeModel MODEL_WALL_HEAD = new BukkitWallHead();
 
     // Static blocks (various height and inset values).

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
@@ -56,7 +56,7 @@ public class BukkitFence implements BukkitShapeModel {
     public BukkitFence(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = Math.min(height, 1.0);
+        this.height = BukkitModelUtil.clampHeight(height);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
@@ -36,7 +36,7 @@ public class BukkitFence implements BukkitShapeModel {
     public BukkitFence(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitFence.java
@@ -29,10 +29,30 @@ public class BukkitFence implements BukkitShapeModel {
     private final double maxXZ;
     private final double height;
 
+    /**
+     * Construct a fence model with symmetric inset.
+     * <p>
+     * Heights above {@code 1.0} are automatically reduced to keep the bounding
+     * box within the block space.
+     * </p>
+     *
+     * @param inset  distance from the block edge on both x and z
+     * @param height requested model height
+     */
     public BukkitFence(double inset, double height) {
         this(inset, 1.0 - inset, height);
     }
 
+    /**
+     * Construct a fence model with explicit bounds.
+     * <p>
+     * The height is capped at {@code 1.0} for safety.
+     * </p>
+     *
+     * @param minXZ minimum x/z coordinate
+     * @param maxXZ maximum x/z coordinate
+     * @param height requested model height
+     */
     public BukkitFence(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
@@ -36,7 +36,7 @@ public class BukkitGate implements BukkitShapeModel {
     public BukkitGate(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
@@ -29,10 +29,25 @@ public class BukkitGate implements BukkitShapeModel {
     private final double maxXZ;
     private final double height;
 
+    /**
+     * Construct a gate model with symmetric inset.
+     * Heights above {@code 1.0} are reduced to maintain a valid bounding box.
+     *
+     * @param inset  distance from the block edge on both x and z
+     * @param height requested model height
+     */
     public BukkitGate(double inset, double height) {
         this(inset, 1.0 - inset, height);
     }
 
+    /**
+     * Construct a gate model with explicit bounds.
+     * The height will never exceed {@code 1.0}.
+     *
+     * @param minXZ minimum x/z coordinate
+     * @param maxXZ maximum x/z coordinate
+     * @param height requested model height
+     */
     public BukkitGate(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitGate.java
@@ -51,7 +51,7 @@ public class BukkitGate implements BukkitShapeModel {
     public BukkitGate(double minXZ, double maxXZ, double height) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = Math.min(height, 1.0);
+        this.height = BukkitModelUtil.clampHeight(height);
     }
 
     @Override

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitModelUtil.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitModelUtil.java
@@ -1,0 +1,19 @@
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+/**
+ * Utility methods for working with Bukkit block shape models.
+ */
+public final class BukkitModelUtil {
+
+    private BukkitModelUtil() {}
+
+    /**
+     * Clamp the given height so it does not exceed one block.
+     *
+     * @param height the requested height
+     * @return {@code Math.min(height, 1.0)}
+     */
+    public static double clampHeight(double height) {
+        return Math.min(height, 1.0);
+    }
+}

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
@@ -24,8 +24,12 @@ import org.bukkit.block.ShulkerBox;
 
 public class BukkitShulkerBox implements BukkitShapeModel {
 
+    /**
+     * Return the shulker box shape. When the box is open the height is capped
+     * to {@code 1.0} to avoid exceeding the block boundaries.
+     */
     @Override
-    public double[] getShape(final BlockCache blockCache, 
+    public double[] getShape(final BlockCache blockCache,
             final World world, final int x, final int y, final int z) {
 
         final Block block = world.getBlockAt(x, y, z);

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
@@ -34,7 +34,7 @@ public class BukkitShulkerBox implements BukkitShapeModel {
 
         if (state instanceof ShulkerBox) {
             if (!((ShulkerBox) state).getInventory().getViewers().isEmpty()) {
-                return new double[] {0.0, 0.0, 0.0, 1.0, 1.5, 1.0};
+                return new double[] {0.0, 0.0, 0.0, 1.0, Math.min(1.5, 1.0), 1.0};
             }
         }
         return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitShulkerBox.java
@@ -22,6 +22,8 @@ import org.bukkit.block.Container;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import org.bukkit.block.ShulkerBox;
 
+import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitModelUtil;
+
 public class BukkitShulkerBox implements BukkitShapeModel {
 
     /**
@@ -38,7 +40,7 @@ public class BukkitShulkerBox implements BukkitShapeModel {
 
         if (state instanceof ShulkerBox) {
             if (!((ShulkerBox) state).getInventory().getViewers().isEmpty()) {
-                return new double[] {0.0, 0.0, 0.0, 1.0, Math.min(1.5, 1.0), 1.0};
+                return new double[] {0.0, 0.0, 0.0, 1.0, BukkitModelUtil.clampHeight(1.5), 1.0};
             }
         }
         return new double[] {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -33,8 +33,12 @@ public class BukkitStatic implements BukkitShapeModel {
 
     /**
      * Create a shape model using full xz-bounds for the given height.
+     * <p>
+     * Any value greater than {@code 1.0} is reduced to {@code 1.0} so the
+     * returned bounding box never exceeds the default block height.
+     * </p>
      *
-     * @param height
+     * @param height requested model height
      * @return New instance.
      */
     public static BukkitStatic ofHeight(double height) {
@@ -46,9 +50,13 @@ public class BukkitStatic implements BukkitShapeModel {
 
     /**
      * Create a shape model with the given xz-inset and height.
+     * <p>
+     * Height values above {@code 1.0} will be capped to ensure the resulting
+     * shape is contained within a single block space.
+     * </p>
      *
-     * @param xzInset
-     * @param height
+     * @param xzInset inset to apply on x and z
+     * @param height requested model height
      * @return New instance.
      */
     public static BukkitStatic ofInsetAndHeight(double xzInset, double height) {

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -41,7 +41,7 @@ public class BukkitStatic implements BukkitShapeModel {
         if (height <= 0.0) {
             throw new IllegalArgumentException("Height must be positive: " + height);
         }
-        return ofInsetAndHeight(0.0, height);
+        return ofInsetAndHeight(0.0, Math.min(height, 1.0));
     }
 
     /**
@@ -55,6 +55,7 @@ public class BukkitStatic implements BukkitShapeModel {
         if (height <= 0.0) {
             throw new IllegalArgumentException("Height must be positive: " + height);
         }
+        height = Math.min(height, 1.0);
         return ofBounds(xzInset, 0.0, xzInset, 1.0 - xzInset, height, 1.0 - xzInset);
     }
 

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStatic.java
@@ -45,7 +45,7 @@ public class BukkitStatic implements BukkitShapeModel {
         if (height <= 0.0) {
             throw new IllegalArgumentException("Height must be positive: " + height);
         }
-        return ofInsetAndHeight(0.0, Math.min(height, 1.0));
+        return ofInsetAndHeight(0.0, BukkitModelUtil.clampHeight(height));
     }
 
     /**
@@ -63,7 +63,7 @@ public class BukkitStatic implements BukkitShapeModel {
         if (height <= 0.0) {
             throw new IllegalArgumentException("Height must be positive: " + height);
         }
-        height = Math.min(height, 1.0);
+        height = BukkitModelUtil.clampHeight(height);
         return ofBounds(xzInset, 0.0, xzInset, 1.0 - xzInset, height, 1.0 - xzInset);
     }
 

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
@@ -52,14 +52,36 @@ public class BukkitWall implements BukkitShapeModel {
     private final double[] eastwest;
     private final double[] southnorth;
 
+    /**
+     * Construct a wall model with symmetric inset.
+     *
+     * @param inset  distance from the block edge
+     * @param height requested model height (capped at {@code 1.0})
+     */
     public BukkitWall(double inset, double height) {
         this(inset, 1.0 - inset, height, 0.0);
     }
 
+    /**
+     * Construct a wall model with symmetric inset and side inset.
+     *
+     * @param inset     distance from the block edge
+     * @param height    requested model height (capped to {@code 1.0})
+     * @param sideInset inset for side posts
+     */
     public BukkitWall(double inset, double height, double sideInset) {
         this(inset, 1.0 - inset, height, sideInset);
     }
 
+    /**
+     * Construct a wall model with explicit bounds.
+     * Height is clamped to {@code 1.0}.
+     *
+     * @param minXZ    minimum x/z coordinate
+     * @param maxXZ    maximum x/z coordinate
+     * @param height   requested model height
+     * @param sideInset inset for side posts
+     */
     public BukkitWall(double minXZ, double maxXZ, double height, double sideInset) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
@@ -85,7 +85,7 @@ public class BukkitWall implements BukkitShapeModel {
     public BukkitWall(double minXZ, double maxXZ, double height, double sideInset) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = Math.min(height, 1.0);
+        this.height = BukkitModelUtil.clampHeight(height);
         this.sideInset = sideInset;
         east = new double[] {maxXZ, 0.0, sideInset, 1.0, this.height, 1.0 - sideInset};
         north = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, this.height, minXZ};

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWall.java
@@ -63,14 +63,14 @@ public class BukkitWall implements BukkitShapeModel {
     public BukkitWall(double minXZ, double maxXZ, double height, double sideInset) {
         this.minXZ = minXZ;
         this.maxXZ = maxXZ;
-        this.height = height;
+        this.height = Math.min(height, 1.0);
         this.sideInset = sideInset;
-        east = new double[] {maxXZ, 0.0, sideInset, 1.0, height, 1.0 - sideInset};
-        north = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, height, minXZ};
-        west = new double[] {0.0, 0.0, sideInset, minXZ, height, 1.0 - sideInset};
-        south = new double[] {sideInset, 0.0, maxXZ, 1.0 - sideInset, height, 1.0};
-        eastwest = new double[] {0.0, 0.0, sideInset, 1.0, height, 1.0 - sideInset};
-        southnorth = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, height, 1.0};
+        east = new double[] {maxXZ, 0.0, sideInset, 1.0, this.height, 1.0 - sideInset};
+        north = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, this.height, minXZ};
+        west = new double[] {0.0, 0.0, sideInset, minXZ, this.height, 1.0 - sideInset};
+        south = new double[] {sideInset, 0.0, maxXZ, 1.0 - sideInset, this.height, 1.0};
+        eastwest = new double[] {0.0, 0.0, sideInset, 1.0, this.height, 1.0 - sideInset};
+        southnorth = new double[] {sideInset, 0.0, 0.0, 1.0 - sideInset, this.height, 1.0};
     }
 
     /**

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitModelHeightCapTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitModelHeightCapTest.java
@@ -1,0 +1,74 @@
+package fr.neatmonster.nocheatplus.compat.bukkit.model;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
+import org.bukkit.block.data.MultipleFacing;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.block.ShulkerBox;
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
+
+public class BukkitModelHeightCapTest {
+
+    @Test
+    public void testFenceHeightCapped() {
+        BukkitFence fence = new BukkitFence(0.375, 1.5);
+        World world = mock(World.class);
+        Block block = mock(Block.class);
+        BlockState state = mock(BlockState.class);
+        MultipleFacing data = mock(MultipleFacing.class, withSettings().extraInterfaces(BlockData.class));
+        when(world.getBlockAt(0, 0, 0)).thenReturn(block);
+        when(block.getState()).thenReturn(state);
+        when(state.getBlockData()).thenReturn((BlockData) data);
+        when(data.getFaces()).thenReturn(Collections.emptySet());
+
+        double[] expected = {0.375, 0.0, 0.375, 0.625, 1.0, 0.625};
+        double[] res = fence.getShape(mock(BlockCache.class), world, 0, 0, 0);
+        assertArrayEquals(expected, res, 0.0);
+    }
+
+    @Test
+    public void testGateHeightCapped() {
+        BukkitGate gate = new BukkitGate(0.375, 1.5);
+        World world = mock(World.class);
+        Block block = mock(Block.class);
+        BlockState state = mock(BlockState.class);
+        BlockData data = mock(BlockData.class, withSettings().extraInterfaces(Directional.class));
+        when(world.getBlockAt(0, 0, 0)).thenReturn(block);
+        when(block.getState()).thenReturn(state);
+        when(state.getBlockData()).thenReturn(data);
+        when(((Directional) data).getFacing()).thenReturn(org.bukkit.block.BlockFace.EAST);
+
+        double[] expected = {0.375, 0.0, 0.0, 0.625, 1.0, 1.0};
+        double[] res = gate.getShape(mock(BlockCache.class), world, 0, 0, 0);
+        assertArrayEquals(expected, res, 0.0);
+    }
+
+    @Test
+    public void testShulkerBoxHeightCapped() {
+        BukkitShulkerBox model = new BukkitShulkerBox();
+        World world = mock(World.class);
+        Block block = mock(Block.class);
+        ShulkerBox state = mock(ShulkerBox.class);
+        Inventory inv = mock(Inventory.class);
+        HumanEntity viewer = mock(HumanEntity.class);
+        when(world.getBlockAt(0,0,0)).thenReturn(block);
+        when(block.getState()).thenReturn(state);
+        when(state.getInventory()).thenReturn(inv);
+        when(inv.getViewers()).thenReturn(Collections.singletonList(viewer));
+
+        double[] expected = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+        double[] res = model.getShape(mock(BlockCache.class), world, 0, 0, 0);
+        assertArrayEquals(expected, res, 0.0);
+    }
+}

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStaticTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStaticTest.java
@@ -33,4 +33,18 @@ public class BukkitStaticTest {
     public void testOfInsetAndHeightInvalid() {
         BukkitStatic.ofInsetAndHeight(0.25, -0.1);
     }
+
+    @Test
+    public void testOfHeightCapped() {
+        BukkitStatic model = BukkitStatic.ofHeight(1.5);
+        double[] expected = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+        assertArrayEquals(expected, model.getShape(null, null, 0, 0, 0), 0.0);
+    }
+
+    @Test
+    public void testOfInsetAndHeightCapped() {
+        BukkitStatic model = BukkitStatic.ofInsetAndHeight(0.25, 1.5);
+        double[] expected = {0.25, 0.0, 0.25, 0.75, 1.0, 0.75};
+        assertArrayEquals(expected, model.getShape(null, null, 0, 0, 0), 0.0);
+    }
 }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
@@ -19,7 +19,7 @@ public class BukkitWallTest {
         MultipleFacing data = mock(MultipleFacing.class);
         Set<BlockFace> faces = EnumSet.of(BlockFace.SOUTH, BlockFace.EAST);
         when(data.getFaces()).thenReturn(faces);
-        double[] expected = {0.3125, 0.0, 0.0, 1.0 - 0.3125, 1.5, 1.0};
+        double[] expected = {0.3125, 0.0, 0.0, 1.0 - 0.3125, 1.0, 1.0};
         double[] res = invokeMultipleFacing(wall, data);
         assertArrayEquals(expected, res, 0.0);
     }
@@ -33,7 +33,7 @@ public class BukkitWallTest {
         when(data.getHeight(BlockFace.EAST)).thenReturn(Wall.Height.NONE);
         when(data.getHeight(BlockFace.NORTH)).thenReturn(Wall.Height.NONE);
         when(data.getHeight(BlockFace.SOUTH)).thenReturn(Wall.Height.NONE);
-        double[] expected = {0.25,0.0,0.25,0.75,1.5,0.75,0.0,0.0,0.3125,0.25,1.5,0.6875};
+        double[] expected = {0.25,0.0,0.25,0.75,1.0,0.75,0.0,0.0,0.3125,0.25,1.0,0.6875};
         double[] res = invokeWall(wall, data);
         assertArrayEquals(expected, res, 0.0);
     }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ModelHeightLimitTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/ModelHeightLimitTest.java
@@ -1,0 +1,33 @@
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+import fr.neatmonster.nocheatplus.compat.bukkit.MCAccessBukkitModern;
+import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitShapeModel;
+import fr.neatmonster.nocheatplus.compat.bukkit.model.BukkitStatic;
+
+public class ModelHeightLimitTest {
+
+    @Test
+    public void testStaticModelHeights() throws IllegalAccessException {
+        for (Field field : MCAccessBukkitModern.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            if (!BukkitShapeModel.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+            field.setAccessible(true);
+            BukkitShapeModel model = (BukkitShapeModel) field.get(null);
+            if (model instanceof BukkitStatic) {
+                double[] shape = model.getShape(null, null, 0, 0, 0);
+                for (int i = 5; i < shape.length; i += 6) {
+                    assertTrue(field.getName() + " exceeds height 1.0", shape[i] <= 1.0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- cap height in BukkitShape model builders
- rebuild fence, gate, wall and shulker box models with capped heights
- ensure new height limit in block model tests

## Testing
- `mvn -q test`
- `mvn -q -pl NCPCompatBukkit checkstyle:check`
- `mvn -q -pl NCPCompatBukkit pmd:check`
- `mvn -q -pl NCPCompatBukkit spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685f460a8a288329b292966bbd2770ce

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Cap the model height for block structures such as fences, gates, shulker boxes, and walls to a maximum of 1.0, and add corresponding unit tests.

### Why are these changes being made?
These changes address the issue of model heights inadvertently exceeding the intended limit of 1.0, which could lead to unexpected behaviors or rendering issues. By capping the height and implementing unit tests, we ensure consistency across different block models while validating the new functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->