### PR TITLE
Use ConcurrentHashMap for processingEvents

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -15,7 +15,6 @@
 package fr.neatmonster.nocheatplus.checks.moving;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -177,7 +176,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
     private final Passable passable = addCheck(new Passable());
     
     /** Store events by player name, in order to invalidate moving processing on higher priority level in case of teleports. */
-    private final Map<String, PlayerMoveEvent> processingEvents = new HashMap<String, PlayerMoveEvent>();
+    private final Map<String, PlayerMoveEvent> processingEvents = new ConcurrentHashMap<String, PlayerMoveEvent>();
 
     /** Player names to check hover for, case insensitive. */
     private final Set<String> hoverTicks = ConcurrentHashMap.newKeySet(30); // Rename


### PR DESCRIPTION
## Summary
- use a thread-safe `ConcurrentHashMap` for `processingEvents`
- remove unused `HashMap` import

## Testing
- `mvn verify`

------
https://chatgpt.com/codex/tasks/task_b_685fec405bc48329ac9eb945b4248870

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `HashMap` with `ConcurrentHashMap` for the `processingEvents` Map in `MovingListener.java`.

### Why are these changes being made?

The change is necessary to ensure thread-safe operations on the `processingEvents` Map, as it might be accessed concurrently by multiple threads in a multithreaded environment, such as handling concurrent player movement events. Using `ConcurrentHashMap` ensures that the operations on this Map are performed atomically, thus preventing possible data inconsistency issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->