### PR TITLE
Fix unsafe cast in block move check

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -2639,17 +2639,24 @@ public class SurvivalFly extends Check {
             // Push by 0.49-0.51 in one direction. Also observed 1.02.
             final double xDistance = to.getX() - from.getX();
             final double zDistance = to.getZ() - from.getZ();
-            if (Math.abs(xDistance) > 0.485 && Math.abs(xDistance) < 1.025
-                && from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef,
-                        xDistance < 0 ? Direction.X_NEG : Direction.X_POS, 0.05)) {
-                hAllowedDistance = thisMove.hDistance; // MAGIC
-                hDistanceAboveLimit = 0.0;
+
+            final IBlockChangeTracker tracker = blockChangeTracker;
+
+            if (Math.abs(xDistance) > 0.485 && Math.abs(xDistance) < 1.025) {
+                if (tracker instanceof BlockChangeTracker mutableTracker
+                        && from.matchBlockChange(mutableTracker, data.blockChangeRef,
+                                xDistance < 0 ? Direction.X_NEG : Direction.X_POS, 0.05)) {
+                    hAllowedDistance = thisMove.hDistance; // MAGIC
+                    hDistanceAboveLimit = 0.0;
+                }
             }
-            else if (Math.abs(zDistance) > 0.485 && Math.abs(zDistance) < 1.025
-                    && from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef,
-                        zDistance < 0 ? Direction.Z_NEG : Direction.Z_POS, 0.05)) {
-                hAllowedDistance = thisMove.hDistance; // MAGIC
-                hDistanceAboveLimit = 0.0;
+            else if (Math.abs(zDistance) > 0.485 && Math.abs(zDistance) < 1.025) {
+                if (tracker instanceof BlockChangeTracker mutableTracker
+                        && from.matchBlockChange(mutableTracker, data.blockChangeRef,
+                                zDistance < 0 ? Direction.Z_NEG : Direction.Z_POS, 0.05)) {
+                    hAllowedDistance = thisMove.hDistance; // MAGIC
+                    hDistanceAboveLimit = 0.0;
+                }
             }
         }
         return new double[]{hAllowedDistance, hDistanceAboveLimit};


### PR DESCRIPTION
## Summary
- prevent ClassCastException in block move detection by verifying tracker type

## Testing
- `mvn -DskipTests=false verify`

------
https://chatgpt.com/codex/tasks/task_b_686047a62bd083299d5cd3eef00fbd3f

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace unsafe cast with a safer instance check using the `instanceof` operator in `SurvivalFly.java`.

### Why are these changes being made?

The previous implementation used an unsafe cast that could lead to a `ClassCastException`. Using `instanceof` provides a safer way to ensure that the object is of the correct type before casting, hence improving the code's robustness and preventing potential runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of block movement checks for better reliability and safety. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->