### PR TITLE
Refactor block change tracker usage

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/MovingListener.java
@@ -1251,7 +1251,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                 }
                 if (verticalBounce == BounceType.NO_BOUNCE && useBlockChangeTracker && BounceUtil
                         .checkPastStateBounceDescend(player, pFrom, pTo, thisMove, lastMove, tick, data, cc,
-                                (BlockChangeTracker) blockChangeTracker) != BounceType.NO_BOUNCE) {
+                                blockChangeTracker) != BounceType.NO_BOUNCE) {
                     checkNf = false;
                 }
             }
@@ -1260,7 +1260,7 @@ public class MovingListener extends CheckListener implements TickListener, IRemo
                     && BounceUtil.onPreparedBounceSupport(player, from, to, thisMove, lastMove, tick, data))
                     || useBlockChangeTracker && thisMove.yDistance <= 1.515) {
                 verticalBounce = BounceUtil.checkPastStateBounceAscend(player, pFrom, pTo, thisMove, lastMove, tick,
-                        pData, this, data, cc, (BlockChangeTracker) blockChangeTracker);
+                        pData, this, data, cc, blockChangeTracker);
                 if (verticalBounce != BounceType.NO_BOUNCE) {
                     checkNf = false;
                 }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGround.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGround.java
@@ -29,6 +29,7 @@ import fr.neatmonster.nocheatplus.checks.moving.util.MovingUtil;
 import fr.neatmonster.nocheatplus.compat.Bridge1_17;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.utilities.TickTask;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
