### PR TITLE
Replace DataManager API usage

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -442,7 +442,10 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
                 if (sender instanceof Player) {
                     // Use the permission caching feature.
                     final Player player = (Player) sender;
-                    final IPlayerData data = DataManager.getInstance().getInstance().getPlayerData(player);
+                    if (player == null) {
+                        continue;
+                    }
+                    final IPlayerData data = NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player);
                     if (data.getNotifyOff() || !data.hasPermission(Permissions.NOTIFY, player)) {
                         continue;
                     }
@@ -1195,7 +1198,10 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
         }
         // Update some moving data for players that logged in while the plugin was disabled.
         for (final Player player : onlinePlayers) {
-            final IPlayerData pData = DataManager.getInstance().getInstance().getPlayerData(player);
+            if (player == null) {
+                continue;
+            }
+            final IPlayerData pData = NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player);
             if (player.isSleeping()) {
                 pData.getGenericInstance(MovingData.class).wasInBed = true;
             }
@@ -1356,7 +1362,8 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
             // Check if login is denied (plus expiration check).
             // Could switch to using player UUIDs and handle AsyncPlayerPreLogin.
             if (checkDenyLoginsNames(player.getName())) {
-                if (DataManager.getInstance().getInstance().getPlayerData(player).hasPermission(Permissions.BYPASS_DENY_LOGIN, player)) {
+                if (player != null && NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager()
+                        .getPlayerData(player).hasPermission(Permissions.BYPASS_DENY_LOGIN, player)) {
                     return;
                 }
                 // An alternative would be to use the built in temporary ban feature and include the remaining duration.
@@ -1419,8 +1426,11 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
     }
 
     private void onJoinLow(final Player player) {
+        if (player == null) {
+            return;
+        }
         final String playerName = player.getName();
-        final IPlayerData data = DataManager.getInstance().getInstance().getPlayerData(player);
+        final IPlayerData data = NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player);
         if (data.hasPermission(Permissions.NOTIFY, player)) { // Updates the cache.
             // Login notifications...
             //            // Update available.


### PR DESCRIPTION
## Summary
- use `NCPAPIProvider` to access player data
- add basic null checks for player instances

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check` *(fails: EI_EXPOSE_REP, RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE, NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE)*

------
https://chatgpt.com/codex/tasks/task_b_686005f73470832985a52b595a8d34a9