### PR TITLE
Add chunk load cooldown cache

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
@@ -1375,6 +1375,12 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
      * @return Number of chunks loaded.
      */
     public int ensureChunksLoaded(final double xzMargin) {
+        if (world == null) {
+            return 0;
+        }
+        if (!MapUtil.shouldLoadChunks(world, x, z, xzMargin)) {
+            return 0;
+        }
         return MapUtil.ensureChunksLoaded(world, x, z, xzMargin);
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MapUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MapUtil.java
@@ -14,6 +14,11 @@
  */
 package fr.neatmonster.nocheatplus.utilities.map;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
@@ -29,6 +34,52 @@ import fr.neatmonster.nocheatplus.utilities.StringUtil;
  *
  */
 public class MapUtil {
+
+    /** Default cooldown in milliseconds between chunk load attempts. */
+    private static final long CHUNK_LOAD_COOLDOWN_MS = TimeUnit.SECONDS.toMillis(2);
+
+    /**
+     * Track the last attempted chunk load per world.
+     * Map key is the world UUID, value maps chunk key to last attempt time.
+     */
+    private static final Map<UUID, Map<Long, Long>> CHUNK_LOAD_CACHE = new ConcurrentHashMap<>();
+
+    /** Generate a unique key for chunk coordinates. */
+    private static long chunkKey(final int cx, final int cz) {
+        return (((long) cx) << 32) ^ (cz & 0xffffffffL);
+    }
+
+    /**
+     * Determine whether a chunk is currently on cooldown for loading.
+     *
+     * @param world the world
+     * @param cx chunk x coordinate
+     * @param cz chunk z coordinate
+     * @param now the current timestamp
+     * @return true if a new load should be skipped
+     */
+    private static boolean isOnCooldown(final World world, final int cx, final int cz, final long now) {
+        final Map<Long, Long> worldCache = CHUNK_LOAD_CACHE.get(world.getUID());
+        if (worldCache == null) {
+            return false;
+        }
+        final Long last = worldCache.get(chunkKey(cx, cz));
+        return last != null && now - last < CHUNK_LOAD_COOLDOWN_MS;
+    }
+
+    /**
+     * Mark a chunk as attempted to load.
+     *
+     * @param world the world
+     * @param cx chunk x coordinate
+     * @param cz chunk z coordinate
+     * @param now the current timestamp
+     */
+    private static void markLoadAttempt(final World world, final int cx, final int cz, final long now) {
+        CHUNK_LOAD_CACHE
+            .computeIfAbsent(world.getUID(), k -> new ConcurrentHashMap<>())
+            .put(chunkKey(cx, cz), now);
+    }
 
     /**
      * Find the appropriate BlockFace.
@@ -64,6 +115,41 @@ public class MapUtil {
     }
 
     /**
+     * Check if at least one chunk within the coordinates should be attempted to
+     * load. This consults an internal cooldown cache.
+     *
+     * @param world the world
+     * @param x the x coordinate
+     * @param z the z coordinate
+     * @param xzMargin search radius
+     * @return {@code true} if any chunk should be loaded
+     */
+    public static boolean shouldLoadChunks(final World world, final double x, final double z,
+            final double xzMargin) {
+        if (world == null) return false;
+        final int minX = Location.locToBlock(x - xzMargin) / 16;
+        final int maxX = Location.locToBlock(x + xzMargin) / 16;
+        final int minZ = Location.locToBlock(z - xzMargin) / 16;
+        final int maxZ = Location.locToBlock(z + xzMargin) / 16;
+        final long now = System.currentTimeMillis();
+        final Map<Long, Long> worldCache = CHUNK_LOAD_CACHE.get(world.getUID());
+        for (int cx = minX; cx <= maxX; cx++) {
+            for (int cz = minZ; cz <= maxZ; cz++) {
+                if (!world.isChunkLoaded(cx, cz)) {
+                    if (worldCache == null) {
+                        return true;
+                    }
+                    final Long last = worldCache.get(chunkKey(cx, cz));
+                    if (last == null || now - last >= CHUNK_LOAD_COOLDOWN_MS) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Check if chunks are loaded and load all not yet loaded chunks, using
      * normal world coordinates.<br>
      * NOTE: Not sure where to put this. Method does not use any caching.
@@ -84,15 +170,22 @@ public class MapUtil {
         final int maxX = Location.locToBlock(x + xzMargin) / 16;
         final int minZ = Location.locToBlock(z - xzMargin) / 16;
         final int maxZ = Location.locToBlock(z + xzMargin) / 16;
-        for (int cx = minX; cx <= maxX; cx ++) {
-            for (int cz = minZ; cz <= maxZ; cz ++) {
+        final long now = System.currentTimeMillis();
+        for (int cx = minX; cx <= maxX; cx++) {
+            for (int cz = minZ; cz <= maxZ; cz++) {
                 if (!world.isChunkLoaded(cx, cz)) {
+                    if (isOnCooldown(world, cx, cz, now)) {
+                        continue;
+                    }
+                    markLoadAttempt(world, cx, cz, now);
                     try {
                         world.getChunkAt(cx, cz);
-                        loaded ++;
+                        loaded++;
                     } catch (Exception ex) {
                         // (Can't seem to catch more precisely: TileEntity with CB 1.7.10)
-                        NCPAPIProvider.getNoCheatPlusAPI().getLogManager().severe(Streams.STATUS, "Failed to load chunk at " + (cx * 16) + "," + (cz * 16) + " (real coordinates):\n" + StringUtil.throwableToString(ex));
+                        NCPAPIProvider.getNoCheatPlusAPI().getLogManager().severe(Streams.STATUS,
+                                "Failed to load chunk at " + (cx * 16) + "," + (cz * 16)
+                                        + " (real coordinates):\n" + StringUtil.throwableToString(ex));
                         // (Don't count as loaded.)
                     }
                 }


### PR DESCRIPTION
## Summary
- cache recently loaded chunks in `MapUtil` with a short cooldown
- add `MapUtil.shouldLoadChunks` to check the cooldown
- consult the cache from `RichBoundsLocation.ensureChunksLoaded`

## Testing
- `mvn -DskipTests=false test`
- `mvn checkstyle:check`
- `mvn pmd:check`
- `mvn spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685fcea5bc0083298b93f1a0cd230f4d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Implement a chunk load cooldown cache mechanism to prevent frequent unnecessary attempts to load the same chunk within a short span of time.

### Why are these changes being made?
This change is made to optimize chunk loading processes by introducing a cooldown period of 2 seconds between consecutive load attempts for the same chunk. This avoids redundant loading operations which can improve performance and reduce resource usage in the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->