### PR TITLE
Inject DataManager into MovingListener

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -220,9 +220,12 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
      */
     private final boolean specialMinecart = ServerVersion.compareMinecraftVersion("1.19.4") >= 0;
 
+    private final DataManager dataManager;
+
     @SuppressWarnings("unchecked")
-    public MovingListener() {
+    public MovingListener(final DataManager dataManager) {
         super(CheckType.MOVING);
+        this.dataManager = dataManager;
         // Register vehicleChecks.
         final NoCheatPlusAPI api = NCPAPIProvider.getNoCheatPlusAPI();
         api.addComponent(vehicleChecks);
@@ -272,7 +275,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         if (isGliding && !Bridge1_9.isGlidingWithElytra(player)) { // Includes check for elytra item.
             final PlayerMoveInfo info = aux.usePlayerMoveInfo();
             info.set(player, player.getLocation(info.useLoc), null, 0.001); // Only restrict very near ground.
-            final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+            final IPlayerData pData = dataManager.getPlayerData(player);
             final MovingData data = pData.getGenericInstance(MovingData.class);
             final boolean res = !MovingUtil.canLiftOffWithElytra(player, info.from, data);
             info.cleanup();
@@ -294,7 +297,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
      */
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerBedEnter(final PlayerBedEnterEvent event) {
-        DataManager.getInstance().getGenericInstance(event.getPlayer(), MovingData.class).wasInBed = true;
+        dataManager.getGenericInstance(event.getPlayer(), MovingData.class).wasInBed = true;
     }
 
 
@@ -316,7 +319,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     }
 
     private void handleBedLeave(final Player player) {
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (pData == null || !pData.isCheckActive(CheckType.MOVING, player)) {
             return;
         }
@@ -390,7 +393,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         if (!Bridge1_13.hasIsSwimming() || specialMinecart) return;
         if (event.getCause() == TeleportCause.UNKNOWN) {
             final Player player = event.getPlayer();
-            final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+            final IPlayerData pData = dataManager.getPlayerData(player);
             final MovingData data = pData.getGenericInstance(MovingData.class);
             if (data.lastVehicleType != null && standsOnEntity(player, player.getLocation().getY())) {
                 event.setCancelled(true);
@@ -426,7 +429,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         // Maybe this helps with people teleporting through Multiverse portals having problems?
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
@@ -447,7 +450,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             Location loc = e.getLocation();
             for (Entity affectedPlayer : loc.getWorld().getNearbyEntities(loc, 1.2, 1.2, 1.2, (entity) -> entity.getType() == EntityType.PLAYER)) {
                 final Player player = (Player) affectedPlayer;
-                final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+                final IPlayerData pData = dataManager.getPlayerData(player);
                 final MovingData data = pData.getGenericInstance(MovingData.class);
                 if (!pData.isCheckActive(CheckType.MOVING, player)) continue;
                 data.noFallCurrentLocOnWindChargeHit = player.getLocation().clone();
@@ -467,7 +470,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         final Player player = event.getPlayer();
         if (player.getGameMode() == GameMode.CREATIVE || event.getNewGameMode() == GameMode.CREATIVE) {
-            final MovingData data = DataManager.getInstance().getGenericInstance(player, MovingData.class);
+            final MovingData data = dataManager.getGenericInstance(player, MovingData.class);
             data.clearWindChargeImpulse();
             data.clearFlyData();
             data.clearPlayerMorePacketsData();
@@ -491,7 +494,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         final Player player = event.getPlayer();
         // Store the event for monitor level checks.
         processingEvents.put(player.getName(), event);
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
         final MovingData data = pData.getGenericInstance(MovingData.class);
@@ -587,7 +590,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             if (debug) debug(player, "Implicitly confirm set back with the start point of a move.");
             return false;
         }
-        else if (DataManager.getInstance().getPlayerData(player).isPlayerSetBackScheduled()) {
+        else if (dataManager.getPlayerData(player).isPlayerSetBackScheduled()) {
             // A set back has been scheduled, but the player is moving randomly.
             // Instead alter the move from location and let it get through? +- when
             event.setCancelled(true);
@@ -1807,7 +1810,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         // Use stored move data to verify if from/to have changed (thus a teleport will result, possibly a minor issue due to the teleport).
         final long now = System.currentTimeMillis();
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(event.getPlayer());
+        final IPlayerData pData = dataManager.getPlayerData(event.getPlayer());
         // This means moving data has been reset by a teleport.
         if (processingEvents.remove(player.getName()) == null) return;
         if (player.isDead() || player.isSleeping()) return;
@@ -1859,7 +1862,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             }
             if (method.shouldSchedule()) {
                 // Schedule the teleport, because it might be faster than the next incoming packet.
-                final IPlayerData pd = DataManager.getInstance().getPlayerData(player);
+                final IPlayerData pd = dataManager.getPlayerData(player);
                 if (pd.isPlayerSetBackScheduled()) debug(player, "Teleport (set back) already scheduled to: " + ref);
                 else if (debug) {
                     pd.requestPlayerSetBack();
@@ -1954,7 +1957,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     public void onPlayerPortalLowest(final PlayerPortalEvent event) {
 
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(event.getPlayer());
+        final IPlayerData pData = dataManager.getPlayerData(event.getPlayer());
         if (MovingUtil.hasScheduledPlayerSetBack(player)) {
             if (pData.isDebugActive(checkType)) debug(player, "[PORTAL] Prevent use, due to a scheduled set back.");
             event.setCancelled(true);
@@ -1972,7 +1975,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     public void onPlayerPortal(final PlayerPortalEvent event) {
 
         final Location to = event.getTo();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(event.getPlayer());
+        final IPlayerData pData = dataManager.getPlayerData(event.getPlayer());
         final MovingData data = pData.getGenericInstance(MovingData.class);
         if (pData.isDebugActive(checkType)) debug(event.getPlayer(), "[PORTAL] to=" + to);
         // This should be redundant, might remove anyway.
@@ -1990,7 +1993,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     public void onPlayerDeath(final PlayerDeathEvent event) {
 
         final Player player = event.getEntity();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
         //final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
         data.clearMostMovingCheckData();
@@ -2023,7 +2026,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
             return;
         }
 
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!isMovingCheckActive(pData, player)) {
             return;
         }
@@ -2069,7 +2072,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private void checkUndoCancelledSetBack(final PlayerTeleportEvent event) {
 
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
         // Revert cancel on set back (only precise match).
         // Teleport by NCP.
@@ -2111,7 +2114,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         // Evaluate result and adjust data.
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingData data = pData.getGenericInstance(MovingData.class);
         // Invalidate first-move thing.
@@ -2283,7 +2286,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         }
 
         if (data.hasTeleported()) {
-            if (DataManager.getInstance().getPlayerData(player).isPlayerSetBackScheduled()) {
+            if (dataManager.getPlayerData(player).isPlayerSetBackScheduled()) {
                 // Assume set back event following later.
                 event.setCancelled(true);
                 if (debug) debugTeleportMessage(player, event, "Cancel, due to a scheduled set back.");
@@ -2493,7 +2496,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     public void onPlayerVelocity(final PlayerVelocityEvent event) {
 
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingData data = pData.getGenericInstance(MovingData.class);
         // Ignore players who are in vehicles.
@@ -2524,7 +2527,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
     private void checkFallDamageEvent(final Player player, final EntityDamageEvent event) {
 
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         final MovingData data = pData.getGenericInstance(MovingData.class);
         final PlayerMoveData thisMove = data.playerMoves.getCurrentMove();
         final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
@@ -2737,7 +2740,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     public void onPlayerRespawn(final PlayerRespawnEvent event) {
 
         final Player player = event.getPlayer();
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingData data = pData.getGenericInstance(MovingData.class);
         // Prevent/cancel scheduled teleport (use PlayerData/task for teleport, or a sequence count).
@@ -2759,7 +2762,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
      */
     private void redoShield(final Player player) {
 
-        // Does not work: DataManager.getInstance().getPlayerData(player).requestUpdateInventory();
+        // Does not work: dataManager.getPlayerData(player).requestUpdateInventory();
         if (mcAccess.getHandle().resetActiveItem(player)) return;
         final PlayerInventory inv = player.getInventory();
         ItemStack stack = inv.getItemInOffHand();
@@ -2780,7 +2783,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     @Override
     public void playerJoins(final Player player) {
 
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         dataOnJoin(player, player.getLocation(useJoinLoc), false, pData.getGenericInstance(MovingData.class), 
                   pData.getGenericInstance(MovingConfig.class), pData.isDebugActive(checkType));
@@ -2886,7 +2889,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     @Override
     public void playerLeaves(final Player player) {
 
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingData data = pData.getGenericInstance(MovingData.class);
         final Location loc = player.getLocation(useLeaveLoc);
@@ -3019,7 +3022,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerToggleSprint(final PlayerToggleSprintEvent event) {
-        if (!event.isSprinting()) DataManager.getInstance().getGenericInstance(event.getPlayer(), MovingData.class).timeSprinting = 0;
+        if (!event.isSprinting()) dataManager.getGenericInstance(event.getPlayer(), MovingData.class).timeSprinting = 0;
     }
 
 
@@ -3029,7 +3032,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         // (ignoreCancelled = false: we track the bit of vertical extra momentum/thing).
         final Player player = event.getPlayer();
         if (player.isFlying() || event.isFlying() && !event.isCancelled())  return;
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = dataManager.getPlayerData(player);
         if (!pData.isCheckActive(CheckType.MOVING, player)) return;
         final MovingData data = pData.getGenericInstance(MovingData.class);
         final MovingConfig cc = pData.getGenericInstance(MovingConfig.class);
@@ -3077,12 +3080,12 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
         for (final String playerName : hoverTicks) {
             // put players into the set (+- one tick would not matter ?)
             // might add an online flag to data !
-            final Player player = DataManager.getInstance().getPlayerExact(playerName);
+            final Player player = dataManager.getPlayerExact(playerName);
             if (player == null || !player.isOnline()) {
                 rem.add(playerName);
                 continue;
             }
-            final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+            final IPlayerData pData = dataManager.getPlayerData(player);
             final MovingData data = pData.getGenericInstance(MovingData.class);
             if (player.isDead() || player.isSleeping() || player.isInsideVehicle()) {
                 data.sfHoverTicks = -1;
@@ -3129,7 +3132,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
 
         final List<String> rem = new ArrayList<String>(playersEnforce.size()); // Pessimistic.
         for (final String playerName : playersEnforce) {
-            final Player player = DataManager.getInstance().getPlayerExact(playerName);
+            final Player player = dataManager.getPlayerExact(playerName);
             if (player == null || !player.isOnline()) {
                 rem.add(playerName);
                 continue;
@@ -3138,7 +3141,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 // Don't remove but also don't check [subject to change].
                 continue;
             }
-            final MovingData data = DataManager.getInstance().getGenericInstance(player, MovingData.class);
+            final MovingData data = dataManager.getGenericInstance(player, MovingData.class);
             final Location newTo = enforceLocation(player, player.getLocation(useTickLoc), data);
             if (newTo != null) {
                 data.prepareSetBack(newTo);

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -1071,7 +1071,7 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                 // Do mind registration order: Combined must come before Fight.
                 new FightListener(),
                 new InventoryListener(),
-                new MovingListener(),
+                new MovingListener(dataManager),
         }) {
             addComponent(obj);
             // Register sub-components (allow later added to use registries, if any).


### PR DESCRIPTION
## Summary
- add DataManager dependency field
- update MovingListener constructor to accept DataManager
- use the injected DataManager instead of the singleton
- pass DataManager instance when registering MovingListener

## Testing
- `mvn -q verify`

------
https://chatgpt.com/codex/tasks/task_b_685fe26774f88329a0230999bb7b85e3