### PR TITLE
Refactor tests to JUnit 5

### DIFF
--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestBukkitAttributeAccess.java
@@ -1,16 +1,21 @@
 package fr.neatmonster.nocheatplus.compat.bukkit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 import java.util.Collections;
 
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 public class TestBukkitAttributeAccess {
 
@@ -19,11 +24,17 @@ public class TestBukkitAttributeAccess {
         // Get instance via factory method.
         BukkitAttributeAccess access = BukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            doReturn(null).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -31,11 +42,17 @@ public class TestBukkitAttributeAccess {
         // Get instance via factory method.
         BukkitAttributeAccess access = BukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            doReturn(null).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -43,15 +60,21 @@ public class TestBukkitAttributeAccess {
         // Get instance via factory method.
         BukkitAttributeAccess access = BukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        AttributeInstance inst = mock(AttributeInstance.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(inst);
-        when(inst.getValue()).thenReturn(0.1);
-        when(inst.getBaseValue()).thenReturn(0.1);
-        when(inst.getModifiers()).thenReturn(Collections.emptySet());
-        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
-        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            AttributeInstance inst = mock(AttributeInstance.class);
+            doReturn(inst).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            when(inst.getValue()).thenReturn(0.1);
+            when(inst.getBaseValue()).thenReturn(0.1);
+            when(inst.getModifiers()).thenReturn(Collections.emptySet());
+            assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+            assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestEntityAccessVehicleMultiPassenger.java
@@ -1,14 +1,14 @@
 package fr.neatmonster.nocheatplus.compat.bukkit;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mockStatic;
 
 import java.lang.reflect.Method;
 import java.util.List;
 
 import org.bukkit.entity.Entity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import fr.neatmonster.nocheatplus.support.FeatureSupportRegistry;

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/TestNSBukkitAttributeAccess.java
@@ -1,16 +1,21 @@
 package fr.neatmonster.nocheatplus.compat.bukkit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 import java.util.Collections;
 
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 public class TestNSBukkitAttributeAccess {
 
@@ -19,11 +24,17 @@ public class TestNSBukkitAttributeAccess {
         // Get instance via factory method.
         NSBukkitAttributeAccess access = NSBukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            doReturn(null).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -31,11 +42,17 @@ public class TestNSBukkitAttributeAccess {
         // Get instance via factory method.
         NSBukkitAttributeAccess access = NSBukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(null);
-        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            doReturn(null).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -43,15 +60,21 @@ public class TestNSBukkitAttributeAccess {
         // Get instance via factory method.
         NSBukkitAttributeAccess access = NSBukkitAttributeAccess.createIfSupported();
         // Skip this test if the class is not supported in the test environment.
-        Assume.assumeNotNull(access);
+        Assumptions.assumeTrue(access != null);
         
-        Player player = mock(Player.class);
-        AttributeInstance inst = mock(AttributeInstance.class);
-        when(player.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)).thenReturn(inst);
-        when(inst.getValue()).thenReturn(0.1);
-        when(inst.getBaseValue()).thenReturn(0.1);
-        when(inst.getModifiers()).thenReturn(Collections.emptySet());
-        assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
-        assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock base = server.addPlayer();
+            Player player = spy(base);
+            AttributeInstance inst = mock(AttributeInstance.class);
+            doReturn(inst).when(player).getAttribute(Attribute.GENERIC_MOVEMENT_SPEED);
+            when(inst.getValue()).thenReturn(0.1);
+            when(inst.getBaseValue()).thenReturn(0.1);
+            when(inst.getModifiers()).thenReturn(Collections.emptySet());
+            assertEquals(1.0, access.getSpeedAttributeMultiplier(player), 0.0);
+            assertEquals(1.0, access.getSprintAttributeMultiplier(player), 0.0);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairsTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStairsTest.java
@@ -1,11 +1,11 @@
 package fr.neatmonster.nocheatplus.compat.bukkit.model;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BukkitStairsTest {
 

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStaticTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitStaticTest.java
@@ -1,8 +1,10 @@
 package fr.neatmonster.nocheatplus.compat.bukkit.model;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 public class BukkitStaticTest {
 
@@ -14,9 +16,9 @@ public class BukkitStaticTest {
         assertArrayEquals(expected, model.getShape(null, null, 0, 0, 0), 0.0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOfHeightInvalid() {
-        BukkitStatic.ofHeight(0.0);
+        assertThrows(IllegalArgumentException.class, () -> BukkitStatic.ofHeight(0.0));
     }
 
     @Test
@@ -27,8 +29,9 @@ public class BukkitStaticTest {
         assertArrayEquals(expected, model.getShape(null, null, 0, 0, 0), 0.0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testOfInsetAndHeightInvalid() {
-        BukkitStatic.ofInsetAndHeight(0.25, -0.1);
+        assertThrows(IllegalArgumentException.class,
+                () -> BukkitStatic.ofInsetAndHeight(0.25, -0.1));
     }
 }

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/bukkit/model/BukkitWallTest.java
@@ -1,6 +1,6 @@
 package fr.neatmonster.nocheatplus.compat.bukkit.model;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -8,7 +8,7 @@ import java.util.Set;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.MultipleFacing;
 import org.bukkit.block.data.type.Wall;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
 
 public class BukkitWallTest {

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflectTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/MCAccessCBReflectTest.java
@@ -1,9 +1,9 @@
 package fr.neatmonster.nocheatplus.compat.cbreflect;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MCAccessCBReflectTest {
 

--- a/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSixTest.java
+++ b/NCPCompatBukkit/src/test/java/fr/neatmonster/nocheatplus/compat/cbreflect/reflect/ReflectBlockSixTest.java
@@ -1,12 +1,12 @@
 package fr.neatmonster.nocheatplus.compat.cbreflect.reflect;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReflectBlockSixTest {
 

--- a/NCPCompatProtocolLib/src/test/java/fr/neatmonster/nocheatplus/checks/net/protocollib/FightTest.java
+++ b/NCPCompatProtocolLib/src/test/java/fr/neatmonster/nocheatplus/checks/net/protocollib/FightTest.java
@@ -1,9 +1,9 @@
 package fr.neatmonster.nocheatplus.checks.net.protocollib;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Fight}. */
 public class FightTest {

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContextTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakContextTest.java
@@ -1,11 +1,14 @@
 package fr.neatmonster.nocheatplus.checks.blockbreak;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
 
@@ -13,14 +16,19 @@ public class FastBreakContextTest {
 
     @Test
     public void testContextEncapsulation() {
-        Player player = mock(Player.class);
-        Block block = mock(Block.class);
-        FastBreakContext ctx = new FastBreakContext(player, block, null, null, null, AlmostBoolean.NO);
-        assertSame(player, ctx.player());
-        assertSame(block, ctx.block());
-        assertNull(ctx.config());
-        assertNull(ctx.breakData());
-        assertNull(ctx.playerData());
-        assertEquals(AlmostBoolean.NO, ctx.isInstaBreak());
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock player = server.addPlayer();
+            Block block = mock(Block.class);
+            FastBreakContext ctx = new FastBreakContext(player, block, null, null, null, AlmostBoolean.NO);
+            assertSame(player, ctx.player());
+            assertSame(block, ctx.block());
+            assertNull(ctx.config());
+            assertNull(ctx.breakData());
+            assertNull(ctx.playerData());
+            assertEquals(AlmostBoolean.NO, ctx.isInstaBreak());
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecisionTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/checks/blockbreak/FastBreakDecisionTest.java
@@ -1,9 +1,9 @@
 package fr.neatmonster.nocheatplus.checks.blockbreak;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import fr.neatmonster.nocheatplus.compat.AlmostBoolean;
 
@@ -11,7 +11,7 @@ public class FastBreakDecisionTest {
 
     private long clamp;
 
-    @Before
+    @BeforeEach
     public void setup() {
         clamp = 100;
     }

--- a/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
+++ b/NCPCore/src/test/java/fr/neatmonster/nocheatplus/utilities/entity/PassengerUtilTest.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import fr.neatmonster.nocheatplus.checks.moving.MovingConfig;
 import fr.neatmonster.nocheatplus.checks.moving.MovingData;
 import fr.neatmonster.nocheatplus.components.entity.IEntityAccessVehicle;
@@ -97,13 +100,18 @@ public class PassengerUtilTest {
         Method sched = PassengerUtil.class.getDeclaredMethod("handlePassengerScheduling", Player.class,
                 Entity.class, MovingConfig.class, MovingData.class, boolean.class);
         sched.setAccessible(true);
-        Player player = mock(Player.class);
-        Entity vehicle = mock(Entity.class);
-        when(vehicle.getType()).thenReturn(EntityType.MINECART);
-        MovingConfig cfg = newConfig();
-        MovingData data = newData();
-        sched.invoke(util, player, vehicle, cfg, data, false);
-        assertTrue(access.called);
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock player = server.addPlayer();
+            Entity vehicle = mock(Entity.class);
+            when(vehicle.getType()).thenReturn(EntityType.MINECART);
+            MovingConfig cfg = newConfig();
+            MovingData data = newData();
+            sched.invoke(util, player, vehicle, cfg, data, false);
+            assertTrue(access.called);
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -112,11 +120,16 @@ public class PassengerUtilTest {
         PassengerUtil util = newUtil(access);
         Method m = PassengerUtil.class.getDeclaredMethod("addPassengerWithRetry", Entity.class, Entity.class, int.class);
         m.setAccessible(true);
-        Player player = mock(Player.class);
-        Entity vehicle = mock(Entity.class);
-        @SuppressWarnings("unchecked")
-        java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
-        assertTrue(res.get());
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock player = server.addPlayer();
+            Entity vehicle = mock(Entity.class);
+            @SuppressWarnings("unchecked")
+            java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
+            assertTrue(res.get());
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 
     @Test
@@ -125,10 +138,15 @@ public class PassengerUtilTest {
         PassengerUtil util = newUtil(access);
         Method m = PassengerUtil.class.getDeclaredMethod("addPassengerWithRetry", Entity.class, Entity.class, int.class);
         m.setAccessible(true);
-        Player player = mock(Player.class);
-        Entity vehicle = mock(Entity.class);
-        @SuppressWarnings("unchecked")
-        java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
-        assertFalse(res.get());
+        ServerMock server = MockBukkit.mock();
+        try {
+            PlayerMock player = server.addPlayer();
+            Entity vehicle = mock(Entity.class);
+            @SuppressWarnings("unchecked")
+            java.util.concurrent.CompletableFuture<Boolean> res = (java.util.concurrent.CompletableFuture<Boolean>) m.invoke(util, player, vehicle, 1);
+            assertFalse(res.get());
+        } finally {
+            MockBukkit.unmock();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- migrate remaining JUnit 4 tests to JUnit 5
- replace Player mocks with MockBukkit's PlayerMock and use ServerMock setup

## Testing
- `mvn test` *(fails: NoSuchMethodError `NamespacedKey.value`)*
- `mvn checkstyle:check pmd:check spotbugs:check` *(fails: SpotBugs errors)*

------
https://chatgpt.com/codex/tasks/task_b_6860525e38b88329afa25c95d311f16a