### PR TITLE
Refactor getActionLegacy

### DIFF
--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/UseEntityAdapter.java
@@ -164,7 +164,7 @@ public class UseEntityAdapter extends BaseAdapter {
         boolean attack = false;
         boolean interpreted = false;
         if (legacySet != null) {
-            final int flags = getAction_legacy(packet);
+            final int flags = getActionLegacy(packet);
             if ((flags & INTERPRETED) != 0) {
                 interpreted = true;
                 if ((flags & ATTACK) != 0) {
@@ -211,7 +211,7 @@ public class UseEntityAdapter extends BaseAdapter {
         }
     }
 
-    private int getAction_legacy(final PacketContainer packetContainer) {
+    private int getActionLegacy(final PacketContainer packetContainer) {
         // (For some reason the object didn't appear work with equality checks, thus compare the short string.)
         final String actionName = legacySet.getActionFromNMSPacket(packetContainer.getHandle());
         return actionName == null ? 0 : (INTERPRETED | ("ATTACK".equals(actionName) ? ATTACK : 0));


### PR DESCRIPTION
## Summary
- rename method `getAction_legacy` to `getActionLegacy`
- update invocation to use camelCase

## Testing
- `mvn -q -DskipTests=false test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_685fceba1ad88329a3c82c9d264f6bb1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor the method name `getAction_legacy` to `getActionLegacy` in the `UseEntityAdapter.java` file.

### Why are these changes being made?
The method name refactoring improves code readability and consistency with standard camelCase naming conventions, enhancing overall code maintainability. This change does not affect the logic or functionality of the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->