### PR TITLE
Fix deprecated reflection access

### DIFF
--- a/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
+++ b/NCPCommons/src/main/java/fr/neatmonster/nocheatplus/utilities/ReflectionUtil.java
@@ -553,10 +553,24 @@ public class ReflectionUtil {
     }
 
     private static String getSimpleMemberModifierDescription(final Member member) {
-        final boolean accessible = member instanceof AccessibleObject && ((AccessibleObject) member).isAccessible();
         final int mod = member.getModifiers();
-        final String out = Modifier.isPublic(mod) ? "(public" : (accessible ? "(accessible" : "( -");
-        return out + (Modifier.isStatic(mod) ? " static) " : ") ");
+        final StringBuilder out = new StringBuilder();
+        out.append(Modifier.isPublic(mod) ? "(public" : "( -");
+        if (member instanceof AccessibleObject) {
+            AccessibleObject ao = (AccessibleObject) member;
+            boolean accessible = false;
+            try {
+                if (Modifier.isStatic(mod)) {
+                    accessible = ao.canAccess(null);
+                }
+            } catch (RuntimeException ignored) {
+            }
+            if (accessible) {
+                out.append(" accessible");
+            }
+        }
+        out.append(Modifier.isStatic(mod) ? " static) " : ") ");
+        return out.toString();
     }
 
 }

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectHelper.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectHelper.java
@@ -157,7 +157,7 @@ public class ReflectHelper {
                 if (rootField.isAnnotationPresent(MostlyHarmless.class)) {
                     continue;
                 }
-                boolean accessible = rootField.isAccessible();
+                boolean accessible = rootField.canAccess(this);
                 if (!accessible) {
                     rootField.setAccessible(true);
                 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MultiListenerRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/event/mini/MultiListenerRegistry.java
@@ -170,7 +170,7 @@ public abstract class MultiListenerRegistry<EB, P> extends MiniListenerRegistry<
                 listener, method, order, basePriority);
     }
 
-    protected boolean check_and_prepare_method(final Method method) {
+    protected boolean check_and_prepare_method(final Object listener, final Method method) {
         try {
             if (!method.getReturnType().equals(void.class)) {
                 return false;
@@ -183,8 +183,7 @@ public abstract class MultiListenerRegistry<EB, P> extends MiniListenerRegistry<
                 // NOTE: Add a specific log message here.
                 return false;
             }
-            if (!method.isAccessible()) {
-                // NOTE: Can this step be minimized?
+            if (!method.canAccess(listener)) {
                 method.setAccessible(true);
             }
             return true;
@@ -230,7 +229,7 @@ public abstract class MultiListenerRegistry<EB, P> extends MiniListenerRegistry<
         for (Method method : listenerClass.getMethods()) {
             if (shouldBeEventHandler(method)) {
                 MiniListener<? extends EB> miniListener = null;
-                if (check_and_prepare_method(method)) {
+                if (check_and_prepare_method(listener, method)) {
                     miniListener = register(listener, method, 
                             getPriority(method, defaultPriority), order, 
                             getIgnoreCancelled(method, defaultIgnoreCancelled));


### PR DESCRIPTION
## Summary
- remove `isAccessible` usage from `ReflectionUtil`
- update ReflectHelper and MultiListenerRegistry for Java 9+ reflection API

## Testing
- `mvn -DskipITs verify`


------
https://chatgpt.com/codex/tasks/task_b_6860011c4b908329a381809fd9cc2a7b


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
