### PR TITLE
Refactor equality check for BlockCacheNode

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockCache.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockCache.java
@@ -168,6 +168,20 @@ public abstract class BlockCache {
             fetched |= FETCHED_BOUNDS;
         }
 
+        private boolean hasSameData(IBlockCacheNode other) {
+            if (!isDataFetched() || !other.isDataFetched()) {
+                return !isDataFetched() && !other.isDataFetched();
+            }
+            return data == other.getData();
+        }
+
+        private boolean hasSameBounds(IBlockCacheNode other) {
+            if (!isBoundsFetched() || !other.isBoundsFetched()) {
+                return !isBoundsFetched() && !other.isBoundsFetched();
+            }
+            return BlockProperties.isSameShape(bounds, other.getBounds());
+        }
+
         @Override
         public int hashCode() {
             return 42;
@@ -180,13 +194,9 @@ public abstract class BlockCache {
             }
             if (obj instanceof IBlockCacheNode) {
                 final IBlockCacheNode other = (IBlockCacheNode) obj;
-                return id == other.getType() 
-                        && (!isDataFetched() && !other.isDataFetched() 
-                                || isDataFetched() && other.isDataFetched() && data == other.getData())
-                        && (!isBoundsFetched() && !other.isBoundsFetched()
-                                || isBoundsFetched() && other.isBoundsFetched() 
-                                && BlockProperties.isSameShape(bounds, other.getBounds())
-                                );
+                return id == other.getType()
+                        && hasSameData(other)
+                        && hasSameBounds(other);
             }
             return false;
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockCache.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockCache.java
@@ -169,10 +169,15 @@ public abstract class BlockCache {
         }
 
         private boolean hasSameData(IBlockCacheNode other) {
-            if (!isDataFetched() || !other.isDataFetched()) {
-                return !isDataFetched() && !other.isDataFetched();
+            final boolean thisDataFetched = isDataFetched();
+            final boolean otherDataFetched = other.isDataFetched();
+
+            // Either both have fetched data or neither does.
+            if (thisDataFetched != otherDataFetched) {
+                return false;
             }
-            return data == other.getData();
+
+            return !thisDataFetched || data == other.getData();
         }
 
         private boolean hasSameBounds(IBlockCacheNode other) {


### PR DESCRIPTION
## Summary
- simplify `BlockCacheNode.equals` by extracting helper methods
- add `hasSameData` and `hasSameBounds` helpers

## Testing
- `mvn -B verify`

------
https://chatgpt.com/codex/tasks/task_b_685fceb612048329a01d68570ca01801

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the equality check for `BlockCacheNode` by introducing helper methods `hasSameData` and `hasSameBounds` to simplify the `equals` method.

### Why are these changes being made?

The refactoring improves the readability and maintainability of the `equals` method by abstracting repetitive conditional checks into dedicated helper methods. This approach encapsulates the logic for data and bounds comparison, reducing code duplication and making the logic clearer.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->