### PR TITLE
Fix empty window lag scaling

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -159,12 +159,25 @@ public class NetStatic {
         packetFreq.setBucket(0, maxPackets + firstBucketScore);
     }
 
+    /**
+     * Adjust the number of empty windows for server lag in a conservative way.
+     * <p>
+     * Negative values are ignored to avoid increasing the violation score when
+     * lag measurements would otherwise suggest shrinking the window. This keeps
+     * the check strict under normal conditions while still allowing extra room
+     * when the server is actually lagging behind.
+     * <p>
+     * The scaling is applied only if the measured lag is at least {@code 1.0f}
+     * to avoid unintended leniency during optimal tick conditions.
+     */
     private static int adjustEmptyForLag(int empty, final long totalDur, final int winNum) {
-        if (empty > 0) {
-            final float lag = TickTask.getLag(totalDur, true);
-            final int lagEmpty = (int) Math.round((lag - 1f) * winNum);
-            empty = lagEmpty > 0 ? Math.min(empty, lagEmpty) : empty;
-            empty = Math.max(0, empty);
+        if (empty <= 0) {
+            return 0;
+        }
+        final float lag = TickTask.getLag(totalDur, true);
+        if (lag >= 1.0f) {
+            empty = (int) Math.round(empty * (1f / lag));
+            empty = Math.max(0, Math.min(winNum, empty));
         }
         return empty;
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
@@ -6,8 +6,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import static org.mockito.Mockito.*;
 
 import fr.neatmonster.nocheatplus.utilities.ds.count.ActionFrequency;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
 
 public class TestMorePacketsCheck {
 
@@ -40,5 +43,49 @@ public class TestMorePacketsCheck {
         NetStatic.BurnInfo info = NetStatic.computeBurnInfo(freq);
         assertEquals(3, info.burnStart);
         assertEquals(1, info.empty);
+    }
+
+    @Test
+    public void testLagBelowOne_NoAdjustmentOccurs() throws Exception {
+        try (MockedStatic<TickTask> tick = mockStatic(TickTask.class)) {
+            tick.when(() -> TickTask.getLag(anyLong(), eq(true))).thenReturn(0.75f);
+            final var method = NetStatic.class.getDeclaredMethod("adjustEmptyForLag", int.class, long.class, int.class);
+            method.setAccessible(true);
+            int adjusted = (Integer) method.invoke(null, 3, 5000L, 5);
+            assertEquals("Lag < 1.0 should result in no scaling", 3, adjusted);
+        }
+    }
+
+    @Test
+    public void testLagExactlyOne_NoAdjustmentOccurs() throws Exception {
+        try (MockedStatic<TickTask> tick = mockStatic(TickTask.class)) {
+            tick.when(() -> TickTask.getLag(anyLong(), eq(true))).thenReturn(1.0f);
+            final var method = NetStatic.class.getDeclaredMethod("adjustEmptyForLag", int.class, long.class, int.class);
+            method.setAccessible(true);
+            int adjusted = (Integer) method.invoke(null, 4, 5000L, 5);
+            assertEquals("Lag == 1.0 should result in no scaling", 4, adjusted);
+        }
+    }
+
+    @Test
+    public void testLagAboveOne_AdjustmentOccursAndClamped() throws Exception {
+        try (MockedStatic<TickTask> tick = mockStatic(TickTask.class)) {
+            tick.when(() -> TickTask.getLag(anyLong(), eq(true))).thenReturn(2.0f);
+            final var method = NetStatic.class.getDeclaredMethod("adjustEmptyForLag", int.class, long.class, int.class);
+            method.setAccessible(true);
+            int adjusted = (Integer) method.invoke(null, 4, 5000L, 5);
+            assertEquals("Lag = 2.0 should scale down empty to 2", 2, adjusted);
+        }
+    }
+
+    @Test
+    public void testLagHigh_ClampingToZero() throws Exception {
+        try (MockedStatic<TickTask> tick = mockStatic(TickTask.class)) {
+            tick.when(() -> TickTask.getLag(anyLong(), eq(true))).thenReturn(100f);
+            final var method = NetStatic.class.getDeclaredMethod("adjustEmptyForLag", int.class, long.class, int.class);
+            method.setAccessible(true);
+            int adjusted = (Integer) method.invoke(null, 3, 5000L, 5);
+            assertEquals("Extreme lag should not reduce below 0", 0, adjusted);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- adjust `empty` lag scaling to apply only when `lag >= 1.0`
- document rationale for conservative adjustment
- expand unit tests for various lag scenarios

## Testing
- `mvn -q test`
- `mvn -q checkstyle:check pmd:check spotbugs:check -DskipTests`


------
https://chatgpt.com/codex/tasks/task_b_685f6b01955483298f07518200a29377

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the `adjustEmptyForLag` method in `NetStatic.java` to conservatively adjust the number of empty windows based on server lag, and add new unit tests in `TestMorePacketsCheck.java` to verify the functionality of this adjustment.

### Why are these changes being made?

The changes are implemented to prevent negative adjustments, which can falsely increase violation scores when the server is lagging, and to clamp adjustments to prevent unintended leniency; new tests ensure that lag scaling logic is correctly applied, maintaining strict checks while accommodating server lag.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->