### PR TITLE
Fix redundant interface in LinkedCoordHashMap

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/LinkedCoordHashMap.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ds/map/LinkedCoordHashMap.java
@@ -31,7 +31,7 @@ import java.util.NoSuchElementException;
  *
  * @param <V>
  */
-public class LinkedCoordHashMap<V> extends AbstractCoordHashMap<V, fr.neatmonster.nocheatplus.utilities.ds.map.LinkedCoordHashMap.LinkedHashEntry<V>> implements CoordMap<V> {
+public class LinkedCoordHashMap<V> extends AbstractCoordHashMap<V, fr.neatmonster.nocheatplus.utilities.ds.map.LinkedCoordHashMap.LinkedHashEntry<V>> {
 
     // Add default order for get/put?
     // Tests pending.


### PR DESCRIPTION
## Summary
- remove unnecessary `implements CoordMap` from `LinkedCoordHashMap` to resolve IDE warning

## Testing
- `mvn -B verify`

------
https://chatgpt.com/codex/tasks/task_b_686000b04f848329a9d623acd34801ed

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the redundant `CoordMap<V>` interface implementation from the `LinkedCoordHashMap` class definition.

### Why are these changes being made?

The `CoordMap<V>` interface implementation was unnecessary as `LinkedCoordHashMap` already extends `AbstractCoordHashMap`, which presumably provides the required functionality. This change simplifies the class hierarchy and reduces clutter in the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->