### PR TITLE
Refactor morePacketsCheck logic

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -107,97 +107,102 @@ public class NetStatic {
      * @param tags List to add tags to, for which parts of this check triggered a violation.
      * @return The violation amount, i.e. "count above limit", 0.0 if no violation.
      */
-    public static double morePacketsCheck(final ActionFrequency packetFreq, final long time, final float packets, final float maxPackets, final float idealPackets, final ActionFrequency burstFreq, final float burstPackets, final double burstDirect, final double burstEPM, final List<String> tags) {
+    public static double morePacketsCheck(final ActionFrequency packetFreq, final long time, final float packets,
+            final float maxPackets, final float idealPackets, final ActionFrequency burstFreq, final float burstPackets,
+            final double burstDirect, final double burstEPM, final List<String> tags) {
         // Note: this logic could be refactored into a dedicated PacketFrequency class.
-        // Pull down stuff.
         final long winDur = packetFreq.bucketDuration();
         final int winNum = packetFreq.numberOfBuckets();
         final long totalDur = winDur * winNum;
 
-        // "Relax" bursts from i = 1 on, i.e. distribute to following intervals (if zero ~ ?or lower).
-        // Consider making this smoothing step configurable and refining the implementation.
-        final long tDiff = time - packetFreq.lastAccess();
-        if (tDiff >= winDur && tDiff < totalDur) {
-            // Cache bucket scores to avoid repeated bucketScore() calls.
-            final float[] originalBucketScores = snapshotBucketScores(packetFreq);
-            // There will be some shift, so check if to relax, only if there could be some congestion.
-            float firstBucketScore = originalBucketScores[0];
-            if (firstBucketScore > maxPackets) { // Clarify ideal versus maximum packet counts.
-                // Keep in mind potential burst-to-burst exploits.
-                firstBucketScore -= maxPackets; // Count this down.
-                for (int i = 1; i < winNum; i++) {
-                    final float currentBucketScore = originalBucketScores[i];
-                    if (currentBucketScore < maxPackets) {
-                        // Smoothen, using following empty spots including one occupied spot at most..
-                        float consume = Math.min(firstBucketScore, maxPackets - currentBucketScore);
-                        firstBucketScore -= consume;
-                        packetFreq.setBucket(i, currentBucketScore + consume);
-                        if (currentBucketScore > 0f) {
-                            // Only allow relaxing "into" the next occupied spot.
-                            break;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                // Finally adjust the first bucket score.
-                packetFreq.setBucket(0, maxPackets + firstBucketScore);
-            }
-        }
+        relaxBurstBuckets(packetFreq, time, maxPackets, winDur, winNum, totalDur);
 
-        // Add packet to frequency count.
         packetFreq.add(time, packets);
 
-        // Fill up all "used" time windows (minimum we can do without other events).
         final float burnScore = (float) idealPackets * (float) winDur / 1000f;
         final BurnInfo burnInfo = computeBurnInfo(packetFreq);
         final int burnStart = burnInfo.burnStart;
-        int empty = burnInfo.empty;
+        int empty = adjustEmptyForLag(burnInfo.empty, totalDur, winNum);
 
-        // Future: burn time windows based on other activity counting, such as matching ActinFrequency with keep-alive packets.
+        final double fullCount = computeFullCount(packetFreq, burnScore, burnStart, empty, winNum);
 
-        // Adjust empty based on server side lag, this makes the check more strict.
+        return computeViolations(packetFreq, burstFreq, burstPackets, burstDirect, burstEPM, time, fullCount,
+                maxPackets, winDur, winNum, tags);
+    }
+
+    private static void relaxBurstBuckets(final ActionFrequency packetFreq, final long time, final float maxPackets,
+            final long winDur, final int winNum, final long totalDur) {
+        final long tDiff = time - packetFreq.lastAccess();
+        if (tDiff < winDur || tDiff >= totalDur) {
+            return;
+        }
+
+        final float[] originalBucketScores = snapshotBucketScores(packetFreq);
+        float firstBucketScore = originalBucketScores[0];
+        if (firstBucketScore <= maxPackets) {
+            return;
+        }
+
+        firstBucketScore -= maxPackets;
+        for (int i = 1; i < winNum; i++) {
+            final float currentBucketScore = originalBucketScores[i];
+            if (currentBucketScore >= maxPackets) {
+                break;
+            }
+            final float consume = Math.min(firstBucketScore, maxPackets - currentBucketScore);
+            firstBucketScore -= consume;
+            packetFreq.setBucket(i, currentBucketScore + consume);
+            if (currentBucketScore > 0f) {
+                break;
+            }
+        }
+        packetFreq.setBucket(0, maxPackets + firstBucketScore);
+    }
+
+    private static int adjustEmptyForLag(int empty, final long totalDur, final int winNum) {
         if (empty > 0) {
-            // Consider adding a configuration flag to skip lag adaption when running in strict mode.
-            final float lag = TickTask.getLag(totalDur, true); // Full seconds range considered.
-            // Also consider increasing the allowed maximum for extreme server-side lag conditions.
-            int lagEmpty = (int) Math.round((lag - 1f) * winNum);
+            final float lag = TickTask.getLag(totalDur, true);
+            final int lagEmpty = (int) Math.round((lag - 1f) * winNum);
             empty = lagEmpty > 0 ? Math.min(empty, lagEmpty) : empty;
             empty = Math.max(0, empty);
         }
+        return empty;
+    }
 
-        final double fullCount;
+    private static double computeFullCount(final ActionFrequency packetFreq, final float burnScore, final int burnStart,
+            final int empty, final int winNum) {
         if (burnStart < winNum) {
-            // Assume all following time windows are burnt.
-            // Revisit trailing score calculation to properly account for empty buckets.
-            final float trailing = Math.max(packetFreq.trailingScore(burnStart, 1f), burnScore * (winNum - burnStart - empty));
+            final float trailing = Math.max(packetFreq.trailingScore(burnStart, 1f),
+                    burnScore * (winNum - burnStart - empty));
             final float leading = packetFreq.leadingScore(burnStart, 1f);
-            fullCount = leading + trailing;
-        } else {
-            // All time windows are used.
-            fullCount = packetFreq.score(1f);
+            return leading + trailing;
         }
+        return packetFreq.score(1f);
+    }
 
-        double violation = 0.0; // Classic processing.
+    private static double computeViolations(final ActionFrequency packetFreq, final ActionFrequency burstFreq,
+            final float burstPackets, final double burstDirect, final double burstEPM, final long time,
+            final double fullCount, final float maxPackets, final long winDur, final int winNum,
+            final List<String> tags) {
+        double violation = 0.0;
         final double vEPSAcc = (double) fullCount - (double) (maxPackets * winNum * winDur / 1000f);
         if (vEPSAcc > 0.0) {
             violation = Math.max(violation, vEPSAcc);
             tags.add("epsacc");
         }
 
-        float burst = packetFreq.bucketScore(0); // 500ms
+        float burst = packetFreq.bucketScore(0);
         if (burst > burstPackets) {
-            // Account for server-side lag "minimally".
-            burst /= TickTask.getLag(winDur, true); // First window lag.
+            burst /= TickTask.getLag(winDur, true);
             if (burst > burstPackets) {
                 final double vBurstDirect = burst - burstDirect;
                 if (vBurstDirect > 0.0) {
                     violation = Math.max(violation, vBurstDirect);
                     tags.add("burstdirect");
                 }
-                // Investigate lag adaption for burstFreq with differing window durations.
-                burstFreq.add(time, 1f); // Packet counts are float but only whole packets are expected.
-                final double vBurstEPM = (double) burstFreq.score(0f) - burstEPM * (double) (burstFreq.bucketDuration() * burstFreq.numberOfBuckets()) / 60000.0;
+                burstFreq.add(time, 1f);
+                final double vBurstEPM = (double) burstFreq.score(0f)
+                        - burstEPM * (double) (burstFreq.bucketDuration() * burstFreq.numberOfBuckets()) / 60000.0;
                 if (vBurstEPM > 0.0) {
                     violation = Math.max(violation, vBurstEPM);
                     tags.add("burstepm");


### PR DESCRIPTION
## Summary
- simplify `NetStatic.morePacketsCheck` by extracting helper methods
- add helpers `relaxBurstBuckets`, `adjustEmptyForLag`, `computeFullCount` and `computeViolations`

## Testing
- `mvn -q -DskipTests=false test` *(fails: Cannot invoke "java.lang.Boolean.booleanValue()"...)*
- `mvn -DskipTests=true checkstyle:check`
- `mvn -DskipTests=true pmd:check`
- `mvn -DskipTests=true spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685f65b0ba908329ae94c350fe954f27

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the `morePacketsCheck` method by extracting its internal logic into separate helper methods for better readability and maintainability.

### Why are these changes being made?
The current implementation of the `morePacketsCheck` method is monolithic and hard to read, which makes maintenance and future updates difficult. By breaking down the logic into smaller helper methods like `relaxBurstBuckets`, `adjustEmptyForLag`, `computeFullCount`, and `computeViolations`, the code is more organized and easier to understand, thus facilitating future development and debugging efforts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->