### PR TITLE
Add LocationPool and use pooled locations

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/HotFixFallingBlockPortalEnter.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/HotFixFallingBlockPortalEnter.java
@@ -27,6 +27,7 @@ import org.bukkit.event.entity.EntityPortalEnterEvent;
 
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.compat.BridgeMaterial;
+import fr.neatmonster.nocheatplus.utilities.location.LocationPool;
 import fr.neatmonster.nocheatplus.compat.versions.ServerVersion;
 import fr.neatmonster.nocheatplus.logging.Streams;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
@@ -57,8 +58,7 @@ public class HotFixFallingBlockPortalEnter implements Listener {
         }
     }
 
-    /** Temporary use only: setWorld(null) after use. */
-    private final Location useLoc = new Location(null, 0, 0, 0);
+    private final LocationPool locationPool = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(LocationPool.class);
 
     private final WrapBlockCache wrapBlockCache;
 
@@ -87,7 +87,7 @@ public class HotFixFallingBlockPortalEnter implements Listener {
             mat = null;
         }
         if (mat != null) {
-            final Location loc = entity.getLocation(useLoc);
+            final Location loc = entity.getLocation(locationPool.acquire());
             final World world = loc.getWorld();
             final IWorldData worldData = NCPAPIProvider.getNoCheatPlusAPI().getWorldDataManager().getWorldData(world);
             if (worldData.getGenericInstance(InventoryConfig.class).hotFixFallingBlockEndPortalActive) {
@@ -107,7 +107,7 @@ public class HotFixFallingBlockPortalEnter implements Listener {
                     NCPAPIProvider.getNoCheatPlusAPI().getLogManager().info(Streams.STATUS, message);
                 }
             }
-            useLoc.setWorld(null);
+            locationPool.release(loc);
         }
     }
 

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkit.java
@@ -22,6 +22,8 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.block.data.BlockData;
 
 import fr.neatmonster.nocheatplus.compat.Bridge1_13;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.utilities.location.LocationPool;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockFlags;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -31,8 +33,7 @@ public class BlockCacheBukkit extends BlockCache {
 
     protected World world;
 
-    /** Temporary use. Use LocUtil.clone before passing on. Call setWorld(null) after use. */
-    protected final Location useLoc = new Location(null, 0, 0, 0);
+    protected final LocationPool locationPool = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(LocationPool.class);
 
     public BlockCacheBukkit(World world) {
         setAccess(world);
@@ -87,21 +88,20 @@ public class BlockCacheBukkit extends BlockCache {
 
     @Override
     public boolean standsOnEntity(final Entity entity, final double minX, final double minY, final double minZ, final double maxX, final double maxY, final double maxZ){
-        try{
-            // Possibly check other ids too before doing this.
-            for (final Entity other : entity.getNearbyEntities(2.0, 2.0, 2.0)){
+        final Location temp = locationPool.acquire();
+        try {
+            for (final Entity other : entity.getNearbyEntities(2.0, 2.0, 2.0)) {
                 final EntityType type = other.getType();
-                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER){ //  && !(other instanceof Minecart)) 
+                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER) {
                     continue;
                 }
-                final double locY = entity.getLocation(useLoc).getY();
-                useLoc.setWorld(null);
-                // A "better" estimate is possible, though some more tolerance would be good.
+                final double locY = entity.getLocation(temp).getY();
                 return Math.abs(locY - minY) < 0.7;
             }
-        }
-        catch (Throwable t){
+        } catch (Throwable t) {
             // Ignore exceptions (Context: DisguiseCraft).
+        } finally {
+            locationPool.release(temp);
         }
         return false;
     }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/BlockCacheBukkitModern.java
@@ -16,6 +16,7 @@ package fr.neatmonster.nocheatplus.compat.bukkit;
 
 import java.util.Map;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -89,22 +90,21 @@ public class BlockCacheBukkitModern extends BlockCacheBukkit {
     
     @Override
     public boolean standsOnEntity(final Entity entity, final double minX, final double minY, final double minZ, final double maxX, final double maxY, final double maxZ){
-        try{
-            // Vehicle IDs may need to be checked before performing this action.
-            for (final Entity vehicle : entity.getNearbyEntities(0.1, 2.0, 0.1)){
+        final Location temp = locationPool.acquire();
+        try {
+            for (final Entity vehicle : entity.getNearbyEntities(0.1, 2.0, 0.1)) {
                 final EntityType type = vehicle.getType();
-                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER){ //  && !(vehicle instanceof Minecart)) 
-                    continue; 
+                if (!MaterialUtil.isBoat(type) && type != EntityType.SHULKER) {
+                    continue;
                 }
-                final double vehicleY = vehicle.getLocation(useLoc).getY() + vehicle.getHeight();
-                final double entityY = entity.getLocation(useLoc).getY();
-                useLoc.setWorld(null);
-                // A more accurate estimate may be implemented, though some more tolerance would help.
+                final double vehicleY = vehicle.getLocation(temp).getY() + vehicle.getHeight();
+                final double entityY = entity.getLocation(temp).getY();
                 return vehicleY < entityY + 0.1 && Math.abs(vehicleY - entityY) < 0.7;
-            }		
-        }
-        catch (Throwable t){
+            }
+        } catch (Throwable t) {
             // Ignore exceptions (Context: DisguiseCraft).
+        } finally {
+            locationPool.release(temp);
         }
         return false;
     }

--- a/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/SoundDistance.java
+++ b/NCPCompatProtocolLib/src/main/java/fr/neatmonster/nocheatplus/checks/net/protocollib/SoundDistance.java
@@ -24,6 +24,8 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
+import fr.neatmonster.nocheatplus.utilities.location.LocationPool;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.ListenerPriority;
@@ -94,7 +96,7 @@ public class SoundDistance extends BaseAdapter {
             ));
 
     private final Integer idSoundEffectCancel = counters.registerKey("packet.sound.cancel");
-    private final Location useLoc = new Location(null, 0, 0, 0);
+    private final LocationPool locationPool = NCPAPIProvider.getNoCheatPlusAPI().getGenericInstance(LocationPool.class);
     /** Legacy check behavior. */
     private final boolean pre1_9;
 
@@ -162,8 +164,9 @@ public class SoundDistance extends BaseAdapter {
         }
 
         // Compare distance of player to the weather location.
-        final Location loc = player.getLocation(useLoc);
+        final Location loc = player.getLocation(locationPool.acquire());
         if (loc == null) {
+            locationPool.release(loc);
             return;
         }
         final StructureModifier<Integer> ints = packetContainer.getIntegers();
@@ -176,7 +179,7 @@ public class SoundDistance extends BaseAdapter {
             event.setCancelled(true);
             counters.add(idSoundEffectCancel, 1);
         }
-        useLoc.setWorld(null);
+        locationPool.release(loc);
     }
     
     @Override

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/LocationPool.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/LocationPool.java
@@ -1,0 +1,61 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package fr.neatmonster.nocheatplus.utilities.location;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.bukkit.Location;
+
+/**
+ * Pool of reusable {@link Location} objects.
+ *
+ * <p>This pool is thread-safe for the acquire and release operations.
+ * Instances are meant for temporary use on the calling thread and should not be
+ * shared across asynchronous tasks. Returned locations are reset with
+ * {@code setWorld(null)} before being offered back to the pool.</p>
+ */
+public class LocationPool {
+
+    private final ConcurrentLinkedQueue<Location> pool = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Acquire a temporary {@link Location} instance.
+     *
+     * @return a location either taken from the pool or a new instance
+     */
+    public Location acquire() {
+        Location loc = pool.poll();
+        if (loc == null) {
+            loc = new Location(null, 0, 0, 0);
+        }
+        return loc;
+    }
+
+    /**
+     * Release a location previously acquired via {@link #acquire()}.
+     *
+     * <p>The location will have its world cleared via {@code setWorld(null)}
+     * before being returned to the pool.</p>
+     *
+     * @param loc the location to release; ignored if {@code null}
+     */
+    public void release(final Location loc) {
+        if (loc == null) {
+            return;
+        }
+        loc.setWorld(null);
+        pool.offer(loc);
+    }
+}

--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -144,6 +144,7 @@ import fr.neatmonster.nocheatplus.utilities.OnDemandTickListener;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.entity.PassengerUtil;
+import fr.neatmonster.nocheatplus.utilities.location.LocationPool;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
 import fr.neatmonster.nocheatplus.worlds.IWorldData;
@@ -1026,6 +1027,8 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         genericInstanceRegistry.denyChangeExistingRegistration(WRPT.class);
         registerGenericInstance(new TraceEntryPool(1000)); // Random number.
         genericInstanceRegistry.denyChangeExistingRegistration(TraceEntryPool.class);
+        registerGenericInstance(new LocationPool());
+        genericInstanceRegistry.denyChangeExistingRegistration(LocationPool.class);
         registerGenericInstance(new PassengerUtil());
         genericInstanceRegistry.denyChangeExistingRegistration(PassengerUtil.class);
         // (Allow override others.)


### PR DESCRIPTION
## Summary
- implement `LocationPool` for temporary `Location` reuse
- register the new pool in the main plugin
- refactor inventory fix and block caches to use the pool
- refactor ProtocolLib `SoundDistance` check to use pooled locations

## Testing
- `mvn -q -DskipTests=false test`
- `mvn -q -DskipTests=true verify`

------
https://chatgpt.com/codex/tasks/task_b_685ff726ebfc8329a0dc9b243a005ea5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement LocationPool to manage reusable Location objects efficiently, replacing temporary Location instances with pooled locations across various classes in the codebase.

### Why are these changes being made?

These changes are made to optimize performance by reducing the overhead associated with creating new Location instances repeatedly. Using a pool of reusable Location objects decreases garbage collection workload, thereby enhancing system efficiency. The LocationPool is designed to be thread-safe, ensuring safe acquisition and release of Location instances, which are crucial for performance-critical tasks involving location-based operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->