### PR TITLE
Replace DataManager call in AllViolationsHook

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/hooks/allviolations/AllViolationsHook.java
@@ -29,7 +29,6 @@ import fr.neatmonster.nocheatplus.hooks.NCPHook;
 import fr.neatmonster.nocheatplus.hooks.NCPHookManager;
 import fr.neatmonster.nocheatplus.logging.LogManager;
 import fr.neatmonster.nocheatplus.logging.Streams;
-import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.StringUtil;
 
@@ -109,7 +108,8 @@ public class AllViolationsHook implements NCPHook, ILast, IStats {
             // performance and consistency.
             // If debug is not in IViolationInfo, fall back to
             // PlayerData.isDebug(CheckType).
-            final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+            final IPlayerData pData = NCPAPIProvider.getNoCheatPlusAPI()
+                    .getPlayerDataManager().getPlayerData(player);
             if (pData != null) {
                 debugSet = pData.isDebugActive(checkType);
             }


### PR DESCRIPTION
## Summary
- use `NCPAPIProvider` to get player data instead of `DataManager`

## Testing
- `mvn -pl NCPPlugin -am test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_6860045a9a88832997f8518ac3755616