### PR TITLE
Clean up NoCheatPlus component handling

### DIFF
--- a/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
+++ b/NCPPlugin/src/main/java/fr/neatmonster/nocheatplus/NoCheatPlus.java
@@ -507,7 +507,6 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
      *            Only registers ComponentRegistry instances if this is set to
      *            true.
      */
-    @SuppressWarnings("unchecked")
     @Override
     public boolean addComponent(final Object obj, final boolean allowComponentRegistry) {
 
@@ -615,18 +614,6 @@ public class NoCheatPlus extends JavaPlugin implements NoCheatPlusAPI {
      * @param obj      the component
      * @return {@code true} if added
      */
-    private boolean invokePlayerDataRegistry(final ComponentRegistry<?> registry, final Object obj) {
-        if (registry instanceof PlayerDataManager pdm) {
-            if (obj instanceof IRemoveData) {
-                return pdm.addComponent((IRemoveData) obj);
-            }
-            return pdm.addComponentReflectively(obj);
-        }
-        if (registry instanceof IPlayerDataManager ipdm && obj instanceof IRemoveData) {
-            return ipdm.addComponent((IRemoveData) obj);
-        }
-        return false;
-    }
 
     private boolean registerComponentRegistry(final Object obj) {
         if (obj instanceof ComponentRegistry<?>) {


### PR DESCRIPTION
## Summary
- remove leftover `@SuppressWarnings` on `addComponent`
- drop unused `invokePlayerDataRegistry` method

## Testing
- `mvn -q test checkstyle:check pmd:check spotbugs:check`

------
https://chatgpt.com/codex/tasks/task_b_6860063e24148329a40085ea07333ee0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove deprecated `invokePlayerDataRegistry` method and unnecessary `@SuppressWarnings("unchecked")` annotation from the NoCheatPlus component handling code.

### Why are these changes being made?

The `invokePlayerDataRegistry` method is no longer used or needed in the codebase, so removing it helps simplify and clean up the code. The `@SuppressWarnings("unchecked")` annotation was found to be redundant and could potentially hide useful compile-time warnings, so its removal enhances code quality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->