### PR TITLE
Handle null world in stopwatch

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/testing/stopwatch/LocationBasedStopWatchData.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/testing/stopwatch/LocationBasedStopWatchData.java
@@ -15,7 +15,10 @@
 package fr.neatmonster.nocheatplus.command.testing.stopwatch;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
+
+import fr.neatmonster.nocheatplus.logging.StaticLog;
 
 /**
  * Just base on the players location at initialization.
@@ -39,11 +42,32 @@ public abstract class LocationBasedStopWatchData extends StopWatch{
     public LocationBasedStopWatchData(Player player) {
         super(player);
         final Location loc = player.getLocation(useLoc);
-        worldName = loc.getWorld().getName();
+        worldName = resolveWorldName(player, loc);
         x = loc.getX();
         y = loc.getY();
         z = loc.getZ();
         useLoc.setWorld(null);
+    }
+
+    /**
+     * Resolve the world name for initialization, falling back to the player's
+     * current world if necessary.
+     *
+     * @param player the player owning this stopwatch
+     * @param loc    the location obtained from the player
+     * @return the world name or {@code null} if none is available
+     */
+    private static String resolveWorldName(Player player, Location loc) {
+        World world = loc.getWorld();
+        if (world == null) {
+            world = player.getWorld();
+            if (world == null) {
+                StaticLog.logWarning("StopWatch initialization aborted: no world for player "
+                        + player.getName());
+                return null;
+            }
+        }
+        return world.getName();
     }
 
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationBasedStopWatchData.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/test/TestLocationBasedStopWatchData.java
@@ -1,0 +1,64 @@
+package fr.neatmonster.nocheatplus.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import fr.neatmonster.nocheatplus.command.testing.stopwatch.LocationBasedStopWatchData;
+
+public class TestLocationBasedStopWatchData {
+
+    private static World createWorld() {
+        InvocationHandler h = (proxy, method, args) -> {
+            if ("getName".equals(method.getName())) return "dummy";
+            Class<?> r = method.getReturnType();
+            if (r == boolean.class) return false;
+            if (r.isPrimitive()) return 0;
+            return null;
+        };
+        return (World) Proxy.newProxyInstance(World.class.getClassLoader(), new Class[]{World.class}, h);
+    }
+
+    private static Player createPlayer(World world) {
+        InvocationHandler h = (proxy, method, args) -> {
+            switch(method.getName()) {
+                case "getWorld":
+                    return world;
+                case "getLocation":
+                    Location l = (Location) args[0];
+                    l.setWorld(null);
+                    l.setX(0);
+                    l.setY(0);
+                    l.setZ(0);
+                    return l;
+                case "getName":
+                    return "player";
+                default:
+                    Class<?> r = method.getReturnType();
+                    if (r == boolean.class) return false;
+                    if (r.isPrimitive()) return 0;
+                    return null;
+            }
+        };
+        return (Player) Proxy.newProxyInstance(Player.class.getClassLoader(), new Class[]{Player.class}, h);
+    }
+
+    @Test
+    public void testConstructorNullLocationWorld() {
+        World world = createWorld();
+        Player player = createPlayer(world);
+        LocationBasedStopWatchData data = new LocationBasedStopWatchData(player) {
+            @Override
+            public boolean checkStop() { return false; }
+            @Override
+            public boolean needsTick() { return false; }
+        };
+        assertEquals(world.getName(), data.worldName);
+    }
+}


### PR DESCRIPTION
## Summary
- guard against null world names in stopwatch constructor
- log warnings and use player's world when location world is null
- test null-world initialization

## Testing
- `mvn -DskipTests=false -DskipITs=true test`
- `timeout 300 mvn -DskipTests -Dspotbugs.failOnError=false checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_685ff23114808329a706d035d528ac61