### PR TITLE
Fix deprecated DataManager usages

### DIFF
--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/FastConsume.java
@@ -31,7 +31,6 @@ import fr.neatmonster.nocheatplus.compat.BridgeHealth;
 import fr.neatmonster.nocheatplus.components.config.value.OverrideType;
 import fr.neatmonster.nocheatplus.components.registry.feature.INotifyReload;
 import fr.neatmonster.nocheatplus.logging.StaticLog;
-import fr.neatmonster.nocheatplus.players.DataManager;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.stats.Counters;
 import fr.neatmonster.nocheatplus.utilities.InventoryUtil;
@@ -78,7 +77,7 @@ public class FastConsume extends Check implements Listener, INotifyReload {
             counters.addPrimaryThread(idCancelDead, 1);
             return;
         }
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player);
         if (!pData.isCheckActive(type, player)) {
             return;
         }
@@ -86,7 +85,7 @@ public class FastConsume extends Check implements Listener, INotifyReload {
         final long time = System.currentTimeMillis();
         if (check(player, event.getItem(), time, data, pData)){
             event.setCancelled(true);
-            DataManager.getInstance().getPlayerData(player).requestUpdateInventory();
+            NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player).requestUpdateInventory();
         }
     }
 

--- a/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/Gutenberg.java
+++ b/NCPCompatBukkit/src/main/java/fr/neatmonster/nocheatplus/checks/inventory/Gutenberg.java
@@ -23,7 +23,7 @@ import org.bukkit.inventory.meta.BookMeta;
 
 import fr.neatmonster.nocheatplus.checks.Check;
 import fr.neatmonster.nocheatplus.checks.CheckType;
-import fr.neatmonster.nocheatplus.players.DataManager;
+import fr.neatmonster.nocheatplus.NCPAPIProvider;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 
 public class Gutenberg extends Check implements Listener {
@@ -44,7 +44,7 @@ public class Gutenberg extends Check implements Listener {
         if (!isEnabled(player)) {
             return;
         }
-        final IPlayerData pData = DataManager.getInstance().getPlayerData(player);
+        final IPlayerData pData = NCPAPIProvider.getNoCheatPlusAPI().getPlayerDataManager().getPlayerData(player);
         final InventoryConfig cc = pData.getGenericInstance(InventoryConfig.class);
         final InventoryData data = pData.getGenericInstance(InventoryData.class);
         final BookMeta newMeta = event.getNewBookMeta();


### PR DESCRIPTION
## Summary
- replace DataManager.getInstance calls in FastConsume and Gutenberg checks
- import NCPAPIProvider instead of DataManager

## Testing
- `mvn -B verify`


------
https://chatgpt.com/codex/tasks/task_b_68604a71c8b0832993ce691d4a88843d

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace deprecated `DataManager` usages with the updated `NCPAPIProvider` interface to retrieve `IPlayerData`.

### Why are these changes being made?

`DataManager` has become deprecated and is planned for removal in future updates, necessitating the shift to `NCPAPIProvider` for accessing player data management. These changes ensure the code is using the current API standards and remains functional in upcoming software versions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->