### PR TITLE
Remove unused flag from MoveCheckResult

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -1370,7 +1370,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         if (player == null || pFrom == null || pTo == null || from == null || to == null
                 || data == null || cc == null || pData == null) {
-            return new MoveCheckResult(newTo, checkNf);
+            return new MoveCheckResult(newTo);
         }
 
         MovingUtil.prepareFullCheck(pFrom, pTo, thisMove, Math.max(cc.noFallyOnGround, cc.yOnGround));
@@ -1393,7 +1393,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                     previousSetBackY, data, cc, pData);
         }
 
-        return new MoveCheckResult(newTo, checkNf);
+        return new MoveCheckResult(newTo);
     }
 
     private void handleFlyCheckTransition(final PlayerMoveData lastMove, final Player player,
@@ -1487,10 +1487,8 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
     private static class MoveCheckResult {
         final Location newTo;
-        final boolean checkNf;
-        MoveCheckResult(final Location newTo, final boolean checkNf) {
+        MoveCheckResult(final Location newTo) {
             this.newTo = newTo;
-            this.checkNf = checkNf;
         }
     }
 


### PR DESCRIPTION
## Summary
- drop `checkNf` from `MovingListener.MoveCheckResult`
- update all instantiations to store only the new location
- rebuild with tests and static analysis

## Testing
- `mvn -DskipTests -pl NCPCore -am compile`
- `mvn -DskipTests=false -pl NCPCore -am verify`

------
https://chatgpt.com/codex/tasks/task_b_685fe267906883299fecde62d2362ad1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the unused `checkNf` flag from the `MoveCheckResult` class and its references in the `MovingListener.java`.

### Why are these changes being made?

The `checkNf` flag was identified as unused within the code base, so its removal simplifies the code by eliminating unnecessary parts, which helps in maintaining cleaner and more readable code. This update does not affect the functionality as the flag was redundant.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal result handling for movement checks to improve maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->