### PR TITLE
Replace manual server with MockBukkit

### DIFF
--- a/NCPPlugin/pom.xml
+++ b/NCPPlugin/pom.xml
@@ -57,6 +57,18 @@
             <version>4.57.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.10</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.14.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build Description Profiles -->

--- a/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
+++ b/NCPPlugin/src/test/java/fr/neatmonster/nocheatplus/TestPluginLifecycle.java
@@ -1,44 +1,38 @@
 package fr.neatmonster.nocheatplus;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
 import fr.neatmonster.nocheatplus.components.registry.feature.IDisableListener;
-import org.bukkit.Server;
-import org.bukkit.event.Listener;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import fr.neatmonster.nocheatplus.logging.BukkitLogManager;
-import org.bukkit.scheduler.BukkitScheduler;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.Listener;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.dynamic.loading.ClassReloadingStrategy;
+import net.bytebuddy.implementation.MethodCall;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPluginLifecycle {
 
     private NoCheatPlus plugin;
-    private Server server;
 
     @BeforeEach
     public void setup() throws Exception {
         PluginTests.setUnitTestNoCheatPlusAPI(true);
-        server = createServer();
-        JavaPluginLoader loader = new JavaPluginLoader(server);
-        if (org.bukkit.Bukkit.getServer() == null) org.bukkit.Bukkit.setServer(server);
-        PluginDescriptionFile desc = new PluginDescriptionFile("Test", "1", "test.Main");
-        java.lang.reflect.Constructor<NoCheatPlus> ctor = NoCheatPlus.class.getDeclaredConstructor(JavaPluginLoader.class, PluginDescriptionFile.class, File.class, File.class);
-        ctor.setAccessible(true);
-        plugin = ctor.newInstance(loader, desc, new File("dummy"), new File("dummy"));
+        installTestPatches();
+        MockBukkit.mock();
+        plugin = MockBukkit.load(NoCheatPlus.class);
         DummyLogManager log = new DummyLogManager(plugin);
         java.lang.reflect.Field fLog = NoCheatPlus.class.getDeclaredField("logManager");
         fLog.setAccessible(true);
@@ -47,6 +41,7 @@ public class TestPluginLifecycle {
 
     @AfterEach
     public void teardown() {
+        MockBukkit.unmock();
     }
 @Test
 
@@ -108,40 +103,52 @@ public class TestPluginLifecycle {
         @Override public void shutdown() {}
     }
 
+    private static void installTestPatches() {
+        ByteBuddyAgent.install();
+        new net.bytebuddy.agent.builder.AgentBuilder.Default()
+                .type(net.bytebuddy.matcher.ElementMatchers.named("org.bukkit.NamespacedKey"))
+                .transform((builder, td, cl, module, pd) -> {
+                    if (td.getDeclaredMethods()
+                            .filter(net.bytebuddy.matcher.ElementMatchers.named("value")).isEmpty()) {
+                        return builder.defineMethod("value", String.class, Modifier.PUBLIC)
+                                .intercept(MethodCall.invoke(td.getDeclaredMethods()
+                                        .filter(net.bytebuddy.matcher.ElementMatchers.named("toString")).getOnly()));
+                    }
+                    return builder;
+                })
+                .installOnByteBuddyAgent();
 
-    private static Server createServer() {
-        PluginManager pluginManager = (PluginManager) Proxy.newProxyInstance(
-                TestPluginLifecycle.class.getClassLoader(), new Class[]{PluginManager.class}, defaultHandler());
-        BukkitScheduler scheduler = (BukkitScheduler) Proxy.newProxyInstance(
-                TestPluginLifecycle.class.getClassLoader(), new Class[]{BukkitScheduler.class}, defaultHandler());
-        InvocationHandler serverHandler = (proxy, method, args) -> {
-            switch (method.getName()) {
-                case "getPluginManager": return pluginManager;
-                case "getScheduler": return scheduler;
-                case "getLogger": return Logger.getLogger("TestServer");
-                case "getName": return "Dummy";
-                case "getVersion": return "0";
-                case "getBukkitVersion": return "0";
-                default: return defaultValue(method.getReturnType());
+        new net.bytebuddy.agent.builder.AgentBuilder.Default()
+                .type(net.bytebuddy.matcher.ElementMatchers.named("org.mockbukkit.mockbukkit.tags.TagsMock"))
+                .transform((builder, td, cl, module, pd) ->
+                        builder.method(net.bytebuddy.matcher.ElementMatchers.named("loadDefaultTags"))
+                                .intercept(net.bytebuddy.implementation.StubMethod.INSTANCE))
+                .installOnByteBuddyAgent();
+
+        new net.bytebuddy.agent.builder.AgentBuilder.Default()
+                .type(net.bytebuddy.matcher.ElementMatchers.named("org.mockbukkit.mockbukkit.tags.internal.InternalTag"))
+                .transform((builder, td, cl, module, pd) ->
+                        builder.method(net.bytebuddy.matcher.ElementMatchers.named("loadInternalTags"))
+                                .intercept(net.bytebuddy.implementation.StubMethod.INSTANCE))
+                .installOnByteBuddyAgent();
+
+        new net.bytebuddy.agent.builder.AgentBuilder.Default()
+                .type(net.bytebuddy.matcher.ElementMatchers.named("org.bukkit.plugin.java.JavaPlugin"))
+                .transform((builder, td, cl, module, pd) -> builder.visit(
+                        net.bytebuddy.asm.Advice.to(JavaPluginCtorAdvice.class).on(net.bytebuddy.matcher.ElementMatchers.isConstructor())))
+                .installOnByteBuddyAgent();
+    }
+
+    private static class JavaPluginCtorAdvice {
+        @net.bytebuddy.asm.Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+        static void exit(@net.bytebuddy.asm.Advice.Thrown(readOnly = false) Throwable t) {
+            if (t instanceof IllegalStateException && t.getMessage() != null && t.getMessage().contains("JavaPlugin requires")) {
+                t = null; // ignore plugin class loader check
             }
-        };
-        return (Server) Proxy.newProxyInstance(TestPluginLifecycle.class.getClassLoader(), new Class[]{Server.class}, serverHandler);
+        }
     }
 
-    private static InvocationHandler defaultHandler() {
-        return (proxy, method, args) -> defaultValue(method.getReturnType());
-    }
 
-    private static Object defaultValue(Class<?> type) {
-        if (!type.isPrimitive()) return null;
-        if (type == boolean.class) return false;
-        if (type == char.class) return '\0';
-        if (type == byte.class || type == short.class || type == int.class) return 0;
-        if (type == long.class) return 0L;
-        if (type == float.class) return 0f;
-        if (type == double.class) return 0d;
-        return null;
-    }
 
     @SuppressWarnings("unchecked")
     private List<Object> getListeners() throws Exception {

--- a/NCPPlugin/src/test/java/org/bukkit/NamespacedKey.java
+++ b/NCPPlugin/src/test/java/org/bukkit/NamespacedKey.java
@@ -1,0 +1,70 @@
+package org.bukkit;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Simplified NamespacedKey for tests with value() support. */
+public final class NamespacedKey {
+    public static final String MINECRAFT = "minecraft";
+    public static final String BUKKIT = "bukkit";
+
+    private final String namespace;
+    private final String key;
+
+    public NamespacedKey(String namespace, String key) {
+        this.namespace = Objects.requireNonNull(namespace, "Namespace").toLowerCase(Locale.ROOT);
+        this.key = Objects.requireNonNull(key, "Key").toLowerCase(Locale.ROOT);
+    }
+
+    public NamespacedKey(org.bukkit.plugin.Plugin plugin, String key) {
+        this(plugin.getName(), key);
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String value() {
+        return key;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, key);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        NamespacedKey other = (NamespacedKey) obj;
+        return namespace.equals(other.namespace) && key.equals(other.key);
+    }
+
+    @Override
+    public String toString() {
+        return namespace + ":" + key;
+    }
+
+    public static NamespacedKey minecraft(String key) {
+        return new NamespacedKey(MINECRAFT, key);
+    }
+
+    public static NamespacedKey fromString(String string) {
+        if (string == null) return null;
+        int idx = string.indexOf(':');
+        if (idx == -1) {
+            return new NamespacedKey(MINECRAFT, string);
+        }
+        return new NamespacedKey(string.substring(0, idx), string.substring(idx + 1));
+    }
+
+    public static NamespacedKey randomKey() {
+        return new NamespacedKey(MINECRAFT, UUID.randomUUID().toString());
+    }
+}

--- a/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/command/CommandMapMock.java
+++ b/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/command/CommandMapMock.java
@@ -1,0 +1,12 @@
+package org.mockbukkit.mockbukkit.command;
+
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.SimpleCommandMap;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+/** Simplified command map for tests compatible with older Spigot APIs. */
+public class CommandMapMock extends SimpleCommandMap implements CommandMap {
+    public CommandMapMock(ServerMock server) {
+        super(server);
+    }
+}

--- a/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/tags/MaterialTagMock.java
+++ b/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/tags/MaterialTagMock.java
@@ -1,0 +1,41 @@
+package org.mockbukkit.mockbukkit.tags;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+
+/** Test replacement that ignores unknown Material names to maintain compatibility. */
+public class MaterialTagMock extends BaseTagMock<Material> {
+    public MaterialTagMock(NamespacedKey key, Collection<Material> materials) {
+        super(key, materials);
+    }
+
+    public MaterialTagMock(NamespacedKey key, Material... materials) {
+        super(key, materials);
+    }
+
+    public static MaterialTagMock from(NamespacedKey key, JsonArray array) {
+        Collection<Material> materials = new ArrayList<>();
+        for (JsonElement element : array) {
+            Preconditions.checkState(element.isJsonPrimitive(), "The value is not a primitive value");
+            JsonPrimitive prim = element.getAsJsonPrimitive();
+            Preconditions.checkState(prim.isString(), "The value is not a string value");
+            NamespacedKey materialKey = NamespacedKey.fromString(prim.getAsString());
+            Preconditions.checkArgument(materialKey != null, "The value is not a valid namespaced key");
+            String matName = materialKey.value().toUpperCase(Locale.ROOT);
+            try {
+                materials.add(Material.valueOf(matName));
+            } catch (IllegalArgumentException ignored) {
+                // Material not present in this MockBukkit version; ignore.
+            }
+        }
+        return new MaterialTagMock(key, materials);
+    }
+}

--- a/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/tags/TagFactory.java
+++ b/NCPPlugin/src/test/java/org/mockbukkit/mockbukkit/tags/TagFactory.java
@@ -1,0 +1,48 @@
+package org.mockbukkit.mockbukkit.tags;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.bukkit.NamespacedKey;
+
+/** Replacement for MockBukkit TagFactory that avoids using NamespacedKey.value(). */
+public final class TagFactory {
+    private TagFactory() {
+    }
+
+    public static org.bukkit.Tag<?> createTag(TagRegistry registry, NamespacedKey key) {
+        Preconditions.checkNotNull(registry, "registry cannot be null");
+        Preconditions.checkNotNull(key, "key cannot be null");
+        String path = String.format("/tags/%s/%s.json", registry.getRegistry(), key.getKey());
+        JsonObject json = org.mockbukkit.mockbukkit.util.ResourceLoader.loadResource(path).getAsJsonObject();
+        JsonElement values = json.get("values");
+        Preconditions.checkArgument(values.isJsonArray(), "Invalid tag values");
+        return createTag(registry, key, values.getAsJsonArray());
+    }
+
+    static org.bukkit.Tag<?> createTag(TagRegistry registry, NamespacedKey key, JsonArray array) {
+        switch (registry) {
+            case BLOCKS:
+            case ITEMS:
+                return MaterialTagMock.from(key, array);
+            default:
+                return new org.bukkit.Tag<org.bukkit.Keyed>() {
+                    @Override
+                    public boolean isTagged(org.bukkit.Keyed tagged) {
+                        return false;
+                    }
+
+                    @Override
+                    public java.util.Set<org.bukkit.Keyed> getValues() {
+                        return java.util.Collections.emptySet();
+                    }
+
+                    @Override
+                    public NamespacedKey getKey() {
+                        return key;
+                    }
+                };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add ByteBuddy test agent patches for MockBukkit classes
- stub TagFactory and MaterialTag to avoid missing enums
- provide lightweight CommandMapMock for old Spigot APIs
- patch JavaPlugin class loader checks during tests

## Testing
- `mvn -pl NCPPlugin -Dtest=TestPluginLifecycle -DskipITs test` *(fails: PluginLoadException)*
- `mvn -pl NCPPlugin -DskipTests=true checkstyle:check pmd:check spotbugs:check` *(passes with SpotBugs warnings)*

------
https://chatgpt.com/codex/tasks/task_b_685f74b441288329a153a6243316c32d