### PR TITLE
Document main-thread requirements for async tasks

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/top/TopCommand.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/command/admin/top/TopCommand.java
@@ -87,7 +87,12 @@ public class TopCommand extends BaseCommand{
                 // Start sorting and result processing asynchronously.
                 final CheckType ct = type;
                 final List<VLView> vlviews = views;
-                Folia.runAsyncTask(plugin, (arg) -> new AsynchronousWorker(sender, ct, vlviews, checkTypes, comparator, n, plugin).run());
+                // Offload heavy sorting to a background thread. All Bukkit API
+                // interactions inside AsynchronousWorker must be rescheduled
+                // using Folia.runSyncTask to ensure execution on the main thread.
+                Folia.runAsyncTask(plugin,
+                        (arg) -> new AsynchronousWorker(sender, ct, vlviews, checkTypes,
+                                comparator, n, plugin).run());
             }
         }
         

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/details/BukkitLogNodeDispatcher.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/logging/details/BukkitLogNodeDispatcher.java
@@ -62,8 +62,12 @@ public class BukkitLogNodeDispatcher extends AbstractLogNodeDispatcher {
         synchronized (queueAsynchronous) {
             if (!Folia.isTaskScheduled(taskAsynchronousID)) {
                 // Deadlocking should not be possible.
+                // The asynchronous task only processes queued log records and
+                // must avoid directly invoking Bukkit API methods. Any such
+                // operations must be rescheduled via Folia.runSyncTask.
                 try {
-                    taskAsynchronousID = Folia.runAsyncTask(plugin, (arg) -> taskAsynchronous.run());
+                    taskAsynchronousID =
+                            Folia.runAsyncTask(plugin, (arg) -> taskAsynchronous.run());
                 } catch (IllegalPluginAccessException ex) {
                     // (Should be during onDisable, ignore for now.)
                 }


### PR DESCRIPTION
## Summary
- document that async tasks must return to the main thread
- clarify asynchronous log dispatcher behavior

## Testing
- `mvn -q verify` *(fails: build output truncated)*

------
https://chatgpt.com/codex/tasks/task_b_685ffa0d38588329a3826a51cbde129e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation to clarify main-thread requirements for asynchronous tasks in `TopCommand.java` and `BukkitLogNodeDispatcher.java`.

### Why are these changes being made?

To ensure asynchronous tasks that involve interactions with the Bukkit API are properly rescheduled onto the main thread, as interacting with the API on non-main threads can cause issues. This approach minimizes the risk of deadlocks and ensures stability by adhering to Bukkit's threading mandates.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->