### PR TITLE
Optimize packet score lookup

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -107,17 +107,17 @@ public class NetStatic {
         final long tDiff = time - packetFreq.lastAccess();
         if (tDiff >= winDur && tDiff < totalDur) {
             // Cache bucket scores to avoid repeated bucketScore() calls.
-            final float[] bucketScores = new float[winNum];
+            final float[] originalBucketScores = new float[winNum];
             for (int i = 0; i < winNum; i++) {
-                bucketScores[i] = packetFreq.bucketScore(i);
+                originalBucketScores[i] = packetFreq.bucketScore(i);
             }
             // There will be some shift, so check if to relax, only if there could be some congestion.
-            float firstBucketScore = bucketScores[0];
+            float firstBucketScore = originalBucketScores[0];
             if (firstBucketScore > maxPackets) { // Clarify ideal versus maximum packet counts.
                 // Keep in mind potential burst-to-burst exploits.
                 firstBucketScore -= maxPackets; // Count this down.
                 for (int i = 1; i < winNum; i++) {
-                    final float currentBucketScore = bucketScores[i];
+                    final float currentBucketScore = originalBucketScores[i];
                     if (currentBucketScore < maxPackets) {
                         // Smoothen, using following empty spots including one occupied spot at most..
                         float consume = Math.min(firstBucketScore, maxPackets - currentBucketScore);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -51,10 +51,7 @@ public class NetStatic {
         int empty = 0;
         boolean firstUsed = false;
         boolean counting = false;
-        final float[] bucketScores = new float[winNum];
-        for (int i = 0; i < winNum; i++) {
-            bucketScores[i] = packetFreq.bucketScore(i);
-        }
+        final float[] bucketScores = snapshotBucketScores(packetFreq);
         for (int i = 1; i < winNum; i++) {
             final float bucket = bucketScores[i];
             if (bucket > 0f) {
@@ -69,6 +66,21 @@ public class NetStatic {
             }
         }
         return new BurnInfo(burnStart, empty);
+    }
+
+    /**
+     * Snapshot all bucket scores from the given frequency instance.
+     *
+     * @param packetFreq the packet frequency source
+     * @return an array of bucket scores
+     */
+    private static float[] snapshotBucketScores(final ActionFrequency packetFreq) {
+        final int winNum = packetFreq.numberOfBuckets();
+        final float[] scores = new float[winNum];
+        for (int i = 0; i < winNum; i++) {
+            scores[i] = packetFreq.bucketScore(i);
+        }
+        return scores;
     }
 
     /**
@@ -107,10 +119,7 @@ public class NetStatic {
         final long tDiff = time - packetFreq.lastAccess();
         if (tDiff >= winDur && tDiff < totalDur) {
             // Cache bucket scores to avoid repeated bucketScore() calls.
-            final float[] originalBucketScores = new float[winNum];
-            for (int i = 0; i < winNum; i++) {
-                originalBucketScores[i] = packetFreq.bucketScore(i);
-            }
+            final float[] originalBucketScores = snapshotBucketScores(packetFreq);
             // There will be some shift, so check if to relax, only if there could be some congestion.
             float firstBucketScore = originalBucketScores[0];
             if (firstBucketScore > maxPackets) { // Clarify ideal versus maximum packet counts.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -106,13 +106,18 @@ public class NetStatic {
         // Consider making this smoothing step configurable and refining the implementation.
         final long tDiff = time - packetFreq.lastAccess();
         if (tDiff >= winDur && tDiff < totalDur) {
-            // There will be some shift, so check if to relax, only if there could be some congestion. 
-            float firstBucketScore = packetFreq.bucketScore(0);
+            // Cache bucket scores to avoid repeated bucketScore() calls.
+            final float[] bucketScores = new float[winNum];
+            for (int i = 0; i < winNum; i++) {
+                bucketScores[i] = packetFreq.bucketScore(i);
+            }
+            // There will be some shift, so check if to relax, only if there could be some congestion.
+            float firstBucketScore = bucketScores[0];
             if (firstBucketScore > maxPackets) { // Clarify ideal versus maximum packet counts.
                 // Keep in mind potential burst-to-burst exploits.
                 firstBucketScore -= maxPackets; // Count this down.
                 for (int i = 1; i < winNum; i++) {
-                    final float currentBucketScore = packetFreq.bucketScore(i);
+                    final float currentBucketScore = bucketScores[i];
                     if (currentBucketScore < maxPackets) {
                         // Smoothen, using following empty spots including one occupied spot at most..
                         float consume = Math.min(firstBucketScore, maxPackets - currentBucketScore);


### PR DESCRIPTION
## Summary
- cache packet frequency bucket scores before adjusting for burst conditions

## Testing
- `mvn -P checks clean verify` *(fails: There are test failures)*

------
https://chatgpt.com/codex/tasks/task_b_685f470e537c83299c5e319ab40312f6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Optimize the packet score lookup by caching the bucket scores to reduce repeated calls to the `bucketScore()` method within the `morePacketsCheck()` function.

### Why are these changes being made?

The optimization reduces the computational overhead of repeatedly accessing bucket scores, which are now cached in an array, leading to improved performance in processing packet frequencies. This change enhances efficiency by minimizing redundant method calls and potentially increases the responsiveness of the system when managing packet congestion.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->