### PR TITLE
Adjust log levels for common warnings

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/BlockChangeTracker.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/compat/blocks/changetracker/BlockChangeTracker.java
@@ -1165,7 +1165,10 @@ public class BlockChangeTracker implements IBlockChangeTracker {
     private void checkProcessBlocks() {
         if (!processBlocks.isEmpty()) {
             processBlocks.clear();
-            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().warning(Streams.STATUS, "BlockChangeTracker: processBlocks is not empty on starting to add blocks.");
+            // This can happen if previous processing was interrupted. It's not
+            // a severe issue, so use debug level to avoid console spam.
+            NCPAPIProvider.getNoCheatPlusAPI().getLogManager().debug(Streams.STATUS,
+                    "BlockChangeTracker: processBlocks is not empty on starting to add blocks.");
         }
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/PathUtils.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/PathUtils.java
@@ -229,7 +229,8 @@ public class PathUtils {
     protected static void warnPaths(final ConfigurationSection config, final CharPrefixTree<?, ?> paths, final String msgPrefix, final Set<String> warnedPaths) {
         for (final String path : config.getKeys(true)) {
             if (paths.hasPrefix(path)) {
-                StaticLog.logWarning("Config path '" + path + "'" + msgPrefix);
+                // Deprecated or moved config paths are expected; log as debug.
+                StaticLog.logDebug("Config path '" + path + "'" + msgPrefix);
                 if (warnedPaths != null) {
                     warnedPaths.add(path);
                 }
@@ -392,7 +393,8 @@ public class PathUtils {
                     addPaths.put(newPath, value);
                     removePaths.add(path);
                 }
-                StaticLog.logWarning("Config path '" + path + "' (" + configName + ") has been moved" + to);
+                // Path moves are normal during updates; use debug level.
+                StaticLog.logDebug("Config path '" + path + "' (" + configName + ") has been moved" + to);
             }
         }
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/RawConfigFile.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/config/RawConfigFile.java
@@ -197,7 +197,8 @@ public class RawConfigFile  extends YamlConfiguration {
                 materialLookup.put(key, mat);
             }
             if (mat == null) {
-                StaticLog.logWarning("Bad material entry (" + path + "): " + entry);
+                // Invalid material names can be frequent in configs; log as debug.
+                StaticLog.logDebug("Bad material entry (" + path + "): " + entry);
             } else {
                 target.add(mat);
             }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockFlags.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockFlags.java
@@ -366,8 +366,8 @@ public class BlockFlags {
     public static void setFlag(Material material, long addFlag) {
         try {
             if (!material.isBlock()) {
-                // Let's not fail hard here.
-                StaticLog.logWarning("Attempt to set flag for a non-block: " + material);
+                // Expected if plugins misuse API; keep at debug level.
+                StaticLog.logDebug("Attempt to set flag for a non-block: " + material);
             }
         }
         catch (Exception e) {
@@ -379,8 +379,8 @@ public class BlockFlags {
     public static void maskFlag(Material material, long addFlag) {
         try {
             if (!material.isBlock()) {
-                // Let's not fail hard here.
-                StaticLog.logWarning("Attempt to mask flag for a non-block: " + material);
+                // Expected if plugins misuse API; keep at debug level.
+                StaticLog.logDebug("Attempt to mask flag for a non-block: " + material);
             }
         }
         catch (Exception e) {
@@ -500,8 +500,8 @@ public class BlockFlags {
     public static final void setBlockFlags(final Material blockType, final long flags) {
         try {
             if (!blockType.isBlock()) {
-                // Let's not fail hard here.
-                StaticLog.logWarning("Attempt to set flags for a non-block: " + blockType);
+                // Expected if plugins misuse API; keep at debug level.
+                StaticLog.logDebug("Attempt to set flags for a non-block: " + blockType);
             }
         }
         catch (Exception e) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/BlockProperties.java
@@ -1105,7 +1105,8 @@ public class BlockProperties {
     private static void setBlock(Material material, BlockProps props) {
         try {
             if (!material.isBlock()) {
-                StaticLog.logWarning("Material is not a block: " + material);
+                // Misconfigured materials are common; log at debug level.
+                StaticLog.logDebug("Material is not a block: " + material);
             }
         } catch (Throwable t) {
             StaticLog.logSevere("Failed to validate block material: " + material);


### PR DESCRIPTION
## Summary
- quiet expected BlockChangeTracker messages
- lower verbosity for config path checks
- log invalid config materials at debug level
- reduce console warnings in BlockFlags and BlockProperties

## Testing
- `mvn -B verify`

------
https://chatgpt.com/codex/tasks/task_b_685ff72bca5c83299962245efd7ca5d0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Change log levels from warning to debug for common warnings across multiple classes.

### Why are these changes being made?

This adjustment reduces console spam by reclassifying log entries related to non-severe issues, such as common misconfigurations and expected conditions during updates, to the debug level. This approach helps maintain focus on more critical warnings while still allowing developers to access detailed information when needed through the debug logs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->