### PR TITLE
Fix lag adjustment clamping

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -159,12 +159,28 @@ public class NetStatic {
         packetFreq.setBucket(0, maxPackets + firstBucketScore);
     }
 
+    /**
+     * Adjust empty window count for server lag.
+     * <p>
+     * Values below zero are ignored to avoid artificially reducing tolerance
+     * when the server is running faster than usual. The returned value is
+     * clamped to the range {@code [0, winNum]}.
+     *
+     * TODO: Make lag scaling behavior configurable.
+     */
     private static int adjustEmptyForLag(int empty, final long totalDur, final int winNum) {
         if (empty > 0) {
             final float lag = TickTask.getLag(totalDur, true);
             final int lagEmpty = (int) Math.round((lag - 1f) * winNum);
-            empty = lagEmpty > 0 ? Math.min(empty, lagEmpty) : empty;
-            empty = Math.max(0, empty);
+            if (lagEmpty > 0) {
+                empty = Math.min(empty, lagEmpty);
+            }
+        }
+        if (empty < 0) {
+            empty = 0;
+        }
+        if (empty > winNum) {
+            empty = winNum;
         }
         return empty;
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/net/TestMorePacketsCheck.java
@@ -7,7 +7,13 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import org.mockito.MockedStatic;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+
 import fr.neatmonster.nocheatplus.utilities.ds.count.ActionFrequency;
+import fr.neatmonster.nocheatplus.utilities.TickTask;
 
 public class TestMorePacketsCheck {
 
@@ -40,5 +46,20 @@ public class TestMorePacketsCheck {
         NetStatic.BurnInfo info = NetStatic.computeBurnInfo(freq);
         assertEquals(3, info.burnStart);
         assertEquals(1, info.empty);
+    }
+
+    @Test
+    public void testLagBelowOneDoesNotDecreaseWindowCount() {
+        ActionFrequency freq = new ActionFrequency(5, 1000);
+        freq.setBucket(1, 1f);
+        freq.setBucket(3, 1f);
+        ActionFrequency burst = new ActionFrequency(12, 5000);
+        List<String> tags = new ArrayList<String>();
+        double expect = NetStatic.morePacketsCheck(freq, 0L, 0f, 2f, 2f, burst, 10f, 100.0, 1000.0, new ArrayList<String>());
+        try (MockedStatic<TickTask> tt = mockStatic(TickTask.class)) {
+            tt.when(() -> TickTask.getLag(anyLong(), eq(true))).thenReturn(0.5f);
+            double result = NetStatic.morePacketsCheck(freq, 0L, 0f, 2f, 2f, burst, 10f, 100.0, 1000.0, tags);
+            assertEquals(expect, result, 0.0001, "Lag below one should not reduce empty count");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- clamp empty count to `[0, winNum]`
- explain why negative values are ignored in JavaDoc
- add regression test for lag below 1.0

## Testing
- `mvn --no-transfer-progress -DskipITs -DtrimStackTrace=false -Dcheckstyle.failOnViolation=false -Dpmd.failOnViolation=false -Dspotbugs.failOnError=false test | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_b_685fc108b9a483298a67f9c329f4c5b5