### PR TITLE
Modify registry grouping signatures

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockbreak/BlockBreakListener.java
@@ -29,6 +29,7 @@ import org.bukkit.event.player.PlayerAnimationEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
+import java.util.List;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -101,7 +102,7 @@ public class BlockBreakListener extends CheckListener {
                 .factory(arg -> new BlockBreakData(
                         arg.playerData.getGenericInstance(BlockBreakConfig.class)))
                 // (Complete data removal for now.)
-                .addToGroups(CheckType.BLOCKBREAK, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.BLOCKBREAK, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockinteract/BlockInteractListener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import java.util.List;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -117,7 +118,7 @@ public class BlockInteractListener extends CheckListener {
                 // BlockinteractData
                 .registerDataPlayer(BlockInteractData.class)
                 .factory(arg -> new BlockInteractData())
-                .addToGroups(CheckType.BLOCKINTERACT, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.BLOCKINTERACT, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/blockplace/BlockPlaceListener.java
@@ -145,7 +145,7 @@ public class BlockPlaceListener extends CheckListener {
                 // BlockPlaceData
                 .registerDataPlayer(BlockPlaceData.class)
                 .factory(arg -> new BlockPlaceData())
-                .addToGroups(CheckType.BLOCKPLACE, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.BLOCKPLACE, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/chat/ChatListener.java
@@ -99,7 +99,7 @@ public class ChatListener extends CheckListener implements INotifyReload, JoinLe
                 .context() //
                 .registerDataPlayer(ChatData.class)
                 .factory(arg -> new ChatData())
-                .addToGroups(CheckType.CHAT, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.CHAT, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/combined/CombinedListener.java
@@ -28,6 +28,7 @@ import org.bukkit.event.player.PlayerToggleSprintEvent;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
+import java.util.List;
 import fr.neatmonster.nocheatplus.components.NoCheatPlusAPI;
 import fr.neatmonster.nocheatplus.components.data.ICheckData;
 import fr.neatmonster.nocheatplus.components.data.IData;
@@ -66,7 +67,7 @@ public class CombinedListener extends CheckListener {
                 // CombinedData
                 .registerDataPlayer(CombinedData.class)
                 .factory(arg -> new CombinedData())
-                .addToGroups(CheckType.MOVING, false, IData.class, ICheckData.class)
+                .addToGroups(CheckType.MOVING, false, List.of(IData.class, ICheckData.class))
                 .removeSubCheckData(CheckType.COMBINED, true)
                 .context() //
                 );

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/fight/FightListener.java
@@ -32,6 +32,7 @@ import org.bukkit.event.player.PlayerAnimationEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
+import java.util.List;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -142,7 +143,7 @@ public class FightListener extends CheckListener implements JoinLeaveListener{
                 // FightData
                 .registerDataPlayer(FightData.class)
                 .factory(arg -> new FightData(arg.playerData.getGenericInstance(FightConfig.class)))
-                .addToGroups(CheckType.FIGHT, false, IData.class, ICheckData.class)
+                .addToGroups(CheckType.FIGHT, false, List.of(IData.class, ICheckData.class))
                 .removeSubCheckData(CheckType.FIGHT, true)
                 .context() //
                 );

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/InventoryListener.java
@@ -50,6 +50,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import java.util.List;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckListener;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -130,7 +131,7 @@ public class InventoryListener  extends CheckListener implements JoinLeaveListen
                 // InventoryData
                 .registerDataPlayer(InventoryData.class)
                 .factory(arg -> new InventoryData())
-                .addToGroups(CheckType.INVENTORY, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.INVENTORY, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
         // Move to BridgeMisc?

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -239,7 +239,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 .registerDataPlayer(MovingData.class)
                 .factory(arg -> new MovingData(arg.worldData.getGenericInstance(
                         MovingConfig.class), arg.playerData))
-                .addToGroups(CheckType.MOVING, false, IData.class, ICheckData.class)
+                .addToGroups(CheckType.MOVING, false, List.of(IData.class, ICheckData.class))
                 .removeSubCheckData(CheckType.MOVING, true)
                 .context() //
                 );

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/net/NetStatic.java
@@ -218,7 +218,7 @@ public class NetStatic {
                 // NetData
                 .registerDataPlayer(NetData.class)
                 .factory(arg -> new NetData(arg.playerData.getGenericInstance(NetConfig.class)))
-                .addToGroups(CheckType.NET, true, IData.class, ICheckData.class)
+                .addToGroups(CheckType.NET, true, List.of(IData.class, ICheckData.class))
                 .context() //
                 );
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/RichFactoryRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/factory/RichFactoryRegistry.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.components.registry.factory;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import fr.neatmonster.nocheatplus.checks.CheckType;
@@ -100,7 +101,7 @@ public class RichFactoryRegistry<A> extends RichTypeSetRegistry implements IRich
             factoryRegistry.registerFactory(registerFor, factory);
             for (final Class<?> groupType: autoGroups) {
                 if (groupType.isAssignableFrom(registerFor)) {
-                    addToGroups(registerFor, (Class<? super T>) groupType);
+                    addToGroups(registerFor, List.of((Class<? super T>) groupType));
                 }
             }
         } finally {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/IRichTypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/IRichTypeSetRegistry.java
@@ -58,8 +58,8 @@ public interface IRichTypeSetRegistry {
      * @param itemType
      * @param groupTypes
      */
-    public <I> void addToGroups(Class<I> itemType, 
-            Class<? super I>... groupTypes);
+    public <I> void addToGroups(Class<I> itemType,
+            Collection<Class<? super I>> groupTypes);
 
     /**
      * Register the itemType for all applicable group types that already have
@@ -84,8 +84,8 @@ public interface IRichTypeSetRegistry {
      * @param itemType
      * @param groupTypes
      */
-    public <I> void addToGroups(CheckType checkType, 
-            Class<I> itemType, Class<? super I>... groupTypes);
+    public <I> void addToGroups(CheckType checkType,
+            Class<I> itemType, Collection<Class<? super I>> groupTypes);
 
     /**
      * Register the itemType for all applicable group types that already have
@@ -115,8 +115,8 @@ public interface IRichTypeSetRegistry {
      * @param itemType
      * @param groupTypes
      */
-    public <I> void addToGroups(Collection<CheckType> checkTypes, 
-            Class<I> itemType, Class<? super I>... groupTypes);
+    public <I> void addToGroups(Collection<CheckType> checkTypes,
+            Class<I> itemType, Collection<Class<? super I>> groupTypes);
 
     /**
      * Register the itemType for all applicable group types that already have

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/RichTypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/RichTypeSetRegistry.java
@@ -62,7 +62,7 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
 
     @Override
     public <I> void addToGroups(final Class<I> itemType,
-            final Class<? super I>... groupTypes) {
+            final Collection<Class<? super I>> groupTypes) {
         lock.lock();
         try {
             for (final Class<? super I> groupType : groupTypes) {
@@ -76,7 +76,7 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
 
     @Override
     public <I> void addToGroups(CheckType checkType, Class<I> itemType,
-            Class<? super I>... groupTypes) {
+            Collection<Class<? super I>> groupTypes) {
         lock.lock();
         try {
             for (final Class<? super I> groupType : groupTypes) {
@@ -138,7 +138,7 @@ public class RichTypeSetRegistry implements IRichTypeSetRegistry {
 
     @Override
     public <I> void addToGroups(final Collection<CheckType> checkTypes,
-            final Class<I> itemType, final Class<? super I>... groupTypes) {
+            final Class<I> itemType, final Collection<Class<? super I>> groupTypes) {
         lock.lock();
         try {
             for (final CheckType checkType : checkTypes) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/TypeSetRegistry.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/meta/TypeSetRegistry.java
@@ -97,7 +97,7 @@ public class TypeSetRegistry {
      * @param itemType
      * @param groupTypes
      */
-    public <I> void addToGroups(final Class<I> itemType, final Class<? super I>... groupTypes) {
+    public <I> void addToGroups(final Class<I> itemType, final Collection<Class<? super I>> groupTypes) {
         lock.lock();
         try {
             for (final Class<? super I> groupType : groupTypes) {

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/config/RegisterConfigWorld.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/config/RegisterConfigWorld.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.components.registry.setup.config;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.components.config.IConfig;
+import java.util.Collection;
 import fr.neatmonster.nocheatplus.components.registry.factory.IFactoryOne;
 import fr.neatmonster.nocheatplus.components.registry.setup.RegistrationContext;
 import fr.neatmonster.nocheatplus.components.registry.setup.instance.RegisterInstanceWorld;
@@ -54,7 +55,7 @@ public class RegisterConfigWorld<T extends IConfig> extends RegisterInstanceWorl
     @Override
     public RegisterConfigWorld<T> addToGroups(
             final CheckType checkType, final boolean withDescendantCheckTypes,
-            final Class<? super T>... groupTypes) {
+            final Collection<Class<? super T>> groupTypes) {
         super.addToGroups(checkType, withDescendantCheckTypes, groupTypes);
         return this;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/data/RegisterDataPlayer.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/data/RegisterDataPlayer.java
@@ -16,6 +16,7 @@ package fr.neatmonster.nocheatplus.components.registry.setup.data;
 
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.components.data.IData;
+import java.util.Collection;
 import fr.neatmonster.nocheatplus.components.registry.factory.IFactoryOne;
 import fr.neatmonster.nocheatplus.components.registry.setup.RegistrationContext;
 import fr.neatmonster.nocheatplus.components.registry.setup.instance.RegisterInstancePlayer;
@@ -38,7 +39,7 @@ public class RegisterDataPlayer<T extends IData> extends RegisterInstancePlayer<
     @Override
     public RegisterDataPlayer<T> addToGroups(
             final CheckType checkType, final boolean withDescendantCheckTypes,
-            final Class<? super T>... groupTypes) {
+            final Collection<Class<? super T>> groupTypes) {
         super.addToGroups(checkType, withDescendantCheckTypes, groupTypes);
         return this;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/data/RegisterDataWorld.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/data/RegisterDataWorld.java
@@ -17,6 +17,7 @@ package fr.neatmonster.nocheatplus.components.registry.setup.data;
 import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.checks.CheckType;
 import fr.neatmonster.nocheatplus.components.data.IData;
+import java.util.Collection;
 import fr.neatmonster.nocheatplus.components.registry.factory.IFactoryOne;
 import fr.neatmonster.nocheatplus.components.registry.setup.RegistrationContext;
 import fr.neatmonster.nocheatplus.components.registry.setup.instance.RegisterInstanceWorld;
@@ -48,7 +49,7 @@ public class RegisterDataWorld<T extends IData> extends RegisterInstanceWorld<T>
     @Override
     public RegisterDataWorld<T> addToGroups(
             final CheckType checkType, final boolean withDescendantCheckTypes,
-            final Class<? super T>... groupTypes) {
+            final Collection<Class<? super T>> groupTypes) {
         super.addToGroups(checkType, withDescendantCheckTypes, groupTypes);
         return this;
     }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/instance/RegisterInstance.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/components/registry/setup/instance/RegisterInstance.java
@@ -114,9 +114,9 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
      * @param groupTypes
      * @return
      */
-    public RegisterInstance<T,A> addToGroups(final CheckType checkType, 
-            final boolean withDescendantCheckTypes, 
-            final Class<? super T>... groupTypes) {
+    public RegisterInstance<T,A> addToGroups(final CheckType checkType,
+            final boolean withDescendantCheckTypes,
+            final Collection<Class<? super T>> groupTypes) {
         items.add(() -> {
             if (withDescendantCheckTypes) {
                 factoryRegistry.addToGroups(
@@ -168,12 +168,12 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
         if (IConfig.class.isAssignableFrom(type)) {
             genericConfigItems.add(factoryRegistry -> factoryRegistry.addToGroups(checkTypes,
                     (Class<? extends IConfig>) type,
-                    IConfig.class));
+                    List.of(IConfig.class)));
         }
         if (ICheckConfig.class.isAssignableFrom(type)) {
             genericConfigItems.add(factoryRegistry -> factoryRegistry.addToGroups(checkTypes,
                     (Class<? extends ICheckConfig>) type,
-                    ICheckConfig.class));
+                    List.of(ICheckConfig.class)));
         }
         return this;
     }
@@ -216,12 +216,12 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
         if (IData.class.isAssignableFrom(type)) {
             genericConfigItems.add(factoryRegistry -> factoryRegistry.addToGroups(checkTypes,
                     (Class<? extends IData>) type,
-                    IData.class));
+                    List.of(IData.class)));
         }
         if (ICheckData.class.isAssignableFrom(type)) {
             genericConfigItems.add(factoryRegistry -> factoryRegistry.addToGroups(checkTypes,
                     (Class<? extends ICheckData>) type,
-                    ICheckData.class));
+                    List.of(ICheckData.class)));
         }
         return this;
     }
@@ -243,7 +243,7 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
                 : Collections.singletonList(checkType);
         items.add(() -> factoryRegistry.addToGroups(checkTypes,
                 (Class<? extends IDataOnRemoveSubCheckData>) type,
-                IDataOnRemoveSubCheckData.class));
+                List.of(IDataOnRemoveSubCheckData.class)));
         return this;
     }
 
@@ -283,10 +283,10 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
     @SuppressWarnings("unchecked")
     protected void registerConfigTypesPlayer(final IPlayerDataManager pdMan) {
         if (IConfig.class.isAssignableFrom(type)) {
-            pdMan.addToGroups((Class<? extends IConfig>) type, IConfig.class);
+            pdMan.addToGroups((Class<? extends IConfig>) type, List.of(IConfig.class));
         }
         if (ICheckConfig.class.isAssignableFrom(type)) {
-            pdMan.addToGroups((Class<? extends ICheckConfig>) type, ICheckConfig.class);
+            pdMan.addToGroups((Class<? extends ICheckConfig>) type, List.of(ICheckConfig.class));
         }
         for (final IDoRegisterWithRegistry item : genericConfigItems) {
             item.doRegister(pdMan);
@@ -296,10 +296,10 @@ public abstract class RegisterInstance<T, A> implements IDoRegister {
     @SuppressWarnings("unchecked")
     protected void registerDataTypesPlayer(final IPlayerDataManager pdMan) {
         if (IData.class.isAssignableFrom(type)) {
-            pdMan.addToGroups((Class<? extends IData>) type, IData.class);
+            pdMan.addToGroups((Class<? extends IData>) type, List.of(IData.class));
         }
         if (ICheckData.class.isAssignableFrom(type)) {
-            pdMan.addToGroups((Class<? extends ICheckData>) type, ICheckData.class);
+            pdMan.addToGroups((Class<? extends ICheckData>) type, List.of(ICheckData.class));
         }
         for (final IDoRegisterWithRegistry item : genericDataItems) {
             item.doRegister(pdMan);

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/players/PlayerDataManager.java
@@ -1195,14 +1195,14 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
     }
 
     @Override
-    public <I> void addToGroups(final Class<I> itemType, 
-            final Class<? super I>... groupTypes) {
+    public <I> void addToGroups(final Class<I> itemType,
+            final Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(itemType, groupTypes);
     }
 
     @Override
     public <I> void addToGroups(CheckType checkType, Class<I> itemType,
-            Class<? super I>... groupTypes) {
+            Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(checkType, itemType, groupTypes);
     }
 
@@ -1229,7 +1229,7 @@ public class PlayerDataManager  implements IPlayerDataManager, ComponentWithName
 
     @Override
     public <I> void addToGroups(final Collection<CheckType> checkTypes,
-            final Class<I> itemType, final Class<? super I>... groupTypes) {
+            final Class<I> itemType, final Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(checkTypes, itemType, groupTypes);
     }
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/WorldDataManager.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/worlds/WorldDataManager.java
@@ -428,7 +428,7 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
 
     @Override
     public <I> void addToGroups(Class<I> itemType,
-            Class<? super I>... groupTypes) {
+            Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(itemType, groupTypes);
     }
 
@@ -439,7 +439,7 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
 
     @Override
     public <I> void addToGroups(CheckType checkType, Class<I> itemType,
-            Class<? super I>... groupTypes) {
+            Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(checkType, itemType, groupTypes);
     }
 
@@ -451,7 +451,7 @@ public class WorldDataManager implements IWorldDataManager, INotifyReload {
 
     @Override
     public <I> void addToGroups(Collection<CheckType> checkTypes,
-            Class<I> itemType, Class<? super I>... groupTypes) {
+            Class<I> itemType, Collection<Class<? super I>> groupTypes) {
         factoryRegistry.addToGroups(checkTypes, itemType, groupTypes);
     }
 


### PR DESCRIPTION
## Summary
- change IRichTypeSetRegistry to take `Collection<Class<?>>` in addToGroups
- adjust registry implementations for the new parameter
- update registration helpers and listeners to pass `List.of(...)`
- update RichFactoryRegistry to use list for auto groups

## Testing
- `mvn -q verify` *(fails: spotbugs medium warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68600ac9a2688329aee838866ee944bb

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the `addToGroups` method signatures to replace varargs with `Collection` types across multiple classes, and update corresponding method calls in the codebase.

### Why are these changes being made?

This refactoring improves type safety and allows for more flexible handling of group types by using `Collection` instead of varargs, which is particularly advantageous for modern Java applications and leads to cleaner, more maintainable code. This approach removes ambiguity associated with varargs, and provides better compatibility with methods that naturally return `Collection` objects.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal methods to use collections instead of variable arguments for group registrations, improving consistency and maintainability.

* **Documentation**
  * Updated method signatures in public interfaces and classes to reflect the new use of collections for group registrations. This may affect developers who interact with advanced configuration or extendability features. No changes to end-user visible features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->