### PR TITLE
Fix instant eat timestamp logic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -525,9 +525,18 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
 
     private void rememberFoodInteract(final InventoryData data, final Material type) {
         final long now = System.currentTimeMillis();
-        data.instantEatFood = type;
-        data.instantEatInteract = (data.instantEatInteract > 0 && now - data.instantEatInteract < 800)
-                ? Math.min(now, data.instantEatInteract) : now;
+        final long diff = now - data.instantEatInteract;
+
+        if (data.instantEatInteract <= 0) {
+            data.instantEatInteract = now;
+            data.instantEatFood = type;
+        } else if (diff < 800) {
+            data.instantEatInteract = Math.min(now, data.instantEatInteract);
+            data.instantEatFood = type;
+        } else {
+            data.instantEatInteract = now;
+            data.instantEatFood = null;
+        }
         data.instantBowInteract = 0;
     }
 

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListenerTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListenerTest.java
@@ -1,0 +1,56 @@
+package fr.neatmonster.nocheatplus.checks.inventory;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.bukkit.Material;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InventoryListenerTest {
+
+    private sun.misc.Unsafe unsafe;
+
+    @Before
+    public void setup() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        unsafe = (sun.misc.Unsafe) f.get(null);
+    }
+
+    private InventoryListener newListener() throws Exception {
+        return (InventoryListener) unsafe.allocateInstance(InventoryListener.class);
+    }
+
+    @Test
+    public void testFoodNotSetForOldInteract() throws Exception {
+        InventoryListener listener = newListener();
+        InventoryData data = new InventoryData();
+        Method m = InventoryListener.class.getDeclaredMethod("rememberFoodInteract", InventoryData.class, Material.class);
+        m.setAccessible(true);
+
+        long before = System.currentTimeMillis();
+        data.instantEatInteract = before - 900; // older than threshold
+        m.invoke(listener, data, Material.BREAD);
+        long after = System.currentTimeMillis();
+
+        assertNull(data.instantEatFood);
+        assertTrue(data.instantEatInteract >= before && data.instantEatInteract <= after);
+    }
+
+    @Test
+    public void testFoodSetForRecentInteract() throws Exception {
+        InventoryListener listener = newListener();
+        InventoryData data = new InventoryData();
+        Method m = InventoryListener.class.getDeclaredMethod("rememberFoodInteract", InventoryData.class, Material.class);
+        m.setAccessible(true);
+
+        data.instantEatInteract = System.currentTimeMillis() - 100; // within threshold
+        m.invoke(listener, data, Material.APPLE);
+
+        assertEquals(Material.APPLE, data.instantEatFood);
+        assertTrue(data.instantEatInteract > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- handle instant eat interactions without redundant checks
- only set `instantEatFood` on valid interact timing
- test that stale interacts do not set `instantEatFood`

## Testing
- `mvn -q verify` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_b_685f46b72f94832995b0ea23eea3bbaf