@@ -60,8 +61,8 @@ public class LostGround {
      */
     public static boolean lostGround(final Player player, final PlayerLocation from, final PlayerLocation to, 
                                      final double hDistance, final double yDistance, final boolean sprinting, 
-                                     final PlayerMoveData lastMove, final MovingData data, final MovingConfig cc, 
-                                     final BlockChangeTracker blockChangeTracker, final Collection<String> tags) {
+                                     final PlayerMoveData lastMove, final MovingData data, final MovingConfig cc,
+                                     final IBlockChangeTracker blockChangeTracker, final Collection<String> tags) {
         // Consider regrouping conditions with toOnGround first.
         // Some workarounds allow step height (0.6 on MC 1.8).
         // The current yDistance limit might not be appropriate.
@@ -104,8 +105,8 @@ public class LostGround {
     }
 
 
-    private static boolean lostGroundPastState(final Player player, final PlayerLocation from, final PlayerLocation to, 
-                                               final MovingData data, final MovingConfig cc, final BlockChangeTracker blockChangeTracker, 
+    private static boolean lostGroundPastState(final Player player, final PlayerLocation from, final PlayerLocation to,
+                                               final MovingData data, final MovingConfig cc, final IBlockChangeTracker blockChangeTracker,
                                                final Collection<String> tags) {
         // Requires additional heuristics.
         // Consider performing a full y-move at from-xz.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGroundVehicle.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/magic/LostGroundVehicle.java
@@ -26,7 +26,7 @@ import fr.neatmonster.nocheatplus.checks.moving.model.PlayerMoveData;
 import fr.neatmonster.nocheatplus.checks.moving.model.VehicleMoveData;
 import fr.neatmonster.nocheatplus.checks.moving.player.Passable;
 import fr.neatmonster.nocheatplus.compat.MCAccess;
-import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.utilities.location.RichEntityLocation;
 import fr.neatmonster.nocheatplus.utilities.map.BlockCache;
 import fr.neatmonster.nocheatplus.utilities.map.BlockProperties;
@@ -55,7 +55,7 @@ public class LostGroundVehicle {
     public static boolean lostGround(final Entity vehicle, final RichEntityLocation from, final RichEntityLocation to,
             final double hDistance, final double yDistance, final boolean sprinting,
             final VehicleMoveData lastMove, final MovingData data, final MovingConfig cc,
-            final BlockChangeTracker blockChangeTracker, final Collection<String> tags) {
+            final IBlockChangeTracker blockChangeTracker, final Collection<String> tags) {
 
 
 

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/CreativeFly.java
@@ -46,7 +46,6 @@ import fr.neatmonster.nocheatplus.compat.Bridge1_13;
 import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.compat.BridgeEnchant;
 import fr.neatmonster.nocheatplus.compat.BridgeMisc;
-import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.components.modifier.IAttributeAccess;
 import fr.neatmonster.nocheatplus.components.registry.event.IGenericInstanceHandle;
@@ -247,7 +246,7 @@ public class CreativeFly extends Check {
                 }
             } else if (LostGround.lostGround(player, from, to, hDistance, yDistance, sprinting,
                     lastMove, data, cc,
-                    useBlockChangeTracker ? (BlockChangeTracker) blockChangeTracker : null, tags)) {
+                    useBlockChangeTracker ? blockChangeTracker : null, tags)) {
                 return true;
             }
         }

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/player/SurvivalFly.java
@@ -209,7 +209,7 @@ public class SurvivalFly extends Check {
         }
         if (isSamePos) {
             if (useBlockChangeTracker && from.isOnGroundOpportune(cc.yOnGround, 0L,
-                    (BlockChangeTracker) blockChangeTracker, data.blockChangeRef, tick)) {
+                    blockChangeTracker, data.blockChangeRef, tick)) {
                 tags.add("pastground_from");
                 return true;
             }
@@ -221,7 +221,7 @@ public class SurvivalFly extends Check {
         }
         return LostGround.lostGround(player, from, to, hDistance, yDistance, sprinting,
                 lastMove, data, cc,
-                useBlockChangeTracker ? (BlockChangeTracker) blockChangeTracker : null, tags);
+                useBlockChangeTracker ? blockChangeTracker : null, tags);
     }
 
     /** Validate player movement parameters and log if invalid. */
@@ -891,7 +891,7 @@ public class SurvivalFly extends Check {
                                          final PlayerMoveData thisMove, int tick,
                                          final MovingData data, final MovingConfig cc) {
 
-        if (to.isOnGroundOpportune(cc.yOnGround, 0L, (BlockChangeTracker) blockChangeTracker, data.blockChangeRef, tick)) {
+        if (to.isOnGroundOpportune(cc.yOnGround, 0L, blockChangeTracker, data.blockChangeRef, tick)) {
             tags.add("pastground_to");
             return true;
         }
@@ -1266,7 +1266,7 @@ public class SurvivalFly extends Check {
                  * (Full blocks: slightly more possible, ending up just above
                  * the block. Bounce allows other end positions.)
                  */
-                if (from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef, Direction.Y_POS, Math.min(yDistance, 1.0))) {
+                if (from.matchBlockChange(blockChangeTracker, data.blockChangeRef, Direction.Y_POS, Math.min(yDistance, 1.0))) {
                     if (yDistance > 1.0) {
                         //
                         //                        final BlockChangeEntry entry = blockChangeTracker.getBlockChangeEntryMatchFlags(data.blockChangeRef,
@@ -1309,7 +1309,7 @@ public class SurvivalFly extends Check {
         }
         // Push (/pull) down.
         else if (yDistance < 0.0 && yDistance >= -1.0) {
-            if (from.matchBlockChange((BlockChangeTracker) blockChangeTracker, data.blockChangeRef, Direction.Y_NEG, -yDistance)) {
+            if (from.matchBlockChange(blockChangeTracker, data.blockChangeRef, Direction.Y_NEG, -yDistance)) {
                 tags.add("blkmv_y_neg");
                 final double maxDistYNeg = yDistance; // from.getY() - from.getBlockY();
                 return new double[]{maxDistYNeg, 0.0};
@@ -2643,16 +2643,14 @@ public class SurvivalFly extends Check {
             final IBlockChangeTracker tracker = blockChangeTracker;
 
             if (Math.abs(xDistance) > 0.485 && Math.abs(xDistance) < 1.025) {
-                if (tracker instanceof BlockChangeTracker mutableTracker
-                        && from.matchBlockChange(mutableTracker, data.blockChangeRef,
+                if (from.matchBlockChange(tracker, data.blockChangeRef,
                                 xDistance < 0 ? Direction.X_NEG : Direction.X_POS, 0.05)) {
                     hAllowedDistance = thisMove.hDistance; // MAGIC
                     hDistanceAboveLimit = 0.0;
                 }
             }
             else if (Math.abs(zDistance) > 0.485 && Math.abs(zDistance) < 1.025) {
-                if (tracker instanceof BlockChangeTracker mutableTracker
-                        && from.matchBlockChange(mutableTracker, data.blockChangeRef,
+                if (from.matchBlockChange(tracker, data.blockChangeRef,
                                 zDistance < 0 ? Direction.Z_NEG : Direction.Z_POS, 0.05)) {
                     hAllowedDistance = thisMove.hDistance; // MAGIC
                     hDistanceAboveLimit = 0.0;

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/bounce/BounceUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/checks/moving/util/bounce/BounceUtil.java
@@ -28,6 +28,7 @@ import fr.neatmonster.nocheatplus.checks.moving.velocity.VelocityFlags;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.Direction;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.components.debug.IDebugPlayer;
 import fr.neatmonster.nocheatplus.players.IPlayerData;
 import fr.neatmonster.nocheatplus.utilities.location.PlayerLocation;
@@ -143,8 +144,8 @@ public class BounceUtil {
      * @return
      */
     public static BounceType checkPastStateBounceDescend(final Player player, final PlayerLocation from, final PlayerLocation to,
-                                                         final PlayerMoveData thisMove, final PlayerMoveData lastMove, final int tick, 
-                                                         final MovingData data, final MovingConfig cc, BlockChangeTracker blockChangeTracker) {
+                                                         final PlayerMoveData thisMove, final PlayerMoveData lastMove, final int tick,
+                                                         final MovingData data, final MovingConfig cc, IBlockChangeTracker blockChangeTracker) {
 
         // Additional preconditions may be required here.
         // It might later be necessary to override or adapt only the bounce effect set by the ordinary method.
@@ -185,8 +186,8 @@ public class BounceUtil {
      * @return
      */
     public static BounceType checkPastStateBounceAscend(final Player player, final PlayerLocation from, final PlayerLocation to,
-                                                        final PlayerMoveData thisMove, final PlayerMoveData lastMove, final int tick, final IPlayerData pData, 
-                                                        final IDebugPlayer idp, final MovingData data, final MovingConfig cc, BlockChangeTracker blockChangeTracker) {
+                                                        final PlayerMoveData thisMove, final PlayerMoveData lastMove, final int tick, final IPlayerData pData,
+                                                        final IDebugPlayer idp, final MovingData data, final MovingConfig cc, IBlockChangeTracker blockChangeTracker) {
 
         // More preconditions might be needed.
         // Side conditions for larger jumps should be determined more precisely if possible.

--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/location/RichBoundsLocation.java
@@ -26,6 +26,7 @@ import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeReferen
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.BlockChangeEntry;
 import fr.neatmonster.nocheatplus.compat.blocks.changetracker.BlockChangeTracker.Direction;
+import fr.neatmonster.nocheatplus.compat.blocks.changetracker.IBlockChangeTracker;
 import fr.neatmonster.nocheatplus.compat.Bridge1_9;
 import fr.neatmonster.nocheatplus.components.location.IGetBox3D;
 import fr.neatmonster.nocheatplus.components.location.IGetBlockPosition;
@@ -1225,7 +1226,7 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
      */
     public final boolean isOnGroundOpportune(
             final double yOnGround, final long ignoreFlags,
-            final BlockChangeTracker blockChangeTracker, final BlockChangeReference blockChangeRef,
+            final IBlockChangeTracker blockChangeTracker, final BlockChangeReference blockChangeRef,
             final int tick) {
         // Consider updating the onGround+distance cache.
         return blockChangeTracker.isOnGround(blockCache, blockChangeRef, tick, world.getUID(), 
@@ -1402,7 +1403,7 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
      *            The (always positive) distance to cover.
      * @return Returns true, iff an entry was found.
      */
-    public boolean matchBlockChange(final BlockChangeTracker blockChangeTracker, final BlockChangeReference ref, 
+    public boolean matchBlockChange(final IBlockChangeTracker blockChangeTracker, final BlockChangeReference ref,
                                     final Direction direction, final double coverDistance) {
         final int tick = TickTask.getTick();
         final UUID worldId = world.getUID();
@@ -1460,8 +1461,8 @@ public class RichBoundsLocation implements IGetBukkitLocation, IGetBlockPosition
      *            matchFlags. If matchFlags is zero, the parameter is ignored.
      * @return Returns true, iff an entry was found.
      */
-    public boolean matchBlockChangeMatchResultingFlags(final BlockChangeTracker blockChangeTracker, 
-            final BlockChangeReference ref, final Direction direction, final double coverDistance, 
+    public boolean matchBlockChangeMatchResultingFlags(final IBlockChangeTracker blockChangeTracker,
+            final BlockChangeReference ref, final Direction direction, final double coverDistance,
             final long matchFlags) {
         /*
          * Not sure with code duplication. Is it better to run


### PR DESCRIPTION
## Summary
- update `RichBoundsLocation` to accept `IBlockChangeTracker`
- use interface type in calls across movement checks
- remove unnecessary casts

## Testing
- `mvn -q -DskipTests=false checkstyle:check pmd:check spotbugs:check test` *(fails: missing BUILD SUCCESS in logs)*

------
https://chatgpt.com/codex/tasks/task_b_68604aae380c832994458bd40c5b5af0

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the usage of `BlockChangeTracker` by replacing it with its interface `IBlockChangeTracker` throughout various classes to improve code flexibility and maintainability.

### Why are these changes being made?

This refactoring is being made to adhere to better software design principles by utilizing interfaces for flexibility, potentially allowing different implementations of block change tracking without modifying existing core logic, thus adhering to an interface-based design pattern. This change improves codebase scalability and maintainability and addresses the unnecessary use of explicit casting, which enhances code readability and reduces the risk of potential runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->