### PR TITLE
Ensure chat captcha obeys world data

### DIFF
--- a/NCPCore/pom.xml
+++ b/NCPCore/pom.xml
@@ -38,8 +38,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
@@ -80,6 +92,14 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Captcha.java
@@ -26,8 +26,12 @@ import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 
 /**
  * NOTE: EARLY REFACTORING STATE, MOST METHODS NEED SYNC OVER DATA !
- * @author mc_dev
+ * <p>
+ * The captcha check must only operate if both the world data and the player
+ * data mark {@link CheckType#CHAT_CAPTCHA} as active.
+ * </p>
  *
+ * @author mc_dev
  */
 public class Captcha extends Check implements ICaptcha{
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
@@ -35,6 +35,7 @@ import fr.neatmonster.nocheatplus.checks.moving.util.MovingUtil;
 import fr.neatmonster.nocheatplus.command.CommandUtil;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
+import fr.neatmonster.nocheatplus.checks.chat.util.ChatCaptchaUtil;
 import fr.neatmonster.nocheatplus.components.data.ICheckData;
 import fr.neatmonster.nocheatplus.components.data.IData;
 import fr.neatmonster.nocheatplus.components.registry.factory.IFactoryOne;
@@ -282,7 +283,9 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
 
         // Reset captcha of player if needed.
         synchronized(data) {
-            captcha.resetCaptcha(player, cc, data, pData);
+            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)) {
+                captcha.resetCaptcha(player, cc, data, pData);
+            }
         }
         // Fast relog check.
         if (relog.isEnabled(player, pData) && relog.unsafeLoginCheck(player, cc, data,pData)) {
@@ -314,7 +317,7 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
          * implementation.
          */
         synchronized (data) {
-            if (captcha.isEnabled(player, pData)) {
+            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)) {
                 if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
                     // shouldCheckCaptcha: only if really enabled.
                     // Possible addition: check cc.captchaOnLogin before shouldCheckCaptcha.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Commands.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.checks.chat.util.ChatCaptchaUtil;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.ColorUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
@@ -46,39 +47,43 @@ public class Commands extends Check {
         final ChatData data = pData.getGenericInstance(ChatData.class);
 
         final boolean captchaEnabled = !cc.captchaSkipCommands
-                && pData.isCheckActive(CheckType.CHAT_CAPTCHA, player);
+                && ChatCaptchaUtil.isCaptchaEnabled(player, pData);
 
-        if (handleCaptcha(player, message, captcha, cc, data, pData, captchaEnabled)) {
-            return true;
+        boolean cancelled = handleCaptcha(player, message, captcha, cc, data, pData, captchaEnabled);
+
+        if (!cancelled) {
+            // Rest of the check is done without sync, because the data is only used by this check.
+
+            // Weight might later be read from some prefix tree (also known / unknown).
+            final float weight = 1f;
+
+            updateCommandWeights(data, cc, pData, weight, now, tick);
+
+            final float nw = data.commandsWeights.score(1f);
+            final double violation = Math.max(nw - cc.commandsLevel,
+                    data.commandsShortTermWeight - cc.commandsShortTermLevel);
+
+            cancelled = processCommandViolation(player, data, cc, captcha, captchaEnabled,
+                    violation, nw, now);
         }
 
-        // Rest of the check is done without sync, because the data is only used by this check.
+        return cancelled;
 
-        // Weight might later be read from some prefix tree (also known / unknown).
-        final float weight = 1f;
-
-        updateCommandWeights(data, cc, pData, weight, now, tick);
-
-        final float nw = data.commandsWeights.score(1f);
-        final double violation = Math.max(nw - cc.commandsLevel,
-                data.commandsShortTermWeight - cc.commandsShortTermLevel);
-
-        return processCommandViolation(player, data, cc, captcha, captchaEnabled,
-                violation, nw, now);
     }
 
     private boolean handleCaptcha(final Player player, final String message,
             final ICaptcha captcha, final ChatConfig cc, final ChatData data,
             final IPlayerData pData, final boolean captchaEnabled) {
+        boolean cancelled = false;
         if (captchaEnabled) {
             synchronized (data) {
                 if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
                     captcha.checkCaptcha(player, message, cc, data, true);
-                    return true;
+                    cancelled = true;
                 }
             }
         }
-        return false;
+        return cancelled;
     }
 
     private void updateCommandWeights(final ChatData data, final ChatConfig cc,

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ICaptcha.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ICaptcha.java
@@ -16,13 +16,18 @@ package fr.neatmonster.nocheatplus.checks.chat;
 
 import org.bukkit.entity.Player;
 
+import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 
 /**
  * Captcha related operations.<br>
  * Auxiliary interface, most methods should need sync over data, unless stated otherwise.
- * @author mc_dev
+ * <p>
+ * Implementations must only run captcha logic if both the player's world data
+ * and the player data indicate that {@link CheckType#CHAT_CAPTCHA} is active.
+ * </p>
  *
+ * @author mc_dev
  */
 public interface ICaptcha {
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/Text.java
@@ -27,6 +27,7 @@ import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.checks.chat.analysis.MessageLetterCount;
 import fr.neatmonster.nocheatplus.checks.chat.analysis.WordLetterCount;
 import fr.neatmonster.nocheatplus.checks.chat.analysis.engine.LetterEngine;
+import fr.neatmonster.nocheatplus.checks.chat.util.ChatCaptchaUtil;
 import fr.neatmonster.nocheatplus.checks.combined.CombinedData;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
 import fr.neatmonster.nocheatplus.components.registry.feature.INotifyReload;
@@ -125,98 +126,111 @@ public class Text extends Check implements INotifyReload {
             final ChatConfig cc, final ChatData data, final IPlayerData pData,
             boolean isMainThread, final boolean alreadyCancelled) {
 
-        synchronized (data) {
-            if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
-                captcha.checkCaptcha(player, message, cc, data, isMainThread);
-                return true;
+        boolean cancelled = handleCaptchaChallenge(player, message, captcha, cc, data, pData, isMainThread,
+                alreadyCancelled);
+
+        if (!cancelled) {
+            final long time = System.currentTimeMillis();
+            final String lcMessage = message.trim().toLowerCase();
+
+            final String lastMessage;
+            final long lastTime;
+            synchronized (data) {
+                data.chatFrequency.update(time);
+                lastMessage = data.chatLastMessage;
+                lastTime = data.chatLastTime;
             }
-        }
+            final String lastGlMessage;
+            final long lastGlTime;
+            final String lastCancMessage;
+            final long lastCancTime;
+            synchronized (globalLock) {
+                lastGlMessage = lastGlobalMessage;
+                lastGlTime = lastGlobalTime;
+                lastCancMessage = lastCancelledMessage;
+                lastCancTime = lastCancelledTime;
+            }
 
-        final long time = System.currentTimeMillis();
-        final String lcMessage = message.trim().toLowerCase();
+            final boolean debug = pData.isDebugActive(type);
+            final List<String> debugParts = debug ? new LinkedList<String>() : null;
+            if (debug) {
+                debugParts.add("Message (length=" + message.length() + "): ");
+            }
 
-        final String lastMessage;
-        final long lastTime;
-        synchronized (data) {
-            data.chatFrequency.update(time);
-            lastMessage = data.chatLastMessage;
-            lastTime = data.chatLastTime;
-        }
-        final String lastGlMessage;
-        final long lastGlTime;
-        final String lastCancMessage;
-        final long lastCancTime;
-        synchronized (globalLock) {
-            lastGlMessage = lastGlobalMessage;
-            lastGlTime = lastGlobalTime;
-            lastCancMessage = lastCancelledMessage;
-            lastCancTime = lastCancelledTime;
-        }
+            final ScoreResult scoreResult = calculateScore(message, lcMessage, time, cc, pData, debug,
+                    debugParts, lastMessage, lastTime, lastGlMessage, lastGlTime, lastCancMessage,
+                    lastCancTime);
+            float score = scoreResult.score;
+            final MessageLetterCount letterCounts = scoreResult.letterCounts;
 
-        final boolean debug = pData.isDebugActive(type);
-        final List<String> debugParts = debug ? new LinkedList<String>() : null;
-        if (debug) {
-            debugParts.add("Message (length=" + message.length()+"): ");
-        }
+            if (debug && score > 0f) {
+                debugParts.add("Simple score: " + StringUtil.fdec3.format(score));
+            }
 
-        final ScoreResult scoreResult = calculateScore(message, lcMessage, time, cc, pData, debug, debugParts,
-                lastMessage, lastTime, lastGlMessage, lastGlTime, lastCancMessage, lastCancTime);
-        float score = scoreResult.score;
-        final MessageLetterCount letterCounts = scoreResult.letterCounts;
+            EngineResult engineResult = invokeEngine(letterCounts, player, cc, data);
+            float wEngine = engineResult.weight;
+            final Map<String, Float> engMap = engineResult.engMap;
+            score += wEngine;
 
-        if (debug && score > 0f) {
-            debugParts.add("Simple score: " + StringUtil.fdec3.format(score));
-        }
-
-        EngineResult engineResult = invokeEngine(letterCounts, player, cc, data);
-        float wEngine = engineResult.weight;
-        final Map<String, Float> engMap = engineResult.engMap;
-        score += wEngine;
-
-        final EvalResult evalResult;
-        synchronized (data) {
-            evalResult = evaluateFrequencyAndViolations(player, captcha, cc, data, pData, lcMessage, time, score);
-            data.chatLastMessage = lcMessage;
-            data.chatLastTime = time;
-        }
-        synchronized (globalLock) {
-            lastGlobalMessage = lcMessage;
-            lastGlobalTime = time;
-        }
-        boolean cancel = evalResult.cancel;
-        float accumulated = evalResult.accumulated;
-        float shortTermAccumulated = evalResult.shortTermAccumulated;
+            final EvalResult evalResult;
+            synchronized (data) {
+                evalResult = evaluateFrequencyAndViolations(player, captcha, cc, data, pData, lcMessage, time, score);
+                data.chatLastMessage = lcMessage;
+                data.chatLastTime = time;
+            }
+            synchronized (globalLock) {
+                lastGlobalMessage = lcMessage;
+                lastGlobalTime = time;
+            }
+            boolean cancel = evalResult.cancel;
+            float accumulated = evalResult.accumulated;
+            float shortTermAccumulated = evalResult.shortTermAccumulated;
 
         if (debug) {
             final List<String> keys = new LinkedList<String>(engMap.keySet());
             Collections.sort(keys);
             for (String key : keys) {
                 Float s = engMap.get(key);
-                if (s.floatValue() > 0.0f)
+                if (s.floatValue() > 0.0f) {
                     debugParts.add(key + ":" + StringUtil.fdec3.format(s));
+                }
             }
-            if (wEngine > 0.0f)
-                debugParts.add("Engine score (" + (cc.textEngineMaximum?"max":"sum") + "): " + StringUtil.fdec3.format(wEngine));
+            if (wEngine > 0.0f) {
+                debugParts.add("Engine score (" + (cc.textEngineMaximum ? "max" : "sum") + "): "
+                        + StringUtil.fdec3.format(wEngine));
+            }
 
-            debugParts.add("Final score: " +  StringUtil.fdec3.format(score));
-            debugParts.add("Normal: min=" +  StringUtil.fdec3.format(cc.textFreqNormMin) +", weight=" +  StringUtil.fdec3.format(cc.textFreqNormWeight) + " => accumulated=" + StringUtil.fdec3.format(accumulated));
-            debugParts.add("Short-term: min=" +  StringUtil.fdec3.format(cc.textFreqShortTermMin) +", weight=" +  StringUtil.fdec3.format(cc.textFreqShortTermWeight) + " => accumulated=" + StringUtil.fdec3.format(shortTermAccumulated));
+            debugParts.add("Final score: " + StringUtil.fdec3.format(score));
+            debugParts.add(
+                    "Normal: min=" + StringUtil.fdec3.format(cc.textFreqNormMin) + ", weight="
+                            + StringUtil.fdec3.format(cc.textFreqNormWeight) + " => accumulated="
+                            + StringUtil.fdec3.format(accumulated));
+            debugParts.add(
+                    "Short-term: min=" + StringUtil.fdec3.format(cc.textFreqShortTermMin) + ", weight="
+                            + StringUtil.fdec3.format(cc.textFreqShortTermWeight) + " => accumulated="
+                            + StringUtil.fdec3.format(shortTermAccumulated));
             debugParts.add("vl: " + StringUtil.fdec3.format(data.textVL));
             debug(player, StringUtil.join(debugParts, " | "));
             debugParts.clear();
         }
 
-        return cancel;
+        cancelled = cancelled || cancel;
+        }
+        return cancelled;
     }
 
-    private boolean handleCaptcha(final Player player, final String message, final ICaptcha captcha,
+    private boolean handleCaptchaChallenge(final Player player, final String message, final ICaptcha captcha,
             final ChatConfig cc, final ChatData data, final IPlayerData pData,
-            boolean isMainThread, final boolean alreadyCancelled) {
-        if (captcha.shouldCheckCaptcha(player, cc, data, pData)) {
-            captcha.checkCaptcha(player, message, cc, data, isMainThread);
-            return true;
+            final boolean isMainThread, final boolean alreadyCancelled) {
+        boolean cancelled = alreadyCancelled;
+        synchronized (data) {
+            if (ChatCaptchaUtil.isCaptchaEnabled(player, pData)
+                    && captcha.shouldCheckCaptcha(player, cc, data, pData)) {
+                captcha.checkCaptcha(player, message, cc, data, isMainThread);
+                cancelled = true;
+            }
         }
-        return alreadyCancelled;
+        return cancelled;
     }
 
     private static final class ScoreResult {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/util/ChatCaptchaUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/util/ChatCaptchaUtil.java
@@ -1,0 +1,35 @@
+package fr.neatmonster.nocheatplus.checks.chat.util;
+
+import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.worlds.IWorldData;
+
+/**
+ * Utility methods for chat captcha related checks.
+ */
+public final class ChatCaptchaUtil {
+
+    private ChatCaptchaUtil() {}
+
+    /**
+     * Determine if chat captcha should be active for the given player.
+     * <p>
+     * Both the world data of the player's current world and the player data
+     * must indicate that {@link CheckType#CHAT_CAPTCHA} is active.
+     *
+     * @param player the player, may be {@code null}
+     * @param pData  player data, may be {@code null}
+     * @return {@code true} if captcha checks should run
+     */
+    public static boolean isCaptchaEnabled(final Player player, final IPlayerData pData) {
+        if (player == null || pData == null) {
+            return false;
+        }
+        final IWorldData worldData = pData.getCurrentWorldDataSafe();
+        return worldData != null
+                && worldData.isCheckActive(CheckType.CHAT_CAPTCHA)
+                && pData.isCheckActive(CheckType.CHAT_CAPTCHA, player, worldData);
+    }
+}

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/chat/util/ChatCaptchaUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/chat/util/ChatCaptchaUtilTest.java
@@ -1,0 +1,64 @@
+package fr.neatmonster.nocheatplus.checks.chat.util;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import fr.neatmonster.nocheatplus.checks.CheckType;
+import fr.neatmonster.nocheatplus.players.IPlayerData;
+import fr.neatmonster.nocheatplus.worlds.IWorldData;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatCaptchaUtilTest {
+
+    @Mock
+    private Player player;
+    @Mock
+    private IPlayerData playerData;
+    @Mock
+    private IWorldData worldData;
+
+    @Test
+    void returnsFalse_whenPlayerIsNull() {
+        assertFalse(ChatCaptchaUtil.isCaptchaEnabled(null, playerData));
+    }
+
+    @Test
+    void returnsFalse_whenPlayerDataIsNull() {
+        assertFalse(ChatCaptchaUtil.isCaptchaEnabled(player, null));
+    }
+
+    @Test
+    void returnsFalse_whenWorldDataIsNull() {
+        when(playerData.getCurrentWorldDataSafe()).thenReturn(null);
+        assertFalse(ChatCaptchaUtil.isCaptchaEnabled(player, playerData));
+    }
+
+    @Test
+    void returnsFalse_whenWorldDisablesCaptcha() {
+        when(playerData.getCurrentWorldDataSafe()).thenReturn(worldData);
+        when(worldData.isCheckActive(CheckType.CHAT_CAPTCHA)).thenReturn(false);
+        assertFalse(ChatCaptchaUtil.isCaptchaEnabled(player, playerData));
+    }
+
+    @Test
+    void returnsFalse_whenPlayerDisablesCaptcha() {
+        when(playerData.getCurrentWorldDataSafe()).thenReturn(worldData);
+        when(worldData.isCheckActive(CheckType.CHAT_CAPTCHA)).thenReturn(true);
+        when(playerData.isCheckActive(CheckType.CHAT_CAPTCHA, player, worldData)).thenReturn(false);
+        assertFalse(ChatCaptchaUtil.isCaptchaEnabled(player, playerData));
+    }
+
+    @Test
+    void returnsTrue_whenBothEnableCaptcha() {
+        when(playerData.getCurrentWorldDataSafe()).thenReturn(worldData);
+        when(worldData.isCheckActive(CheckType.CHAT_CAPTCHA)).thenReturn(true);
+        when(playerData.isCheckActive(CheckType.CHAT_CAPTCHA, player, worldData)).thenReturn(true);
+        assertTrue(ChatCaptchaUtil.isCaptchaEnabled(player, playerData));
+    }
+}


### PR DESCRIPTION
## Summary
- check player's world data before enforcing chat captcha
- use `ChatCaptchaUtil.isCaptchaEnabled` in chat checks and listeners
- avoid early returns and add `handleCaptchaChallenge` helper
- add JUnit 5 tests for `ChatCaptchaUtil`

## Testing
- `mvn -q -DskipTests=false verify`
- `mvn -q checkstyle:check pmd:check spotbugs:check` *(medium severity issues flagged)*

------
https://chatgpt.com/codex/tasks/task_b_685f48b5760c8329a2281d0e72fa32f6

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Integrate world data checks into the chat captcha mechanism to ensure that captcha activities are only performed when both the world data and player data have chat captcha checks enabled; add necessary dependencies and utilities to improve chat captcha functionality.

### Why are these changes being made?

The previous chat captcha implementation lacked coordination with world data, which could lead to unintentional execution of captcha processes in worlds where it should be inactive. By introducing a utility class `ChatCaptchaUtil` and related test `ChatCaptchaUtilTest`, we now ensure that captchas are informed by world-specific configurations, enhancing user experience by preventing unnecessary captchas. Moreover, the addition of dependencies such as `junit-jupiter` enhances testing capabilities, ensuring reliability and correctness of the code changes.


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->