### PR TITLE
Central registry for feature support

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/bukkit/EntityAccessVehicleMultiPassenger.java
@@ -14,64 +14,18 @@
  */
 package fr.neatmonster.nocheatplus.compat.bukkit;
 
-import java.lang.reflect.Method;
 import java.util.List;
 
 import org.bukkit.entity.Entity;
 
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
-import fr.neatmonster.nocheatplus.logging.StaticLog;
-import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+import fr.neatmonster.nocheatplus.support.Feature;
+import fr.neatmonster.nocheatplus.support.FeatureSupportRegistry;
 
 public class EntityAccessVehicleMultiPassenger implements IEntityAccessVehicle {
 
-    /** Cached getPassengers method. */
-    private static Method methodGetPassengers;
-
-    /** Cached addPassenger method. */
-    private static Method methodAddPassenger;
-
     private EntityAccessVehicleMultiPassenger() {
         // Empty constructor.
-    }
-
-    /**
-     * Resolve and cache required methods for multi passenger support.
-     *
-     * @return {@code true} if both methods exist with expected signatures
-     */
-    private static boolean resolveAccessMethods() {
-        if (methodGetPassengers != null && methodAddPassenger != null) {
-            return true;
-        }
-
-        methodGetPassengers = ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers");
-        if (methodGetPassengers == null) {
-            StaticLog.logDebug("Entity#getPassengers() method not found.");
-            return false;
-        }
-        if (!List.class.isAssignableFrom(methodGetPassengers.getReturnType())) {
-            StaticLog.logDebug("Entity#getPassengers() has unexpected return type: "
-                    + methodGetPassengers.getReturnType().getName());
-            methodGetPassengers = null;
-            return false;
-        }
-
-        methodAddPassenger = ReflectionUtil.getMethod(Entity.class, "addPassenger", Entity.class);
-        if (methodAddPassenger == null) {
-            StaticLog.logDebug("Entity#addPassenger(Entity) method not found.");
-            methodGetPassengers = null;
-            return false;
-        }
-        final Class<?> returnType = methodAddPassenger.getReturnType();
-        if (returnType != boolean.class && returnType != void.class) {
-            StaticLog.logDebug("Entity#addPassenger(Entity) has unexpected return type: "
-                    + returnType.getName());
-            methodGetPassengers = null;
-            methodAddPassenger = null;
-            return false;
-        }
-        return true;
     }
 
     /**
@@ -80,7 +34,7 @@ public class EntityAccessVehicleMultiPassenger implements IEntityAccessVehicle {
      * @return Instance or {@code null} if not supported.
      */
     public static EntityAccessVehicleMultiPassenger createIfSupported() {
-        if (!resolveAccessMethods()) {
+        if (!FeatureSupportRegistry.isSupported(Feature.VEHICLE_MULTI_PASSENGER)) {
             return null;
         }
         return new EntityAccessVehicleMultiPassenger();

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Entity;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
+import fr.neatmonster.nocheatplus.support.FeatureSupportRegistry;
 import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
 
 public class TestEntityAccessVehicleMultiPassenger {
@@ -20,6 +21,7 @@ public class TestEntityAccessVehicleMultiPassenger {
 
     @Test
     public void testMissingGetPassengers() throws Exception {
+        FeatureSupportRegistry.clearCache();
         Method dummyAdd = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyAddPassenger");
         try (MockedStatic<ReflectionUtil> util = mockStatic(ReflectionUtil.class)) {
             util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class))
@@ -33,6 +35,7 @@ public class TestEntityAccessVehicleMultiPassenger {
 
     @Test
     public void testMissingAddPassenger() throws Exception {
+        FeatureSupportRegistry.clearCache();
         Method dummyGet = TestEntityAccessVehicleMultiPassenger.class.getDeclaredMethod("dummyPassengers");
         try (MockedStatic<ReflectionUtil> util = mockStatic(ReflectionUtil.class)) {
             util.when(() -> ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers", List.class))

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/support/Feature.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/support/Feature.java
@@ -1,0 +1,9 @@
+package fr.neatmonster.nocheatplus.support;
+
+/**
+ * Features that may or may not be supported depending on the server version.
+ */
+public enum Feature {
+    /** Support for multiple passengers per vehicle. */
+    VEHICLE_MULTI_PASSENGER
+}

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/support/FeatureSupportRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/support/FeatureSupportRegistry.java
@@ -1,0 +1,67 @@
+package fr.neatmonster.nocheatplus.support;
+
+import java.lang.reflect.Method;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.entity.Entity;
+
+import fr.neatmonster.nocheatplus.utilities.ReflectionUtil;
+
+/**
+ * Central registry caching results of runtime feature detection.
+ */
+public final class FeatureSupportRegistry {
+
+    /** Cache for feature support flags. */
+    private static final Map<Feature, Boolean> SUPPORT = new EnumMap<>(Feature.class);
+
+    private FeatureSupportRegistry() {
+        // static only
+    }
+
+    /**
+     * Determine if the given feature is supported.
+     * Results are cached after the first check.
+     *
+     * @param feature the feature to query
+     * @return {@code true} if the feature is supported
+     */
+    public static boolean isSupported(Feature feature) {
+        Boolean cached = SUPPORT.get(feature);
+        if (cached != null) {
+            return cached.booleanValue();
+        }
+        boolean res;
+        switch (feature) {
+            case VEHICLE_MULTI_PASSENGER:
+                res = detectVehicleMultiPassenger();
+                break;
+            default:
+                res = false;
+        }
+        SUPPORT.put(feature, Boolean.valueOf(res));
+        return res;
+    }
+
+    /**
+     * For tests only: clear cached feature results.
+     */
+    public static void clearCache() {
+        SUPPORT.clear();
+    }
+
+    private static boolean detectVehicleMultiPassenger() {
+        Method getPassengers = ReflectionUtil.getMethodNoArgs(Entity.class, "getPassengers");
+        if (getPassengers == null || !List.class.isAssignableFrom(getPassengers.getReturnType())) {
+            return false;
+        }
+        Method addPassenger = ReflectionUtil.getMethod(Entity.class, "addPassenger", Entity.class);
+        if (addPassenger == null) {
+            return false;
+        }
+        Class<?> returnType = addPassenger.getReturnType();
+        return returnType == boolean.class || returnType == void.class;
+    }
+}


### PR DESCRIPTION
## Summary
- add `Feature` enum and `FeatureSupportRegistry`
- update `EntityAccessVehicleMultiPassenger` to use the registry
- refresh related unit tests

## Testing
- `mvn -DskipITs verify`

------
https://chatgpt.com/codex/tasks/task_b_685ffa11ca7083299e90ed6ef435744c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a central registry for feature support to replace direct method calls with a registry-based approach for detecting vehicle multi-passenger support.

### Why are these changes being made?

These changes are made to centralize the feature support checks, improving maintainability and scalability by using the new `FeatureSupportRegistry`. This approach allows caching and manages feature support evaluations efficiently, replacing repetitive reflection-based checks in `EntityAccessVehicleMultiPassenger`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->